### PR TITLE
Fix for #46 (GTK3 missing filename file in save as)

### DIFF
--- a/pluma/pluma-file-chooser-dialog.c
+++ b/pluma/pluma-file-chooser-dialog.c
@@ -407,6 +407,9 @@ pluma_file_chooser_dialog_new_valist (const gchar          *title,
 	gtk_file_filter_set_name (filter, ALL_FILES);
 	gtk_file_filter_add_pattern (filter, "*");
 	gtk_file_chooser_add_filter (GTK_FILE_CHOOSER (result), filter);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_file_chooser_set_action (GTK_FILE_CHOOSER (result), action);
+#endif
 
 	if (active_filter != 1)
 	{


### PR DESCRIPTION
Before:

![](https://sites.google.com/site/bl0ckeduserssoftware/pluma-before.png)

After:

![](https://sites.google.com/site/bl0ckeduserssoftware/pluma-after.png)
