### PR TITLE
Fix undelinking issue with plugins and plugin-loaders

### DIFF
--- a/plugin-loaders/c/Makefile.am
+++ b/plugin-loaders/c/Makefile.am
@@ -19,6 +19,8 @@ libcloader_la_SOURCES = \
 	$(NOINST_H_FILES)
 
 libcloader_la_LDFLAGS = $(LOADER_LIBTOOL_FLAGS)
-libcloader_la_LIBADD = $(PLUMA_LIBS)
+libcloader_la_LIBADD = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 -include $(top_srcdir)/git.mk

--- a/plugin-loaders/python/Makefile.am
+++ b/plugin-loaders/python/Makefile.am
@@ -30,7 +30,8 @@ libpythonloader_la_SOURCES = \
 
 libpythonloader_la_LDFLAGS = $(LOADER_LIBTOOL_FLAGS)
 libpythonloader_la_LIBADD = \
-	$(PLUMA_LIBS) 			\
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la \
 	bindings/pluma.la
 
 -include $(top_srcdir)/git.mk

--- a/plugins/changecase/Makefile.am
+++ b/plugins/changecase/Makefile.am
@@ -14,7 +14,9 @@ libchangecase_la_SOURCES = \
 	pluma-changecase-plugin.c
 
 libchangecase_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
-libchangecase_la_LIBADD = $(PLUMA_LIBS)
+libchangecase_la_LIBADD = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/changecase
 ui_DATA =

--- a/plugins/docinfo/Makefile.am
+++ b/plugins/docinfo/Makefile.am
@@ -14,7 +14,9 @@ libdocinfo_la_SOURCES = \
 	pluma-docinfo-plugin.c
 
 libdocinfo_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
-libdocinfo_la_LIBADD  = $(PLUMA_LIBS)
+libdocinfo_la_LIBADD  = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/docinfo
 ui_DATA = docinfo.ui

--- a/plugins/filebrowser/Makefile.am
+++ b/plugins/filebrowser/Makefile.am
@@ -38,7 +38,9 @@ libfilebrowser_la_SOURCES = \
 	$(NOINST_H_FILES)
 
 libfilebrowser_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
-libfilebrowser_la_LIBADD = $(PLUMA_LIBS)
+libfilebrowser_la_LIBADD = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 # UI files (if you use ui for your plugin, list those files here)
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/filebrowser

--- a/plugins/modelines/Makefile.am
+++ b/plugins/modelines/Makefile.am
@@ -20,7 +20,9 @@ libmodelines_la_SOURCES = \
 	modeline-parser.c
 
 libmodelines_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
-libmodelines_la_LIBADD  = $(PLUMA_LIBS)
+libmodelines_la_LIBADD  = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 plugin_in_files = modelines.pluma-plugin.desktop.in
 %.pluma-plugin: %.pluma-plugin.desktop.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache

--- a/plugins/sort/Makefile.am
+++ b/plugins/sort/Makefile.am
@@ -14,7 +14,9 @@ libsort_la_SOURCES = \
 	pluma-sort-plugin.c
 
 libsort_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
-libsort_la_LIBADD  = $(PLUMA_LIBS)
+libsort_la_LIBADD  = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/sort
 ui_DATA = sort.ui

--- a/plugins/spell/Makefile.am
+++ b/plugins/spell/Makefile.am
@@ -32,7 +32,10 @@ libspell_la_SOURCES = \
 	$(BUILT_SOURCES)			
 
 libspell_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS) 
-libspell_la_LIBADD  = $(PLUMA_LIBS) $(ENCHANT_LIBS)
+libspell_la_LIBADD  = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la \
+    $(ENCHANT_LIBS)
 
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/spell
 ui_DATA = spell-checker.ui languages-dialog.ui

--- a/plugins/taglist/Makefile.am
+++ b/plugins/taglist/Makefile.am
@@ -28,7 +28,9 @@ libtaglist_la_SOURCES = \
 	pluma-taglist-plugin.h
 
 libtaglist_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
-libtaglist_la_LIBADD  = $(PLUMA_LIBS)
+libtaglist_la_LIBADD  = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 plugin_in_files = taglist.pluma-plugin.desktop.in
 

--- a/plugins/time/Makefile.am
+++ b/plugins/time/Makefile.am
@@ -14,7 +14,9 @@ libtime_la_SOURCES = \
 	pluma-time-plugin.c
 
 libtime_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
-libtime_la_LIBADD  = $(PLUMA_LIBS)
+libtime_la_LIBADD  = \
+    $(PLUMA_LIBS) \
+    ../../pluma/libpluma.la
 
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/time
 ui_DATA = \


