### PR TITLE
add a configure option to build pluma with --without-matedesktop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,7 +182,6 @@ PKG_CHECK_MODULES(PLUMA, [
 	gio-2.0 >= 2.26.0
 	gtk+-$GTK_API_VERSION >= $GTK_REQUIRED
 	gtksourceview-$GTK_API_VERSION >= 2.9.7
-	mate-desktop-2.0 >= 1.9.0
 ])
 
 PKG_CHECK_MODULES(X11, [x11])
@@ -197,6 +196,25 @@ PKG_CHECK_MODULES(EGG_SMCLIENT, [sm >= 1.0.0])
 
 AC_SUBST(EGG_SMCLIENT_CFLAGS)
 AC_SUBST(EGG_SMCLIENT_LIBS)
+
+dnl ================================================================
+dnl Mate-desktop support
+dnl ================================================================
+
+MATEDESKTOP_REQUIRED=1.9.0
+
+AC_ARG_WITH(matedesktop,
+        [AS_HELP_STRING([--without-matedesktop],
+                        [Disable the use of matedesktop])],
+        [],
+        [with_matedesktop=yes])
+
+AM_CONDITIONAL([WITH_MATEDESKTOP],[test "$with_matedesktop" = "yes"])
+
+if test "$with_matedesktop" = "yes"; then
+        PKG_CHECK_MODULES([SHELL_CORE], mate-desktop-2.0 >= $MATEDESKTOP_REQUIRED)
+        AC_DEFINE([WITH_MATEDESKTOP],[1],[Define if mate-desktop support is enabled])
+fi
 
 dnl ================================================================
 dnl GSettings related settings
@@ -420,6 +438,7 @@ Configuration:
 	Source code location:	${srcdir}
 	Compiler:		${CC}
 	GTK API version:	$GTK_API_VERSION
+	MATE desktop Support:   $with_matedesktop
 	Python Plugins Support: $enable_python
 	Spell Plugin enabled:	$enable_enchant
 	Gvfs metadata enabled:	$enable_gvfs_metadata

--- a/pluma/pluma-commands-help.c
+++ b/pluma/pluma-commands-help.c
@@ -37,7 +37,9 @@
 
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#ifdef WITH_MATEDESKTOP
 #include <libmate-desktop/mate-aboutdialog.h>
+#endif
 
 #include "pluma-commands.h"
 #include "pluma-debug.h"
@@ -85,8 +87,13 @@ void _pluma_cmd_help_about(GtkAction* action, PlumaWindow* window)
 
 	pluma_debug (DEBUG_COMMANDS);
 
+#ifdef WITH_MATEDESKTOP
 	mate_show_about_dialog(GTK_WINDOW(window),
+#else
+	gtk_show_about_dialog(GTK_WINDOW(window),
+#endif
 		"program-name", "Pluma",
+
 		"authors", authors,
 		"comments", _(comments),
 		"copyright", copyright,


### PR DESCRIPTION
- about-dialog use GtkAbout instead of MateAbout in this case
- this makes transition to gtk3 more simple