### PR TITLE
Gtk+-3.14 pluma-document.c: replace deprecated GdkColor with GdkRGBA

### DIFF
--- a/pluma/pluma-document.c
+++ b/pluma/pluma-document.c
@@ -2246,9 +2246,15 @@ _pluma_document_get_seconds_since_last_save_or_load (PlumaDocument *doc)
 static void
 get_search_match_colors (PlumaDocument *doc,
 			 gboolean      *foreground_set,
+#if GTK_CHECK_VERSION (3, 14, 0)
+			 GdkRGBA       *foreground,
+			 gboolean      *background_set,
+			 GdkRGBA       *background)
+#else
 			 GdkColor      *foreground,
 			 gboolean      *background_set,
 			 GdkColor      *background)
+#endif
 {
 	GtkSourceStyleScheme *style_scheme;
 	GtkSourceStyle *style;
@@ -2273,6 +2279,21 @@ get_search_match_colors (PlumaDocument *doc,
 
 	if (*foreground_set)
 	{
+#if GTK_CHECK_VERSION (3, 14, 0)
+		if (fg == NULL ||
+		    !gdk_rgba_parse (foreground, fg))
+		{
+			*foreground_set = FALSE;
+		}
+	}
+
+	if (*background_set)
+	{
+		if (bg == NULL ||
+		    !gdk_rgba_parse (background, bg))
+		{
+			*background_set = FALSE;
+#else
 		if (fg == NULL ||
 		    !gdk_color_parse (fg, foreground))
 		{
@@ -2286,6 +2307,7 @@ get_search_match_colors (PlumaDocument *doc,
 		    !gdk_color_parse (bg, background))
 		{
 			*background_set = FALSE;
+#endif
 		}
 	}	
 
@@ -2299,7 +2321,11 @@ get_search_match_colors (PlumaDocument *doc,
 			     "Falling back to hard-coded colors "
 			     "for the \"found\" text tag.");
 
+#if GTK_CHECK_VERSION (3, 14, 0)
+	gdk_rgba_parse (background, "#FFFF78");
+#else
 	gdk_color_parse ("#FFFF78", background);
+#endif
 	*background_set = TRUE;
 	*foreground_set = FALSE;
 
@@ -2311,8 +2337,13 @@ sync_found_tag (PlumaDocument *doc,
 		GParamSpec    *pspec,
 		gpointer       data)
 {
+#if GTK_CHECK_VERSION (3, 14, 0)
+	GdkRGBA fg;
+	GdkRGBA bg;
+#else
 	GdkColor fg;
 	GdkColor bg;
+#endif
 	gboolean fg_set;
 	gboolean bg_set;
 
@@ -2325,10 +2356,17 @@ sync_found_tag (PlumaDocument *doc,
 				 &bg_set, &bg);
 
 	g_object_set (doc->priv->found_tag,
+#if GTK_CHECK_VERSION (3, 14, 0)
+		      "foreground-rgba", fg_set ? &fg : NULL,
+		      NULL);
+	g_object_set (doc->priv->found_tag,
+		      "background-rgba", bg_set ? &bg : NULL,
+#else
 		      "foreground-gdk", fg_set ? &fg : NULL,
 		      NULL);
 	g_object_set (doc->priv->found_tag,
 		      "background-gdk", bg_set ? &bg : NULL,
+#endif
 		      NULL);
 }
 


### PR DESCRIPTION
taken from:
https://git.gnome.org/browse/gedit/commit/?id=15994d8