### PR TITLE
Fix issue#100: CRLF across 8k boundary inserts an empty line. 2nd trial.

### DIFF
--- a/pluma/pluma-gio-document-loader.c
+++ b/pluma/pluma-gio-document-loader.c
@@ -389,6 +389,10 @@ async_read_cb (GInputStream *stream,
 
 		loader = PLUMA_DOCUMENT_LOADER (gvloader);
 
+		g_output_stream_flush (gvloader->priv->output,
+				       NULL,
+				       &gvloader->priv->error);
+
 		loader->auto_detected_encoding =
 			pluma_smart_charset_converter_get_guessed (gvloader->priv->converter);
 

--- a/tests/document-output-stream.c
+++ b/tests/document-output-stream.c
@@ -57,6 +57,9 @@ test_consecutive_write (const gchar *inbuf,
 		n += w;
 	} while (w != 0);
 
+	g_assert(g_output_stream_flush (out, NULL, &err) == TRUE);
+	g_assert_no_error (err);
+
 	g_object_get (G_OBJECT (doc), "text", &b, NULL);
 
 	g_assert_cmpstr (inbuf, ==, b);

--- a/tests/document-output-stream.c
+++ b/tests/document-output-stream.c
@@ -91,22 +91,22 @@ test_empty ()
 static void
 test_consecutive ()
 {
-	test_consecutive_write ("hello\nhow\nare\nyou", "hello\nhow\nare\nyou", 2,
+	test_consecutive_write ("hello\nhow\nare\nyou", "hello\nhow\nare\nyou", 3,
 				PLUMA_DOCUMENT_NEWLINE_TYPE_LF);
-	test_consecutive_write ("hello\rhow\rare\ryou", "hello\rhow\rare\ryou", 2,
+	test_consecutive_write ("hello\rhow\rare\ryou", "hello\rhow\rare\ryou", 3,
 				PLUMA_DOCUMENT_NEWLINE_TYPE_CR);
-	test_consecutive_write ("hello\r\nhow\r\nare\r\nyou", "hello\r\nhow\r\nare\r\nyou", 2,
+	test_consecutive_write ("hello\r\nhow\r\nare\r\nyou", "hello\r\nhow\r\nare\r\nyou", 3,
 				PLUMA_DOCUMENT_NEWLINE_TYPE_CR_LF);
 }
 
 static void
 test_consecutive_tnewline ()
 {
-	test_consecutive_write ("hello\nhow\nare\nyou\n", "hello\nhow\nare\nyou", 2,
+	test_consecutive_write ("hello\nhow\nare\nyou\n", "hello\nhow\nare\nyou", 3,
 				PLUMA_DOCUMENT_NEWLINE_TYPE_LF);
-	test_consecutive_write ("hello\rhow\rare\ryou\r", "hello\rhow\rare\ryou", 2,
+	test_consecutive_write ("hello\rhow\rare\ryou\r", "hello\rhow\rare\ryou", 3,
 				PLUMA_DOCUMENT_NEWLINE_TYPE_CR);
-	test_consecutive_write ("hello\r\nhow\r\nare\r\nyou\r\n", "hello\r\nhow\r\nare\r\nyou", 2,
+	test_consecutive_write ("hello\r\nhow\r\nare\r\nyou\r\n", "hello\r\nhow\r\nare\r\nyou", 3,
 				PLUMA_DOCUMENT_NEWLINE_TYPE_CR_LF);
 }
 


### PR DESCRIPTION
Hi,
this is a new attempt to fix issue #100.
Commit 78101257f40bbf8a0d7b606bee36e527f9b0ea11 applied alone makes the test sensible to issue #100. Other commits fix the issue.
Thanks for considering it.
Patrick