### PR TITLE
port Python plugins (except for snippets) to gi and libpeas

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,8 @@ else
 	have_introspection=no
 fi
 
+AM_PATH_PYTHON([2.7])
+
 dnl ================================================================
 dnl GSettings related settings
 dnl ================================================================
@@ -252,6 +254,10 @@ pixmaps/Makefile
 plugins/Makefile
 plugins/changecase/Makefile
 plugins/docinfo/Makefile
+plugins/externaltools/data/Makefile
+plugins/externaltools/Makefile
+plugins/externaltools/scripts/Makefile
+plugins/externaltools/tools/Makefile
 plugins/filebrowser/Makefile
 plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml
 plugins/modelines/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -263,6 +263,8 @@ plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml
 plugins/modelines/Makefile
 plugins/pythonconsole/Makefile
 plugins/pythonconsole/pythonconsole/Makefile
+plugins/quickopen/Makefile
+plugins/quickopen/quickopen/Makefile
 plugins/sort/Makefile
 plugins/spell/Makefile
 plugins/spell/org.mate.pluma.plugins.spell.gschema.xml

--- a/configure.ac
+++ b/configure.ac
@@ -261,6 +261,8 @@ plugins/externaltools/tools/Makefile
 plugins/filebrowser/Makefile
 plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml
 plugins/modelines/Makefile
+plugins/pythonconsole/Makefile
+plugins/pythonconsole/pythonconsole/Makefile
 plugins/sort/Makefile
 plugins/spell/Makefile
 plugins/spell/org.mate.pluma.plugins.spell.gschema.xml

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -5,6 +5,7 @@ DIST_SUBDIRS =		\
 	filebrowser 	\
 	modelines	\
 	pythonconsole	\
+	quickopen	\
 	sort 		\
 	spell 		\
 	taglist 	\
@@ -18,13 +19,14 @@ SUBDIRS = 		\
 	filebrowser	\
 	modelines	\
 	pythonconsole	\
+	quickopen	\
 	sort		\
 	taglist		\
 	time		\
 	trailsave
 
 # python plugins are disabled for now
-#SUBDIRS      += snippets quickopen
+#SUBDIRS      += snippets
 
 if ENABLE_ENCHANT
 SUBDIRS      += spell

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -4,6 +4,7 @@ DIST_SUBDIRS =		\
 	externaltools	\
 	filebrowser 	\
 	modelines	\
+	pythonconsole	\
 	sort 		\
 	spell 		\
 	taglist 	\
@@ -16,13 +17,14 @@ SUBDIRS = 		\
 	externaltools	\
 	filebrowser	\
 	modelines	\
+	pythonconsole	\
 	sort		\
 	taglist		\
 	time		\
 	trailsave
 
 # python plugins are disabled for now
-#SUBDIRS      += pythonconsole snippets quickopen
+#SUBDIRS      += snippets quickopen
 
 if ENABLE_ENCHANT
 SUBDIRS      += spell

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1,6 +1,7 @@
 DIST_SUBDIRS =		\
 	changecase 	\
 	docinfo 	\
+	externaltools	\
 	filebrowser 	\
 	modelines	\
 	sort 		\
@@ -12,6 +13,7 @@ DIST_SUBDIRS =		\
 SUBDIRS = 		\
 	changecase	\
 	docinfo		\
+	externaltools	\
 	filebrowser	\
 	modelines	\
 	sort		\
@@ -20,7 +22,7 @@ SUBDIRS = 		\
 	trailsave
 
 # python plugins are disabled for now
-#SUBDIRS      += externaltools pythonconsole snippets quickopen
+#SUBDIRS      += pythonconsole snippets quickopen
 
 if ENABLE_ENCHANT
 SUBDIRS      += spell

--- a/plugins/externaltools/Makefile.am
+++ b/plugins/externaltools/Makefile.am
@@ -2,10 +2,10 @@
 SUBDIRS = tools data scripts
 plugindir = $(PLUMA_PLUGINS_LIBS_DIR)
 
-plugin_in_files = externaltools.pluma-plugin.desktop.in
-%.pluma-plugin: %.pluma-plugin.desktop.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
+plugin_in_files = externaltools.plugin.desktop.in
+%.plugin: %.plugin.desktop.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
 
-plugin_DATA = $(plugin_in_files:.pluma-plugin.desktop.in=.pluma-plugin)
+plugin_DATA = $(plugin_in_files:.plugin.desktop.in=.plugin)
 
 EXTRA_DIST = $(plugin_in_files)
 

--- a/plugins/externaltools/externaltools.plugin.desktop.in
+++ b/plugins/externaltools/externaltools.plugin.desktop.in
@@ -1,4 +1,4 @@
-[Pluma Plugin]
+[Plugin]
 Loader=python
 Module=externaltools
 IAge=2