### PR DESCRIPTION
Today when i tried to build pluma-1.7.90 rpm for Mageia on my local machine i noticed that pluma plugins and plugin-loaders have underlinking issues:
- /usr/share/spec-helper/fix_eol
- '[' -n '' ']'
- /usr/share/spec-helper/check_elf_files
  Warning: undefined symbols in /usr/lib/pluma/plugins/libchangecase.so: pluma_plugin_get_type pluma_debug pluma_debug_message pluma_window_get_active_view pluma_window_get_ui_manager pluma_window_get_active_document
  Warning: undefined symbols in /usr/lib/pluma/plugins/libdocinfo.so: pluma_plugin_get_type pluma_document_get_short_name_for_display pluma_debug pluma_debug_message pluma_warning pluma_utils_get_ui_objects pluma_plugin_get_data_dir pluma_window_get_active_view pluma_window_get_ui_manager pluma_window_get_active_document
  Warning: undefined symbols in /usr/lib/pluma/plugins/libfilebrowser.so: pluma_utils_menu_position_under_tree_view pluma_plugin_get_type pluma_document_get_uri pluma_utils_is_valid_uri pluma_message_bus_unregister_all pluma_message_has_key pluma_message_get_object_path pluma_app_get_default pluma_utils_basename_for_display pluma_utils_uri_has_file_scheme pluma_utils_file_has_parent pluma_message_bus_register pluma_document_is_untitled pluma_message_type_get_object_path pluma_commands_load_uri pluma_message_type_instantiate pluma_message_get_method pluma_app_get_documents pluma_message_type_lookup pluma_panel_add_item pluma_message_bus_send_message_sync pluma_document_get_location pluma_tab_get_document pluma_plugin_get_data_dir pluma_panel_remove_item pluma_message_type_get_method pluma_window_get_side_panel pluma_document_get_type pluma_message_bus_connect pluma_window_get_active_document pluma_message_get pluma_window_get_message_bus pluma_message_type_identifier pluma_message_set pluma_message_bus_lookup pluma_document_set_uri
  Warning: undefined symbols in /usr/lib/pluma/plugins/libmodelines.so: pluma_plugin_get_type pluma_tab_get_view pluma_prefs_manager_get_insert_spaces pluma_debug pluma_view_get_type pluma_get_language_manager pluma_prefs_manager_get_right_margin_position pluma_prefs_manager_get_wrap_mode pluma_debug_message pluma_prefs_manager_get_tabs_size pluma_plugin_get_data_dir pluma_window_get_views pluma_prefs_manager_get_display_right_margin
  Warning: undefined symbols in /usr/lib/pluma/plugins/libsort.so: pluma_plugin_get_type pluma_debug pluma_debug_message pluma_window_get_group pluma_warning pluma_utils_get_ui_objects pluma_plugin_get_data_dir pluma_window_get_active_view pluma_window_get_ui_manager pluma_window_get_active_document pluma_help_display
  Warning: undefined symbols in /usr/lib/pluma/plugins/libtaglist.so: pluma_plugin_get_type pluma_debug pluma_utils_set_atk_name_description pluma_debug_message pluma_panel_add_item_with_stock_icon pluma_window_get_type pluma_plugin_get_data_dir pluma_window_get_active_view pluma_panel_remove_item pluma_window_get_side_panel pluma_utils_set_atk_relation
  Warning: undefined symbols in /usr/lib/pluma/plugins/libtime.so: pluma_plugin_get_type pluma_debug pluma_debug_message pluma_utils_get_ui_objects pluma_plugin_get_data_dir pluma_window_get_active_view pluma_window_get_ui_manager pluma_window_get_active_document pluma_help_display
  Warning: undefined symbols in /usr/lib/pluma/plugins/libspell.so: pluma_plugin_get_type pluma_tab_get_view pluma_debug pluma_view_get_type pluma_document_set_metadata pluma_debug_message pluma_window_get_group pluma_window_get_documents pluma_document_replace_all pluma_document_get_metadata pluma_view_scroll_to_cursor pluma_tab_get_document pluma_utils_get_ui_objects pluma_plugin_get_data_dir pluma_window_get_active_view pluma_statusbar_get_type pluma_window_get_ui_manager pluma_document_get_type pluma_window_get_statusbar pluma_window_get_active_document pluma_window_get_active_tab pluma_help_display pluma_statusbar_flash_message pluma_tab_get_state
  Warning: undefined symbols in /usr/lib/pluma/plugin-loaders/libcloader.so: pluma_plugin_loader_get_type pluma_object_module_new_object pluma_plugin_info_is_active pluma_object_module_new pluma_plugin_info_get_name pluma_plugin_info_get_module_name
  Warning: undefined symbols in /usr/lib/pluma/plugin-loaders/libpythonloader.so: pluma_plugin_get_type pluma_panel_item_is_active pluma_encoding_get_from_charset pluma_view_delete_selection pluma_window_create_tab pluma_message_get_type pluma_message_bus_disconnect pluma_document_goto_line pluma_document_get_content_type pluma_document_set_search_text pluma_document_get_uri pluma_utils_is_valid_uri pluma_tab_get_view pluma_message_bus_unregister_all pluma_tab_set_auto_save_interval pluma_window_set_active_tab pluma_document_get_short_name_for_display pluma_commands_save_document pluma_message_has_key pluma_encoding_copy pluma_debug pluma_commands_save_all_documents pluma_app_create_window pluma_document_load pluma_document_set_language pluma_app_get_windows pluma_view_copy_clipboard pluma_window_get_state pluma_plugin_get_install_dir pluma_encoding_get_from_index pluma_tab_get_type pluma_message_get_object_path pluma_view_new pluma_window_close_tab pluma_document_get_uri_for_display pluma_app_get_default pluma_message_type_set pluma_document_get_language pluma_message_get_value pluma_language_manager_list_languages_sorted pluma_view_get_type pluma_utils_uri_has_file_scheme pluma_utils_uri_exists pluma_document_save pluma_search_flags_get_type pluma_panel_get_type pluma_document_get_deleted pluma_message_bus_block pluma_message_bus_is_registered pluma_get_language_manager pluma_message_bus_get_default pluma_debug_message pluma_utils_menu_position_under_widget pluma_message_bus_register pluma_document_is_untitled pluma_plugin_create_configure_dialog pluma_document_is_local pluma_tab_get_from_document pluma_document_get_search_text pluma_panel_activate_item pluma_message_type_get_object_path pluma_encoding_to_string pluma_encoding_get_current pluma_document_search_backward pluma_document_save_flags_get_type pluma_document_get_readonly pluma_document_get_can_search_again pluma_tab_set_auto_save_enabled pluma_window_close_all_tabs pluma_utils_uri_has_writable_scheme pluma_commands_load_uri pluma_encoding_get_charset pluma_plugin_loader_get_type pluma_window_state_get_type pluma_document_save_as pluma_message_bus_unblock pluma_message_type_is_supported pluma_message_validate pluma_message_type_instantiate pluma_window_get_group pluma_document_get_enable_search_highlighting pluma_document_get_encoding pluma_window_get_documents pluma_message_get_method pluma_document_search_forward pluma_commands_load_uris pluma_view_cut_clipboard pluma_message_bus_get_type pluma_view_paste_clipboard pluma_document_replace_all pluma_app_get_lockdown pluma_app_get_documents pluma_message_type_lookup pluma_panel_add_item pluma_tab_get_auto_save_enabled pluma_view_select_all pluma_encoding_get_type pluma_panel_add_item_with_stock_icon pluma_message_bus_send_message_sync pluma_encoding_get_name pluma_window_close_tabs pluma_document_insert_file pluma_window_get_type pluma_document_is_untouched pluma_view_scroll_to_cursor pluma_app_get_active_window pluma_message_type_unref pluma_document_get_location pluma_plugin_info_get_name pluma_tab_get_document pluma_message_bus_unregister pluma_plugin_get_data_dir pluma_window_get_tab_from_uri pluma_window_get_active_view pluma_panel_remove_item pluma_message_type_get_method pluma_panel_get_n_items pluma_document_get_mime_type pluma_window_get_side_panel pluma_statusbar_get_type pluma_encoding_get_utf8 pluma_window_get_ui_manager pluma_tab_state_get_type pluma_message_type_get_type pluma_document_load_cancel pluma_message_type_ref pluma_message_set_value pluma_view_set_font pluma_document_get_type pluma_message_bus_connect pluma_window_get_statusbar pluma_window_get_active_document pluma_window_create_tab_from_uri pluma_document_set_enable_search_highlighting pluma_window_get_message_bus pluma_message_type_identifier pluma_window_get_active_tab pluma_help_display pluma_window_get_unsaved_documents pluma_statusbar_flash_message pluma_encoding_free pluma_app_get_views pluma_lockdown_mask_get_type pluma_window_get_views pluma_message_bus_send_message pluma_message_bus_lookup pluma_tab_get_auto_save_interval pluma_tab_get_state pluma_message_get_key_type pluma_document_set_uri pluma_app_get_type pluma_panel_get_orientation pluma_utils_uri_get_dirname pluma_plugin_info_get_module_name pluma_window_get_bottom_panel
- /usr/lib/rpm/mageia/brp-java-repack-jars
- '[' 1 -eq 1 ']'
- /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
- /usr/lib/rpm/brp-python-hardlink
  Processing files: pluma-1.7.90-1.mga5.i586
  Executing(%doc): /bin/sh -e /home/aum/rpm/tmp/rpm-tmp.Rbu6tZ

This pull request fixes these underlinking issues.
