### PR TITLE
Fix issue#100: CRLF across 8k boundary inserts an empty line.

### DIFF
--- a/pluma/pluma-document-output-stream.c
+++ b/pluma/pluma-document-output-stream.c
@@ -290,7 +290,6 @@ pluma_document_output_stream_write (GOutputStream            *stream,
 	gsize len;
 	gboolean freetext = FALSE;
 	const gchar *end;
-	gsize nvalid;
 	gboolean valid;
 
 	if (g_cancellable_set_error_if_cancelled (cancellable, error))
@@ -328,16 +327,22 @@ pluma_document_output_stream_write (GOutputStream            *stream,
 
 	/* validate */
 	valid = g_utf8_validate (text, len, &end);
-	nvalid = end - text;
+
+	/* Avoid keeping a CRLF across two buffers. */
+	if (valid && len > 1 && end[-1] == '\r') {
+		valid = FALSE;
+		end--;
+	}
 
 	if (!valid)
 	{
-		gsize remainder;
-
-		remainder = len - nvalid;
+		gsize nvalid = end - text;
+		gsize remainder = len - nvalid;
+		gunichar ch;
 
 		if ((remainder < MAX_UNICHAR_LEN) &&
-		    (g_utf8_get_char_validated (text + nvalid, remainder) == (gunichar)-2))
+		    ((ch = g_utf8_get_char_validated (text + nvalid, remainder)) == (gunichar)-2 ||
+		     ch == (gunichar)'\r'))
 		{
 			ostream->priv->buffer = g_strndup (end, remainder);
 			ostream->priv->buflen = remainder;
@@ -345,7 +350,7 @@ pluma_document_output_stream_write (GOutputStream            *stream,
 		}
 		else
 		{
-			/* TODO: we cuould escape invalid text and tag it in red
+			/* TODO: we could escape invalid text and tag it in red
 			 * and make the doc readonly.
 			 */
 			g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,


### PR DESCRIPTION
The fix works by delaying the handling of a non-initial, trailing carriage-return as a prefix to the next buffer.
See https://github.com/mate-desktop/pluma/issues/100.