--- a/plugins/externaltools/tools/__init__.py
+++ b/plugins/externaltools/tools/__init__.py
@@ -16,11 +16,9 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-__all__ = ('ExternalToolsPlugin', 'ExternalToolsWindowHelper',
-           'Manager', 'OutputPanel', 'Capture', 'UniqueById')
+__all__ = ('ExternalToolsPlugin', 'Manager', 'OutputPanel', 'Capture', 'UniqueById')
 
-import pluma
-import gtk
+from gi.repository import GObject, Gtk, Peas, Pluma
 from manager import Manager
 from library import ToolLibrary
 from outputpanel import OutputPanel
@@ -28,17 +26,16 @@ from capture import Capture
 from functions import *
 
 class ToolMenu(object):
-    ACTION_HANDLER_DATA_KEY = "ExternalToolActionHandlerData"
-    ACTION_ITEM_DATA_KEY = "ExternalToolActionItemData"
-
-    def __init__(self, library, window, menupath):
+    def __init__(self, library, window, panel, plugin, menupath):
         super(ToolMenu, self).__init__()
         self._library = library
         self._window = window
+        self._panel = panel
+        self._plugin = plugin
         self._menupath = menupath
 
         self._merge_id = 0
-        self._action_group = gtk.ActionGroup("ExternalToolsPluginToolActions")
+        self._action_group = Gtk.ActionGroup("ExternalToolsPluginToolActions")
         self._signals = []
 
         self.update()
@@ -53,17 +50,15 @@ class ToolMenu(object):
             self._merge_id = 0
 
         for action in self._action_group.list_actions():
-            handler = action.get_data(self.ACTION_HANDLER_DATA_KEY)
+            if action._tool_handler is not None:
+                action.disconnect(action._tool_handler)
 
-            if handler is not None:
-                action.disconnect(handler)
-
-            action.set_data(self.ACTION_ITEM_DATA_KEY, None)
-            action.set_data(self.ACTION_HANDLER_DATA_KEY, None)
+            action._tool_item = None
+            action._tool_handler = None
 
             self._action_group.remove_action(action)
         
-        accelmap = gtk.accel_map_get()
+        accelmap = Gtk.AccelMap.get()
 
         for s in self._signals:
             accelmap.disconnect(s)
@@ -75,43 +70,44 @@ class ToolMenu(object):
 
         for item in directory.subdirs:
             action_name = 'ExternalToolDirectory%X' % id(item)
-            action = gtk.Action(action_name, item.name.replace('_', '__'), None, None)
+            action = Gtk.Action(action_name, item.name.replace('_', '__'), None, None)
             self._action_group.add_action(action)
 
             manager.add_ui(self._merge_id, path,
                            action_name, action_name,
-                           gtk.UI_MANAGER_MENU, False)
+                           Gtk.UIManagerItemType.MENU, False)
                            
             self._insert_directory(item, path + '/' + action_name)
 
         for item in directory.tools:
             action_name = 'ExternalToolTool%X' % id(item)
-            action = gtk.Action(action_name, item.name.replace('_', '__'), item.comment, None)
-            handler = action.connect("activate", capture_menu_action, self._window, item)
+            action = Gtk.Action(action_name, item.name.replace('_', '__'), item.comment, None)
+            handler = action.connect("activate", capture_menu_action, self._window, self._panel, item)
 
-            action.set_data(self.ACTION_ITEM_DATA_KEY, item)
-            action.set_data(self.ACTION_HANDLER_DATA_KEY, handler)
+            # Attach the item and the handler to the action object
+            action._tool_item = item
+            action._tool_handler = handler
             
             # Make sure to replace accel
             accelpath = '<Actions>/ExternalToolsPluginToolActions/%s' % (action_name, )
             
             if item.shortcut:
-                key, mod = gtk.accelerator_parse(item.shortcut)
-                gtk.accel_map_change_entry(accelpath, key, mod, True)
+                key, mod = Gtk.accelerator_parse(item.shortcut)
+                Gtk.AccelMap.change_entry(accelpath, key, mod, True)
                 
-                self._signals.append(gtk.accel_map_get().connect('changed::%s' % (accelpath,), self.on_accelmap_changed, item))
+                self._signals.append(Gtk.AccelMap.get().connect('changed::%s' % (accelpath,), self.on_accelmap_changed, item))
                 
             self._action_group.add_action_with_accel(action, item.shortcut)
 
             manager.add_ui(self._merge_id, path,
                            action_name, action_name,
-                           gtk.UI_MANAGER_MENUITEM, False)
+                           Gtk.UIManagerItemType.MENUITEM, False)
 
     def on_accelmap_changed(self, accelmap, path, key, mod, tool):
-        tool.shortcut = gtk.accelerator_name(key, mod)
+        tool.shortcut = Gtk.accelerator_name(key, mod)
         tool.save()
         
-        self._window.get_data("ExternalToolsPluginWindowData").update_manager(tool)
+        self._plugin.update_manager(tool)
 
     def update(self):
         self.remove()
@@ -150,29 +146,36 @@ class ToolMenu(object):
         language = document.get_language()
 
         for action in self._action_group.list_actions():
