### PR TITLE
Add a new Configure dialog for the Spell Check plugin.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,6 +403,7 @@ plugins/snippets/Makefile
 plugins/snippets/snippets/Makefile
 plugins/sort/Makefile
 plugins/spell/Makefile
+plugins/spell/org.mate.pluma.plugins.spell.gschema.xml
 plugins/taglist/Makefile
 plugins/time/Makefile
 plugins/time/org.mate.pluma.plugins.time.gschema.xml

--- a/plugins/spell/Makefile.am
+++ b/plugins/spell/Makefile.am
@@ -35,7 +35,7 @@ libspell_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 libspell_la_LIBADD  = $(PLUMA_LIBS) $(ENCHANT_LIBS)
 
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/spell
-ui_DATA = spell-checker.ui languages-dialog.ui
+ui_DATA = spell-checker.ui languages-dialog.ui pluma-spell-setup-dialog.ui
 
 pluma-spell-marshal.h: pluma-spell-marshal.list $(GLIB_GENMARSHAL)
 	$(AM_V_GEN) $(GLIB_GENMARSHAL) $< --header --prefix=pluma_marshal > $@
@@ -50,12 +50,19 @@ plugin_in_files = spell.pluma-plugin.desktop.in
 
 plugin_DATA = $(plugin_in_files:.pluma-plugin.desktop.in=.pluma-plugin)
 
+@INTLTOOL_XML_NOMERGE_RULE@
+spell_gschema_in = org.mate.pluma.plugins.spell.gschema.xml.in
+gsettings_SCHEMAS = $(spell_gschema_in:.xml.in=.xml)
+@GSETTINGS_RULES@
+
+
 EXTRA_DIST = 					\
 	$(ui_DATA)				\
 	$(plugin_in_files)			\
-	pluma-spell-marshal.list 
+	pluma-spell-marshal.list    	        \
+	$(spell_gschema_in)
 
-CLEANFILES = $(BUILT_SOURCES) $(plugin_DATA)
+CLEANFILES = $(BUILT_SOURCES) $(plugin_DATA) $(gsettings_SCHEMAS)
 
 dist-hook:
 	cd $(distdir); rm -f $(BUILT_SOURCES)

--- a/plugins/spell/org.mate.pluma.plugins.spell.gschema.xml.in
+++ b/plugins/spell/org.mate.pluma.plugins.spell.gschema.xml.in
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="@GETTEXT_PACKAGE@">
+  <enum id="org.mate.pluma.plugins.spell.AutocheckType">
+    <value value="0" nick="never"/>
+    <value value="1" nick="document"/>
+    <value value="2" nick="always"/>
+  </enum>
+  <schema path="/org/mate/pluma/plugins/spell/" id="org.mate.pluma.plugins.spell">
+    <key name="autocheck-type" enum="org.mate.pluma.plugins.spell.AutocheckType">
+      <default>'document'</default>
+      <summary>Autocheck Type</summary>
+    </key>
+  </schema>
+</schemalist>

--- a/plugins/spell/pluma-spell-plugin.h
+++ b/plugins/spell/pluma-spell-plugin.h
@@ -50,6 +50,8 @@ typedef struct _PlumaSpellPlugin	PlumaSpellPlugin;
 struct _PlumaSpellPlugin
 {
 	PlumaPlugin parent_instance;
+
+	PlumaSpellPluginPrivate *priv;
 };
 
 /*

--- a/plugins/spell/pluma-spell-setup-dialog.ui
+++ b/plugins/spell/pluma-spell-setup-dialog.ui
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--*- mode: xml -*-->
+<interface>
+  <object class="GtkDialog" id="spell_dialog">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">_Configure Spell Checker plugin...</property>
+    <property name="resizable">False</property>
+    <property name="type_hint">normal</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="spacing">8</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-help</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button3">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button4">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkVBox" id="spell_dialog_content">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Autocheck spelling on document load...</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="autocheck_never">
+                <property name="label" translatable="yes">_Never autocheck</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <property name="xalign">0</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="autocheck_document">
+                <property name="label" translatable="yes">_Remember autocheck by document</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <property name="xalign">0</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">autocheck_never</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="autocheck_always">
+                <property name="label" translatable="yes">_Always autocheck</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <property name="xalign">0</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">autocheck_never</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="0">button1</action-widget>
+      <action-widget response="0">button3</action-widget>
+      <action-widget response="0">button4</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -88,6 +88,7 @@ plugins/snippets/snippets/Placeholder.py
 plugins/sort/pluma-sort-plugin.c
 plugins/sort/sort.pluma-plugin.desktop.in
 [type: gettext/glade]plugins/sort/sort.ui
+[type: gettext/gsettings]plugins/spell/org.mate.pluma.plugins.spell.gschema.xml.in
 plugins/spell/pluma-automatic-spell-checker.c
 plugins/spell/pluma-spell-checker.c
 plugins/spell/pluma-spell-checker-dialog.c
@@ -96,6 +97,7 @@ plugins/spell/pluma-spell-language-dialog.c
 plugins/spell/pluma-spell-plugin.c
 [type: gettext/glade]plugins/spell/languages-dialog.ui
 [type: gettext/glade]plugins/spell/spell-checker.ui
+[type: gettext/glade]plugins/spell/pluma-spell-setup-dialog.ui
 plugins/spell/spell.pluma-plugin.desktop.in
 plugins/taglist/pluma-taglist-plugin.c
 plugins/taglist/pluma-taglist-plugin-panel.c


### PR DESCRIPTION
mate-desktop/pluma#90

(Creating a new pull request here as the previous one was closed when I deleted and recreated cloned branch after some help from @infirit to tidy up my commit)

There are three options for autocheck when a doc is loaded:

Always autocheck, Never autocheck and Remember the autocheck setting for each document

The chosen option is stored in the gsettings schema.
The default setting is to remember by document as this is what Pluma did previously.
