### PR TITLE
gtk3: fix implicit declaration: gtk_source_language_get_id

### DIFF
--- a/plugins/modelines/modeline-parser.c
+++ b/plugins/modelines/modeline-parser.c
@@ -22,6 +22,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <gtk/gtk.h>
+#if GTK_CHECK_VERSION (3, 0, 0)
+#include <gtksourceview/gtksource.h>
+#endif
 #include <pluma/pluma-language-manager.h>
 #include <pluma/pluma-prefs-manager.h>
 #include <pluma/pluma-debug.h>


### PR DESCRIPTION
modeline-parser.c:651:11: warning: implicit declaration of function 'gtk_source_language_get_id'
[-Wimplicit-function-declaration]
