### PR TITLE
enable the abbility to save the document if it was changed externally

### DIFF
--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -690,13 +690,19 @@ set_sensitivity_according_to_tab (PlumaWindow *window,
 
 	action = gtk_action_group_get_action (window->priv->action_group,
 					      "FileSave");
+
+	if (state == PLUMA_TAB_STATE_EXTERNALLY_MODIFIED_NOTIFICATION) {
+		gtk_text_buffer_set_modified (GTK_TEXT_BUFFER (doc), TRUE);
+	}
+
 	gtk_action_set_sensitive (action,
 				  (state_normal ||
 				   (state == PLUMA_TAB_STATE_EXTERNALLY_MODIFIED_NOTIFICATION) ||
 				   (state == PLUMA_TAB_STATE_SHOWING_PRINT_PREVIEW)) &&
 				  !pluma_document_get_readonly (doc) &&
 				  !(lockdown & PLUMA_LOCKDOWN_SAVE_TO_DISK) &&
-				   (cansave));
+				   (cansave) &&
+				   (editable));
 
 	action = gtk_action_group_get_action (window->priv->action_group,
 					      "FileSaveAs");


### PR DESCRIPTION
This change is needed after https://github.com/mate-desktop/pluma/commit/2b34ed27ac4abde8d70735c008bd214a79b45491

The issue:

1. open file with pluma

2. open the same file with another editor (geany, vim, nano, ... ...)

3. modify and save the file with the other editor

4. go to pluma and see the behavior

Videos:

without the PR:
https://mega.nz/#!Idxz0Rxb!QQ0jKBI5YMW1pd04N9XKWA5G_yOzMySdYpOk_ehjlv4

with the PR:
https://mega.nz/#!xFIBHJJD!hbfgjud_MB-4PggTRQMvFCDtgxY6TCliMhDI-7nPRcg