### PR TITLE
Create pluma.appdata.xml

### DIFF
--- a/data/pluma.appdata.xml
+++ b/data/pluma.appdata.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>pluma.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Pluma</name>
+ <summary>A Text Editor for the MATE desktop environment</summary>
+ <description>
+  <p>
+   Pluma is a small, but powerful text editor designed specifically for
+   the MATE desktop. It has most standard text editor functions and fully
+   supports international text in Unicode. Advanced features include syntax
+   highlighting and automatic indentation of source code, printing and editing
+   of multiple documents in one window.
+  </p>
+  <p>
+   Pluma is extensible through a plugin system, which currently includes
+   support for spell checking, comparing files, viewing CVS ChangeLogs, and
+   adjusting indentation levels.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/pluma/screens/pluma_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/pluma/screens/pluma_02.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/pluma/screens/pluma_03.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