-            item = action.get_data(self.ACTION_ITEM_DATA_KEY)
+            if action._tool_item is not None:
+                action.set_visible(states[action._tool_item.applicability] and
+                                   self.filter_language(language, action._tool_item))
 
-            if item is not None:
-                action.set_visible(states[item.applicability] and self.filter_language(language, item))
+class ExternalToolsPlugin(GObject.Object, Peas.Activatable):
+    __gtype_name__ = "ExternalToolsPlugin"
 
-class ExternalToolsWindowHelper(object):
-    def __init__(self, plugin, window):
-        super(ExternalToolsWindowHelper, self).__init__()
+    object = GObject.Property(type=GObject.Object)
 
-        self._window = window
-        self._plugin = plugin
+    def __init__(self):
+        GObject.Object.__init__(self)
+
+        self._manager = None
+        self._manager_default_size = None
+
+    def do_activate(self):
         self._library = ToolLibrary()
+        self._library.set_locations(os.path.join(self.plugin_info.get_data_dir(), 'tools'))
 
+        window = self.object
         manager = window.get_ui_manager()
 
-        self._action_group = gtk.ActionGroup('ExternalToolsPluginActions')
+        self._action_group = Gtk.ActionGroup('ExternalToolsPluginActions')
         self._action_group.set_translation_domain('pluma')
         self._action_group.add_actions([('ExternalToolManager',
                                          None,
                                          _('Manage _External Tools...'),
                                          None,
                                          _("Opens the External Tools Manager"),
-                                         lambda action: plugin.open_dialog()),
+                                         lambda action: self.open_dialog()),
                                         ('ExternalTools',
                                         None,
                                         _('External _Tools'),
@@ -201,69 +204,47 @@ class ExternalToolsWindowHelper(object):
 
         self._merge_id = manager.add_ui_from_string(ui_string)
 
-        self.menu = ToolMenu(self._library, self._window,
+        # Create output console
+        self._output_buffer = OutputPanel(self.plugin_info.get_data_dir(), window)
+
+        self.menu = ToolMenu(self._library, window, self._output_buffer, self,
                              "/MenuBar/ToolsMenu/ToolsOps_4/ExternalToolsMenu/ExternalToolPlaceholder")
         manager.ensure_update()
 
-        # Create output console
-        self._output_buffer = OutputPanel(self._plugin.get_data_dir(), window)
         bottom = window.get_bottom_panel()
-        bottom.add_item(self._output_buffer.panel,
-                        _("Shell Output"),
-                        gtk.STOCK_EXECUTE)
+        bottom.add_item_with_stock_icon(self._output_buffer.panel,
+                                        _("Shell Output"),
+                                        Gtk.STOCK_EXECUTE)
 
-    def update_ui(self):
-        self.menu.filter(self._window.get_active_document())
-        self._window.get_ui_manager().ensure_update()
+    def do_deactivate(self):
+        window = self.object
+        manager = window.get_ui_manager()
 
-    def deactivate(self):
-        manager = self._window.get_ui_manager()
         self.menu.deactivate()
         manager.remove_ui(self._merge_id)
         manager.remove_action_group(self._action_group)
         manager.ensure_update()
 
-        bottom = self._window.get_bottom_panel()
+        bottom = window.get_bottom_panel()
         bottom.remove_item(self._output_buffer.panel)
 
-    def update_manager(self, tool):
-        self._plugin.update_manager(tool)
+    def do_update_state(self):
+        window = self.object
 
-class ExternalToolsPlugin(pluma.Plugin):
-    WINDOW_DATA_KEY = "ExternalToolsPluginWindowData"
-
-    def __init__(self):
-        super(ExternalToolsPlugin, self).__init__()
-        
-        self._manager = None
-        self._manager_default_size = None
-
-        ToolLibrary().set_locations(os.path.join(self.get_data_dir(), 'tools'))
-
-    def activate(self, window):
-        helper = ExternalToolsWindowHelper(self, window)
-        window.set_data(self.WINDOW_DATA_KEY, helper)
-
-    def deactivate(self, window):
-        window.get_data(self.WINDOW_DATA_KEY).deactivate()
-        window.set_data(self.WINDOW_DATA_KEY, None)
-
-    def update_ui(self, window):
-        window.get_data(self.WINDOW_DATA_KEY).update_ui()
-
-    def create_configure_dialog(self):
-        return self.open_dialog()
+        self.menu.filter(window.get_active_document())
+        window.get_ui_manager().ensure_update()
 
     def open_dialog(self):
         if not self._manager:
-            self._manager = Manager(self.get_data_dir())
+            self._manager = Manager(self.plugin_info.get_data_dir())
 
             if self._manager_default_size:
                 self._manager.dialog.set_default_size(*self._manager_default_size)
 
             self._manager.dialog.connect('destroy', self.on_manager_destroy)
+            self._manager.connect('tools-updated', self.on_manager_tools_updated)
 
-        window = pluma.app_get_default().get_active_window()
+        window = Pluma.App.get_default().get_active_window()
         self._manager.run(window)
 
         return self._manager.dialog
@@ -275,7 +256,10 @@ class ExternalToolsPlugin(pluma.Plugin):
         self._manager.tool_changed(tool, True)
 
     def on_manager_destroy(self, dialog):
-        self._manager_default_size = [dialog.allocation.width, dialog.allocation.height]
+        self._manager_default_size = self._manager.get_final_size()
         self._manager = None
+
+    def on_manager_tools_updated(self, manager):
+        self.menu.update()
 
 # ex:ts=4:et:

--- a/plugins/externaltools/tools/filelookup.py
+++ b/plugins/externaltools/tools/filelookup.py
@@ -17,8 +17,7 @@
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 import os
-import gio
-import pluma
+from gi.repository import Gio, Pluma
 
 class FileLookup:
     """
@@ -73,7 +72,7 @@ class AbsoluteFileLookupProvider(FileLookupProvider):
 
     def lookup(self, path):
         if os.path.isabs(path) and os.path.isfile(path):
-            return gio.File(path)
+            return Gio.file_new_for_path(path)
         else:
             return None
 
@@ -93,7 +92,7 @@ class CwdFileLookupProvider(FileLookupProvider):
         real_path = os.path.join(cwd, path)
 
         if os.path.isfile(real_path):
-            return gio.File(real_path)
+            return Gio.file_new_for_path(real_path)
         else:
             return None
 
@@ -110,14 +109,14 @@ class OpenDocumentRelPathFileLookupProvider(FileLookupProvider):
         if path.startswith('/'):
             return None
 
-        for doc in pluma.app_get_default().get_documents():
+        for doc in Pluma.App.get_default().get_documents():
             if doc.is_local():
                 location = doc.get_location()
                 if location:
                     rel_path = location.get_parent().get_path()
                     joined_path = os.path.join(rel_path, path)
                     if os.path.isfile(joined_path):
-                        return gio.File(joined_path)
+                        return Gio.file_new_for_path(joined_path)
 
         return None
 
@@ -135,7 +134,7 @@ class OpenDocumentFileLookupProvider(FileLookupProvider):
         if path.startswith('/'):
             return None
 
-        for doc in pluma.app_get_default().get_documents():
+        for doc in Pluma.App.get_default().get_documents():
             if doc.is_local():
                 location = doc.get_location()
                 if location and location.get_uri().endswith(path):

--- a/plugins/externaltools/tools/functions.py
+++ b/plugins/externaltools/tools/functions.py
@@ -17,11 +17,7 @@
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 import os
-import gtk
-from gtk import gdk
-import gio
-import pluma
-#import gtksourceview
+from gi.repository import Gio, Gdk, Gtk, GtkSource, Pluma
 from outputpanel import OutputPanel
 from capture import *
 
@@ -44,7 +40,7 @@ def current_word(document):
     return (start, piter)
 
 # ==== Capture related functions ====
-def run_external_tool(window, node):
+def run_external_tool(window, panel, node):
     # Configure capture environment
     try:
         cwd = os.getcwd()
@@ -87,13 +83,13 @@ def run_external_tool(window, node):
         capture.set_env(PLUMA_CURRENT_DOCUMENT_TYPE=document.get_mime_type())
         
         if uri is not None:
-            gfile = gio.File(uri)
+            gfile = Gio.file_new_for_uri(uri)
             scheme = gfile.get_uri_scheme()
             name = os.path.basename(uri)
             capture.set_env(PLUMA_CURRENT_DOCUMENT_URI    = uri,
                             PLUMA_CURRENT_DOCUMENT_NAME   = name,
                             PLUMA_CURRENT_DOCUMENT_SCHEME = scheme)
-            if pluma.utils.uri_has_file_scheme(uri):
+            if Pluma.utils_uri_has_file_scheme(uri):
                 path = gfile.get_path()
                 cwd = os.path.dirname(path)
                 capture.set_cwd(cwd)
@@ -103,9 +99,9 @@ def run_external_tool(window, node):
         documents_uri = [doc.get_uri()
                                  for doc in window.get_documents()
                                  if doc.get_uri() is not None]
-        documents_path = [gio.File(uri).get_path()
+        documents_path = [Gio.file_new_for_uri(uri).get_path()
                                  for uri in documents_uri
-                                 if pluma.utils.uri_has_file_scheme(uri)]
+                                 if Pluma.utils_uri_has_file_scheme(uri)]
         capture.set_env(PLUMA_DOCUMENTS_URI  = ' '.join(documents_uri),
                         PLUMA_DOCUMENTS_PATH = ' '.join(documents_path))
 
@@ -120,8 +116,7 @@ def run_external_tool(window, node):
     input_type = node.input
     output_type = node.output
 
-    # Get the panel
-    panel = window.get_data("ExternalToolsPluginWindowData")._output_buffer
+    # Clear the panel
     panel.clear()
 
     if output_type == 'output-panel':
@@ -167,7 +162,7 @@ def run_external_tool(window, node):
             if not end.ends_word():
                 end.forward_word_end()
 
-        input_text = document.get_text(start, end)
+        input_text = document.get_text(start, end, False)
         capture.set_input(input_text)
 
     # Assign the standard output to the chosen "file"
@@ -211,8 +206,9 @@ def run_external_tool(window, node):
         document.end_user_action()
 
 class MultipleDocumentsSaver:
-    def __init__(self, window, docs, node):
+    def __init__(self, window, panel, docs, node):
         self._window = window
+        self._panel = panel
         self._node = node
         self._error = False
 
@@ -224,7 +220,7 @@ class MultipleDocumentsSaver:
 
         for doc in docs:
             signals[doc] = doc.connect('saving', self.on_document_saving)
-            pluma.commands.save_document(window, doc)
+            Pluma.commands_save_document(window, doc)
             doc.disconnect(signals[doc])
     
     def on_document_saving(self, doc, size, total_size):
@@ -241,17 +237,17 @@ class MultipleDocumentsSaver:
         self._counter -= 1
         
         if self._counter == 0 and not self._error:
-            run_external_tool(self._window, self._node)
+            run_external_tool(self._window, self._panel, self._node)
 
-def capture_menu_action(action, window, node):
+def capture_menu_action(action, window, panel, node):
     if node.save_files == 'document' and window.get_active_document():
-        MultipleDocumentsSaver(window, [window.get_active_document()], node)
+        MultipleDocumentsSaver(window, panel, [window.get_active_document()], node)
         return
     elif node.save_files == 'all':
-        MultipleDocumentsSaver(window, window.get_documents(), node)
+        MultipleDocumentsSaver(window, panel, window.get_documents(), node)
         return
 
-    run_external_tool(window, node)
+    run_external_tool(window, panel, node)
 
 def capture_stderr_line_panel(capture, line, panel):
     if not panel.visible():
@@ -260,7 +256,7 @@ def capture_stderr_line_panel(capture, line, panel):
     panel.write(line, panel.error_tag)
 
 def capture_begin_execute_panel(capture, panel, view, label):
-    view.get_window(gtk.TEXT_WINDOW_TEXT).set_cursor(gdk.Cursor(gdk.WATCH))
+    view.get_window(Gtk.TextWindowType.TEXT).set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
 
     panel['stop'].set_sensitive(True)
     panel.clear()
@@ -276,15 +272,14 @@ def capture_end_execute_panel(capture, exit_code, panel, view, output_type):
         end = start.copy()
         end.forward_chars(300)
 
-        mtype = gio.content_type_guess(data=doc.get_text(start, end))
-        lmanager = pluma.get_language_manager()
-        
+        mtype, uncertain = Gio.content_type_guess(None, doc.get_text(start, end, False).encode('utf-8'))
+        lmanager = GtkSource.LanguageManager.get_default()
         language = lmanager.guess_language(doc.get_uri(), mtype)
         
         if language is not None:
             doc.set_language(language)
 
-    view.get_window(gtk.TEXT_WINDOW_TEXT).set_cursor(gdk.Cursor(gdk.XTERM))
+    view.get_window(Gtk.TextWindowType.TEXT).set_cursor(Gdk.Cursor.new(Gdk.CursorType.XTERM))
     view.set_cursor_visible(True)
     view.set_editable(True)
 

--- a/plugins/externaltools/tools/library.py
+++ b/plugins/externaltools/tools/library.py
@@ -19,6 +19,7 @@
 import os
 import re
 import locale
+from gi.repository import GLib
 
 class Singleton(object):
     _instance = None
@@ -44,7 +45,7 @@ class ToolLibrary(Singleton):
         self.locations.append(datadir)
 
         # self.locations[0] is where we save the custom scripts
-        toolsdir = os.path.expanduser('~/.config/pluma/tools')
+        toolsdir = os.path.join(GLib.get_user_config_dir(), 'pluma/tools')
         self.locations.insert(0, toolsdir);
 
         if not os.path.isdir(self.locations[0]):
@@ -68,7 +69,7 @@ class ToolLibrary(Singleton):
     # storage file.
     def import_old_xml_store(self):
         import xml.etree.ElementTree as et
-        filename = os.path.expanduser('~/.config/pluma/pluma-tools.xml')
+        filename = os.path.join(GLib.get_user_config_dir(), 'pluma/pluma-tools.xml')
 
         if not os.path.isfile(filename):
             return

--- a/plugins/externaltools/tools/tools.ui
+++ b/plugins/externaltools/tools/tools.ui
@@ -131,6 +131,7 @@
     <property name="default_height">500</property>
     <property name="type_hint">dialog</property>
     <property name="skip_taskbar_hint">True</property>
+    <signal name="configure_event" handler="on_tool_manager_dialog_configure_event"/>
     <signal name="focus_out_event" handler="on_tool_manager_dialog_focus_out"/>
     <signal name="response" handler="on_tool_manager_dialog_response"/>
     <child internal-child="vbox">
@@ -551,6 +552,8 @@
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>

--- a/plugins/pythonconsole/Makefile.am
+++ b/plugins/pythonconsole/Makefile.am
@@ -2,10 +2,10 @@
 SUBDIRS = pythonconsole
 plugindir = $(PLUMA_PLUGINS_LIBS_DIR)
 
-plugin_in_files = pythonconsole.pluma-plugin.desktop.in
-%.pluma-plugin: %.pluma-plugin.desktop.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
+plugin_in_files = pythonconsole.plugin.desktop.in
+%.plugin: %.plugin.desktop.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
 
-plugin_DATA = $(plugin_in_files:.pluma-plugin.desktop.in=.pluma-plugin)
+plugin_DATA = $(plugin_in_files:.plugin.desktop.in=.plugin)
 
 EXTRA_DIST = $(plugin_in_files)
 

--- a/plugins/pythonconsole/pythonconsole.plugin.desktop.in
+++ b/plugins/pythonconsole/pythonconsole.plugin.desktop.in
@@ -1,4 +1,4 @@
-[Pluma Plugin]
+[Plugin]
 Loader=python
 Module=pythonconsole
 IAge=2

--- a/plugins/pythonconsole/pythonconsole/__init__.py
+++ b/plugins/pythonconsole/pythonconsole/__init__.py
@@ -24,38 +24,42 @@
 # Bits from pluma Python Console Plugin
 #     Copyrignt (C), 2005 Raphaël Slinckx
 
-import gtk
-import pluma
+from gi.repository import GObject, Gtk, Peas, Pluma
 
 from console import PythonConsole
 from config import PythonConsoleConfigDialog
 from config import PythonConsoleConfig
 
-PYTHON_ICON = 'mate-mime-text-x-python'
+PYTHON_ICON = 'text-x-python'
 
-class PythonConsolePlugin(pluma.Plugin):
+class PythonConsolePlugin(GObject.Object, Peas.Activatable):
+    __gtype_name__ = "PythonConsolePlugin"
+
+    object = GObject.Property(type=GObject.Object)
+
     def __init__(self):
-        pluma.Plugin.__init__(self)
+        GObject.Object.__init__(self)
         self.dlg = None
 
-    def activate(self, window):
-        console = PythonConsole(namespace = {'__builtins__' : __builtins__,
-                                             'pluma' : pluma,
+    def do_activate(self):
+        window = self.object
+
+        self._console = PythonConsole(namespace = {'__builtins__' : __builtins__,
+                                             'pluma' : Pluma,
                                              'window' : window})
-        console.eval('print "You can access the main window through ' \
+        self._console.eval('print "You can access the main window through ' \
                      '\'window\' :\\n%s" % window', False)
         bottom = window.get_bottom_panel()
-        image = gtk.Image()
-        image.set_from_icon_name(PYTHON_ICON, gtk.ICON_SIZE_MENU)
-        bottom.add_item(console, _('Python Console'), image)
-        window.set_data('PythonConsolePluginInfo', console)
+        image = Gtk.Image()
+        image.set_from_icon_name(PYTHON_ICON, Gtk.IconSize.MENU)
+        bottom.add_item(self._console, _('Python Console'), image)
 
-    def deactivate(self, window):
-        console = window.get_data("PythonConsolePluginInfo")
-        console.stop()
-        window.set_data("PythonConsolePluginInfo", None)
+    def do_deactivate(self):
+        window = self.object
+
+        self._console.stop()
         bottom = window.get_bottom_panel()
-        bottom.remove_item(console)
+        bottom.remove_item(self._console)
 
 def create_configure_dialog(self):
 

--- a/plugins/quickopen/Makefile.am
+++ b/plugins/quickopen/Makefile.am
@@ -2,10 +2,10 @@
 SUBDIRS = quickopen
 plugindir = $(PLUMA_PLUGINS_LIBS_DIR)
 
-plugin_in_files = quickopen.pluma-plugin.desktop.in
-%.pluma-plugin: %.pluma-plugin.desktop.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
+plugin_in_files = quickopen.plugin.desktop.in
+%.plugin: %.plugin.desktop.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*po) ; $(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
 
-plugin_DATA = $(plugin_in_files:.pluma-plugin.desktop.in=.pluma-plugin)
+plugin_DATA = $(plugin_in_files:.plugin.desktop.in=.plugin)
 
 EXTRA_DIST = $(plugin_in_files)
 

--- a/plugins/quickopen/quickopen.plugin.desktop.in
+++ b/plugins/quickopen/quickopen.plugin.desktop.in
@@ -1,4 +1,4 @@
-[Pluma Plugin]
+[Plugin]
 Loader=python
 Module=quickopen
 IAge=2

--- a/plugins/quickopen/quickopen/__init__.py
+++ b/plugins/quickopen/quickopen/__init__.py
@@ -17,25 +17,29 @@
 #  Foundation, Inc., 51 Franklin St, Fifth Floor,
 #  Boston, MA 02110-1301, USA.
 
-import pluma
+from gi.repository import GObject, Peas
 from windowhelper import WindowHelper
 
-class QuickOpenPlugin(pluma.Plugin):
+class QuickOpenPlugin(GObject.Object, Peas.Activatable):
+        __gtype_name__ = "QuickOpenPlugin"
+
+        object = GObject.Property(type=GObject.Object)
+
         def __init__(self):
-                pluma.Plugin.__init__(self)
+                GObject.Object.__init__(self)
 
                 self._popup_size = (450, 300)
-                self._helpers = {}
 
-        def activate(self, window):
-                self._helpers[window] = WindowHelper(window, self)
+        def do_activate(self):
+                window = self.object
+                self._helper = WindowHelper(window, self)
 
-        def deactivate(self, window):
-                self._helpers[window].deactivate()
-                del self._helpers[window]
+        def do_deactivate(self):
+                self._helper.deactivate()
+                self._helper = None
 
-        def update_ui(self, window):
-                self._helpers[window].update_ui()
+        def do_update_state(self):
+                self._helper.update_ui()
 
         def get_popup_size(self):
                 return self._popup_size

--- a/plugins/quickopen/quickopen/virtualdirs.py
+++ b/plugins/quickopen/quickopen/virtualdirs.py
@@ -17,10 +17,9 @@
 #  Foundation, Inc., 51 Franklin St, Fifth Floor,
 #  Boston, MA 02110-1301, USA.
 
-import gtk
-import gio
+from gi.repository import Gio, Gtk
 
-class VirtualDirectory:
+class VirtualDirectory(object):
         def __init__(self, name):
                 self._name = name
                 self._children = []
@@ -31,7 +30,7 @@ class VirtualDirectory:
         def get_parent(self):
                 return None
 
-        def enumerate_children(self, attr):
+        def enumerate_children(self, attr, flags, callback):
                 return self._children
 
         def append(self, child):
@@ -39,7 +38,7 @@ class VirtualDirectory:
                         return
 
                 try:
-                        info = child.query_info("standard::*")
+                        info = child.query_info("standard::*", Gio.FileQueryInfoFlags.NONE, None)
 
                         if info:
                                 self._children.append((child, info))
@@ -47,17 +46,14 @@ class VirtualDirectory:
                         pass
 
 class RecentDocumentsDirectory(VirtualDirectory):
-        def __init__(self, maxitems=10, screen=None):
+        def __init__(self, maxitems=10):
                 VirtualDirectory.__init__(self, 'recent')
 
                 self._maxitems = maxitems
-                self.fill(screen)
+                self.fill()
 
-        def fill(self, screen):
-                if screen:
-                        manager = gtk.recent_manager_get_for_screen(screen)
-                else:
-                        manager = gtk.recent_manager_get_default()
+        def fill(self):
+                manager = Gtk.RecentManager.get_default()
 
                 items = manager.get_items()
                 items.sort(lambda a, b: cmp(b.get_visited(), a.get_visited()))
@@ -66,7 +62,7 @@ class RecentDocumentsDirectory(VirtualDirectory):
 
                 for item in items:
                         if item.has_group('pluma'):
-                                self.append(gio.File(item.get_uri()))
+                                self.append(Gio.file_new_for_uri(item.get_uri()))
                                 added += 1
 
                                 if added >= self._maxitems:

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -49,6 +49,19 @@ plugins/changecase/pluma-changecase-plugin.c
 plugins/docinfo/docinfo.plugin.desktop.in
 [type: gettext/glade]plugins/docinfo/docinfo.ui
 plugins/docinfo/pluma-docinfo-plugin.c
+plugins/externaltools/externaltools.plugin.desktop.in
+plugins/externaltools/tools/__init__.py
+plugins/externaltools/tools/capture.py
+plugins/externaltools/tools/functions.py
+plugins/externaltools/tools/manager.py
+plugins/externaltools/tools/outputpanel.py
+[type: gettext/glade]plugins/externaltools/tools/tools.ui
+plugins/externaltools/data/build.desktop.in
+plugins/externaltools/data/open-terminal-here.desktop.in
+plugins/externaltools/data/remove-trailing-spaces.desktop.in
+plugins/externaltools/data/run-command.desktop.in
+plugins/externaltools/data/search-recursive.desktop.in
+plugins/externaltools/data/switch-c.desktop.in
 plugins/filebrowser/filebrowser.plugin.desktop.in
 [type: gettext/gsettings]plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in
 plugins/filebrowser/pluma-file-bookmarks-store.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -73,6 +73,9 @@ plugins/modelines/modelines.plugin.desktop.in
 plugins/pythonconsole/pythonconsole.plugin.desktop.in
 plugins/pythonconsole/pythonconsole/__init__.py
 [type: gettext/glade]plugins/pythonconsole/pythonconsole/config.ui
+plugins/quickopen/quickopen/popup.py
+plugins/quickopen/quickopen/windowhelper.py
+plugins/quickopen/quickopen.plugin.desktop.in
 plugins/sort/pluma-sort-plugin.c
 plugins/sort/sort.plugin.desktop.in
 [type: gettext/glade]plugins/sort/sort.ui

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -70,6 +70,9 @@ plugins/filebrowser/pluma-file-browser-store.c
 plugins/filebrowser/pluma-file-browser-view.c
 plugins/filebrowser/pluma-file-browser-widget.c
 plugins/modelines/modelines.plugin.desktop.in
+plugins/pythonconsole/pythonconsole.plugin.desktop.in
+plugins/pythonconsole/pythonconsole/__init__.py
+[type: gettext/glade]plugins/pythonconsole/pythonconsole/config.ui
 plugins/sort/pluma-sort-plugin.c
 plugins/sort/sort.plugin.desktop.in
 [type: gettext/glade]plugins/sort/sort.ui

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,9 +1,6 @@
 # List of source files that should *not* be translated.
 # Please keep this file sorted alphabetically.
 data/pluma.desktop.in
-plugins/pythonconsole/pythonconsole.pluma-plugin.desktop.in
-plugins/pythonconsole/pythonconsole/__init__.py
-[type: gettext/glade]plugins/pythonconsole/pythonconsole/config.ui
 plugins/quickopen/quickopen/popup.py
 plugins/quickopen/quickopen/windowhelper.py
 plugins/quickopen/quickopen.pluma-plugin.desktop.in

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,9 +1,6 @@
 # List of source files that should *not* be translated.
 # Please keep this file sorted alphabetically.
 data/pluma.desktop.in
-plugins/quickopen/quickopen/popup.py
-plugins/quickopen/quickopen/windowhelper.py
-plugins/quickopen/quickopen.pluma-plugin.desktop.in
 plugins/snippets/snippets.pluma-plugin.desktop.in
 [type: gettext/glade]plugins/snippets/snippets/snippets.ui
 plugins/snippets/snippets/Document.py

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,19 +1,6 @@
 # List of source files that should *not* be translated.
 # Please keep this file sorted alphabetically.
 data/pluma.desktop.in
-plugins/externaltools/externaltools.pluma-plugin.desktop.in
-plugins/externaltools/tools/__init__.py
-plugins/externaltools/tools/capture.py
-plugins/externaltools/tools/functions.py
-plugins/externaltools/tools/manager.py
-plugins/externaltools/tools/outputpanel.py
-[type: gettext/glade]plugins/externaltools/tools/tools.ui
-plugins/externaltools/data/build.desktop.in
-plugins/externaltools/data/open-terminal-here.desktop.in
-plugins/externaltools/data/remove-trailing-spaces.desktop.in
-plugins/externaltools/data/run-command.desktop.in
-plugins/externaltools/data/search-recursive.desktop.in
-plugins/externaltools/data/switch-c.desktop.in
 plugins/pythonconsole/pythonconsole.pluma-plugin.desktop.in
 plugins/pythonconsole/pythonconsole/__init__.py
 [type: gettext/glade]plugins/pythonconsole/pythonconsole/config.ui


### PR DESCRIPTION
@raveit65 @XRevan86 @lukefromdc @sc0w
Please test it if you can guys.
You'll need introspection packages for libpeas and Pluma itself, and also Python plugins loader from libpeas. Depending on your distro, the loader might be in the same package as libpeas itself or in a separate one.

Just in case - how to test plugins:

* externaltools:
  * press Ctrl-F9 to enable the bottom pane
  * select the tab with the gear icon to reveal the shell output window
  * use ```Tools -> External Tools``` menu (or use keyboard shortcuts) to run various tools
  * use ```Tools -> Manage External Tools...``` menu item to invoke the tools manager dialog
  * try adding and removing tools (they should be saved to ```~/.config/pluma/tools/```)
  * try changing various settings for the existing tools (code, shortcuts, languages and so on)

- pythonconsole:
  - press Ctrl-F9 to enable the bottom pane
  - select the tab with Python icon to reveal the Python console

* quickopen:
  * press Ctrl-Alt-O to invoke the quick open dialog
  * in the search field, type folder/file names that are in your home folder or in ```~/.gtk-bookmarks```
  * use arrows and Enter to navigate the folders and files that appear in the list

As for the snippets plugin, I'm still trying to make it work (code completion doesn't work at all at the moment), so it will be kept in a separate dev branch for a while.

Known issue: the bottom pane of Pluma doesn't look good in GTK+3 build. Nobody could find it earlier because there were no plugins that used it, so it was simply disabled in the menu... I will try to fix it later.

Also if you have a GTK+2 build of Pluma somewhere, it would be nice to check if there are any regressions in these plugins, compared to GTK+2 build. I've already tested that in a VM but I could miss something.