### PR TITLE
Use CTRL+TAB and CTRL+SHIFT+TAB for tab switching 

### DIFF
--- a/pluma/pluma-ui.h
+++ b/pluma/pluma-ui.h
@@ -128,9 +128,12 @@ static const GtkActionEntry pluma_menu_entries[] =
 	  N_("Save all open files"), G_CALLBACK (_pluma_cmd_file_save_all) },
 	{ "FileCloseAll", GTK_STOCK_CLOSE, N_("_Close All"), "<shift><control>W",
 	  N_("Close all open files"), G_CALLBACK (_pluma_cmd_file_close_all) },
-	{ "DocumentsPreviousDocument", NULL, N_("_Previous Document"), "<alt><control>Page_Up",
+	/* Note Next and Previous actually handled in handle_keypress() due to
+	 * https://bugzilla.gnome.org/show_bug.cgi?id=123994, kept here so
+	 * that accelerator key is shown in menu */
+	{ "DocumentsPreviousDocument", NULL, N_("_Previous Document"), "<shift><control>Tab",
 	  N_("Activate previous document"), G_CALLBACK (_pluma_cmd_documents_previous_document) },
-	{ "DocumentsNextDocument", NULL, N_("_Next Document"), "<alt><control>Page_Down",
+	{ "DocumentsNextDocument", NULL, N_("_Next Document"), "<control>Tab",
 	  N_("Activate next document"), G_CALLBACK (_pluma_cmd_documents_next_document) },
 	{ "DocumentsMoveToNewWindow", NULL, N_("_Move to New Window"), NULL,
 	  N_("Move the current document to a new window"), G_CALLBACK (_pluma_cmd_documents_move_to_new_window) }

--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -3857,6 +3857,23 @@ on_extension_removed (PeasExtensionSet *extensions,
 	gtk_ui_manager_ensure_update (window->priv->manager);
 }
 
+static gboolean handle_keypress(PlumaWindow *window, GdkEventKey *event)
+{
+	guint keyval = event->keyval;
+	if (event->state & GDK_CONTROL_MASK)
+	{
+		if (keyval == GDK_KEY_Tab || keyval == GDK_KEY_KP_Tab || keyval == GDK_KEY_ISO_Left_Tab) {
+			if (event->state & GDK_SHIFT_MASK ) {
+				_pluma_cmd_documents_previous_document(event, window);
+			} else {
+				_pluma_cmd_documents_next_document(event, window);
+			}
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
 static void
 pluma_window_init (PlumaWindow *window)
 {
@@ -4001,6 +4018,9 @@ pluma_window_init (PlumaWindow *window)
 	init_panels_visibility (window);
 
 	update_sensitivity_according_to_open_tabs (window);
+
+	/* Need to catch CTRL+TAB and CTRL+SHIFT+TAB*/
+	g_signal_connect(window, "key_press_event", G_CALLBACK(handle_keypress), window);
 
 	pluma_debug_message (DEBUG_WINDOW, "END");
 }


### PR DESCRIPTION
Solution for #211

Use the more widely used keyboard shortcuts for tab switching.

Note that GTK uses CTRL+TAB and CTRL+SHIFT+TAB for changing widget
focus, so the keypress signals must be caught directly rather than using
GtkAction.