### PR TITLE
Update pluma-utils.c

### DIFF
--- a/pluma/pluma-utils.c
+++ b/pluma/pluma-utils.c
@@ -771,7 +771,8 @@ pluma_utils_location_get_dirname_for_display (GFile *location)
 		}
 		else
 		{
-			res = mount_name;
+			path =	g_file_get_path ( location );
+			res = g_strdup_printf ("%s %s", mount_name, path);
 		}
 	}
 	else


### PR DESCRIPTION
In my case full path is not being showing at window title working on local hard disk 
Trace at :
pluma_utils_location_get_dirname_for_display (GFile *location)
g_file_find_enclosing_mount() contains "406 GB Unrecognized" the hard disk label but not running as root.
this cause that  pluma_utils_decode_uri (uri,NULL, NULL,NULL, NULL,&path)) returns false so this function only return "mount_name"
So reading https://developer.gnome.org/gio/stable/GFile.html#g-file-get-path I propose to add g_file_get_path() in case pluma_utils_decode_uri () returns false to fix this issue.

Sorry if not properly fixed, but I'm not a C developer.

The PoC
https://gist.github.com/jsenin/0d7bf185a54f09c3c793