### PR TITLE
sync with upstream

### DIFF
--- a/pluma/pluma-notebook.c
+++ b/pluma/pluma-notebook.c
@@ -815,21 +815,6 @@ create_tab_label (PlumaNotebook *nb,
 	return tab_label;
 }
 
-static void
-remove_tab_label (PlumaNotebook *nb,
-		  PlumaTab      *tab)
-{
-	GtkWidget *tab_label;
-
-	tab_label = pluma_tab_label_new (tab);
-
-	g_signal_handlers_disconnect_by_func (tab_label,
-					      G_CALLBACK (close_button_clicked_cb),
-					      nb);
-
-	g_object_set_data (G_OBJECT (tab), "tab-label", NULL);
-}
-
 static GtkWidget *
 get_tab_label (PlumaTab *tab)
 {
@@ -839,6 +824,21 @@ get_tab_label (PlumaTab *tab)
 	g_return_val_if_fail (tab_label != NULL, NULL);
 
 	return tab_label;
+}
+
+static void
+remove_tab_label (PlumaNotebook *nb,
+		  PlumaTab      *tab)
+{
+	GtkWidget *tab_label;
+
+	tab_label = get_tab_label (tab);
+
+	g_signal_handlers_disconnect_by_func (tab_label,
+					      G_CALLBACK (close_button_clicked_cb),
+					      nb);
+
+	g_object_set_data (G_OBJECT (tab), "tab-label", NULL);
 }
 
 /**


### PR DESCRIPTION
Get the current tab label instead of creating a new one.
