### PR TITLE
Move plugins to data_dir, fix accel file location and minor cleanup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+pluma 1.7.1
+===========
+
+  * Move user plugin dir from config_dir to data_dir. Plugins should have
+    never been installed in the config dir as they are not part of the
+    configuration. This means user will need to move the plugins directory
+    from: $HOME/.config/pluma/ to $HOME/.local/share/pluma/.
+
 pluma 1.5.0
 ===========
 

--- a/pluma/pluma-dirs.c
+++ b/pluma/pluma-dirs.c
@@ -67,13 +67,13 @@ gchar* pluma_dirs_get_user_cache_dir(void)
 
 gchar* pluma_dirs_get_user_plugins_dir(void)
 {
-	gchar* config_dir;
+	gchar* data_dir;
 	gchar* plugin_dir;
 
-	config_dir = pluma_dirs_get_user_config_dir();
+	data_dir = g_get_user_data_dir();
 
-	plugin_dir = g_build_filename(config_dir, "plugins", NULL);
-	g_free(config_dir);
+	plugin_dir = g_build_filename(data_dir, "pluma", "plugins", NULL);
+	g_free(data_dir);
 
 	return plugin_dir;
 }


### PR DESCRIPTION
There is no need to do a migration for the accels file as it has been broken since before the 1.6 release
