### PR TITLE
When 'Always autocheck' option is selected turn on Autocheck for new …

### DIFF
--- a/plugins/spell/pluma-spell-plugin.c
+++ b/plugins/spell/pluma-spell-plugin.c
@@ -1041,7 +1041,12 @@ set_auto_spell (PlumaWindow   *window,
 			g_return_if_fail (active_view != NULL);
 
 			autospell = pluma_automatic_spell_checker_new (doc, spell);
-			pluma_automatic_spell_checker_attach_view (autospell, active_view);
+			
+			if (doc == pluma_window_get_active_document (window))
+			{
+				pluma_automatic_spell_checker_attach_view (autospell, active_view);
+			}
+			
 			pluma_automatic_spell_checker_recheck_all (autospell);
 		}
 	}
@@ -1292,8 +1297,24 @@ tab_added_cb (PlumaWindow *window,
 	      gpointer     useless)
 {
 	PlumaDocument *doc;
+	gchar *uri;
+	WindowData *data;
 
 	doc = pluma_tab_get_document (tab);
+	
+	g_object_get(G_OBJECT(doc), "uri", &uri, NULL);
+
+	if (!uri)
+	{
+		
+		data = g_object_get_data (G_OBJECT (window),
+					  WINDOW_DATA_KEY);
+
+		set_auto_spell_from_metadata (window, doc, data->action_group);
+
+		g_free(uri);
+
+	}
 
 	g_signal_connect (doc, "loaded",
 			  G_CALLBACK (on_document_loaded),


### PR DESCRIPTION
mate-desktop/pluma#188

hi @monsta 

I made a small change to try and fix this. Basically the loaded signal is not emitted for new documents so I added a little extra code in the tab added callback function to setup autospell if the document has no uri. I think this signal fires a little too early which is why I had to also add an extra check in set_auto_spell to make sure the doc matches the doc in the view. Without that extra check an error was thrown although functionally it still seemed to work.

Anyway this could definitely do with a review to make sure I haven't broken something else.