### PR TITLE
Fixes for regexp replacement with backreferences (e.g. "\0")

### DIFF
--- a/pluma/pluma-commands-search.c
+++ b/pluma/pluma-commands-search.c
@@ -144,11 +144,6 @@ text_not_found (PlumaWindow *window,
 	g_free (searched);
 }
 
-/* This is the string with last replace statement. The reason to use some kind of
-   global variable is to keep existing methods' signatures not changed (to minimize
-   code changes). This helper is used only for correct regex replacement. */
-static gchar *last_replace_text = NULL;
-
 static gboolean
 run_search (PlumaView   *view,
 	    gboolean     wrap_around,
@@ -172,8 +167,7 @@ run_search (PlumaView   *view,
 						       &start_iter,
 						       NULL,
 						       &match_start,
-						       &match_end,
-						       &last_replace_text);
+						       &match_end);
 	}
 	else
 	{
@@ -185,8 +179,7 @@ run_search (PlumaView   *view,
 							NULL,
 							&start_iter,
 							&match_start,
-							&match_end,
-							&last_replace_text);
+							&match_end);
 	}
 
 	if (!found && wrap_around)
@@ -196,15 +189,13 @@ run_search (PlumaView   *view,
 							       NULL,
 							       NULL, /* FIXME: set the end_inter */
 							       &match_start,
-							       &match_end,
-							       &last_replace_text);
+							       &match_end);
 		else
 			found = pluma_document_search_backward (doc,
 								NULL, /* FIXME: set the start_inter */
 								NULL,
 								&match_start,
-								&match_end,
-								&last_replace_text);
+								&match_end);
 	}
 
 	if (found)
@@ -280,9 +271,9 @@ do_find (PlumaSearchDialog *dialog,
 	}
 
 	g_free (search_text);
-	if(match_regex){
-		g_free(last_replace_text);
-		last_replace_text = g_strdup(pluma_search_dialog_get_replace_text (dialog));
+	if (match_regex)
+	{
+		pluma_document_set_last_replace_text (doc, pluma_search_dialog_get_replace_text (dialog));
 	}
 
 	found = run_search (active_view,
@@ -417,8 +408,7 @@ do_replace (PlumaSearchDialog *dialog,
 
 	if (need_refind)
 	{
-		g_free (last_replace_text);
-		last_replace_text = g_strdup(replace_entry_text);
+		pluma_document_set_last_replace_text (doc, replace_entry_text);
 		do_find (dialog, window);
 		g_free (unescaped_search_text);
 		g_free (selected_text);
@@ -429,7 +419,7 @@ do_replace (PlumaSearchDialog *dialog,
 	if(!match_regex)
 		unescaped_replace_text = pluma_utils_unescape_search_text (replace_entry_text);
 	else
-		unescaped_replace_text = g_strdup(last_replace_text);
+		unescaped_replace_text = g_strdup (pluma_document_get_last_replace_text (doc));
 
 	replace_selected_text (GTK_TEXT_BUFFER (doc), unescaped_replace_text);
 

--- a/pluma/pluma-commands-search.c
+++ b/pluma/pluma-commands-search.c
@@ -280,8 +280,10 @@ do_find (PlumaSearchDialog *dialog,
 	}
 
 	g_free (search_text);
-	if(match_regex)
+	if(match_regex){
+		g_free(last_replace_text);
 		last_replace_text = g_strdup(pluma_search_dialog_get_replace_text (dialog));
+	}
 
 	found = run_search (active_view,
 			    wrap_around,
@@ -415,6 +417,7 @@ do_replace (PlumaSearchDialog *dialog,
 
 	if (need_refind)
 	{
+		g_free (last_replace_text);
 		last_replace_text = g_strdup(replace_entry_text);
 		do_find (dialog, window);
 		g_free (unescaped_search_text);

--- a/pluma/pluma-document.c
+++ b/pluma/pluma-document.c
@@ -116,6 +116,7 @@ struct _PlumaDocumentPrivate
 
 	guint        search_flags;
 	gchar       *search_text;
+	gchar       *last_replace_text;
 	gint	     num_of_lines_search_text;
 
 	PlumaDocumentNewlineType newline_type;
@@ -301,6 +302,7 @@ pluma_document_finalize (GObject *object)
 	g_free (doc->priv->uri);
 	g_free (doc->priv->content_type);
 	g_free (doc->priv->search_text);
+	g_free (doc->priv->last_replace_text);
 
 	if (doc->priv->to_search_region != NULL)
 	{
@@ -1864,6 +1866,35 @@ pluma_document_get_search_text (PlumaDocument *doc,
 	return pluma_utils_escape_search_text (doc->priv->search_text);
 }
 
+/**
+ * pluma_document_set_last_replace_text:
+ * @doc:
+ * @text: (allow-none):
+ **/
+void
+pluma_document_set_last_replace_text (PlumaDocument *doc,
+				      const gchar   *text)
+{
+	g_return_if_fail (PLUMA_IS_DOCUMENT (doc));
+
+	g_free(doc->priv->last_replace_text);
+
+	pluma_debug_message (DEBUG_SEARCH, "last_replace_text = %s", text == NULL ? "NULL" : text);
+	doc->priv->last_replace_text = g_strdup(text);
+}
+
+/**
+ * pluma_document_get_last_replace_text:
+ * @doc:
+ */
+gchar *
+pluma_document_get_last_replace_text (PlumaDocument *doc)
+{
+	g_return_val_if_fail (PLUMA_IS_DOCUMENT (doc), NULL);
+
+	return doc->priv->last_replace_text;
+}
+
 gboolean
 pluma_document_get_can_search_again (PlumaDocument *doc)
 {
@@ -1886,8 +1917,7 @@ pluma_document_search_forward (PlumaDocument     *doc,
 			       const GtkTextIter *start,
 			       const GtkTextIter *end,
 			       GtkTextIter       *match_start,
-			       GtkTextIter       *match_end,
-			       gchar		**replace_text)
+			       GtkTextIter       *match_end)
 {
 	GtkTextIter iter;
 	GtkTextSearchFlags search_flags;
@@ -1939,7 +1969,7 @@ pluma_document_search_forward (PlumaDocument     *doc,
 								  &m_end,
 								  end,
 								  TRUE,
-								  replace_text);
+								  &doc->priv->last_replace_text);
 		}
 	
 		if (found && PLUMA_SEARCH_IS_ENTIRE_WORD (doc->priv->search_flags))
@@ -1976,8 +2006,7 @@ pluma_document_search_backward (PlumaDocument     *doc,
 		const GtkTextIter *start,
 		const GtkTextIter *end,
 		GtkTextIter       *match_start,
-		GtkTextIter       *match_end,
-		gchar            **replace_text)
+		GtkTextIter       *match_end)
 {
 	GtkTextIter iter;
 	GtkTextSearchFlags search_flags;
@@ -2031,7 +2060,7 @@ pluma_document_search_backward (PlumaDocument     *doc,
 								  &m_end,
 								  end,
 								  FALSE,
-								  replace_text);
+								  &doc->priv->last_replace_text);
 		}
 
 		if (found && PLUMA_SEARCH_IS_ENTIRE_WORD (doc->priv->search_flags))

--- a/pluma/pluma-document.h
+++ b/pluma/pluma-document.h
@@ -232,9 +232,16 @@ gboolean	 pluma_document_goto_line_offset(PlumaDocument *doc,
 void		 pluma_document_set_search_text	(PlumaDocument       *doc,
 						 const gchar         *text,
 						 guint                flags);
-						 
+
 gchar		*pluma_document_get_search_text	(PlumaDocument       *doc,
 						 guint               *flags);
+
+gchar		*pluma_document_get_last_replace_text
+						(PlumaDocument       *doc);
+
+void		 pluma_document_set_last_replace_text
+						(PlumaDocument       *doc,
+						 const gchar         *text);
 
 gboolean	 pluma_document_get_can_search_again
 						(PlumaDocument       *doc);
@@ -243,15 +250,13 @@ gboolean	 pluma_document_search_forward	(PlumaDocument       *doc,
 						 const GtkTextIter   *start,
 						 const GtkTextIter   *end,
 						 GtkTextIter         *match_start,
-						 GtkTextIter         *match_end,
-						 gchar              **replace_text);
+						 GtkTextIter         *match_end);
 
 gboolean	 pluma_document_search_backward	(PlumaDocument       *doc,
 						 const GtkTextIter   *start,
 						 const GtkTextIter   *end,
 						 GtkTextIter         *match_start,
-						 GtkTextIter         *match_end,
-						 gchar              **replace_text);
+						 GtkTextIter         *match_end);
 
 gint		 pluma_document_replace_all 	(PlumaDocument       *doc,
 				            	 const gchar         *find, 

--- a/pluma/pluma-document.h
+++ b/pluma/pluma-document.h
@@ -243,13 +243,15 @@ gboolean	 pluma_document_search_forward	(PlumaDocument       *doc,
 						 const GtkTextIter   *start,
 						 const GtkTextIter   *end,
 						 GtkTextIter         *match_start,
-						 GtkTextIter         *match_end);
-						 
+						 GtkTextIter         *match_end,
+						 gchar              **replace_text);
+
 gboolean	 pluma_document_search_backward	(PlumaDocument       *doc,
 						 const GtkTextIter   *start,
 						 const GtkTextIter   *end,
 						 GtkTextIter         *match_start,
-						 GtkTextIter         *match_end);
+						 GtkTextIter         *match_end,
+						 gchar              **replace_text);
 
 gint		 pluma_document_replace_all 	(PlumaDocument       *doc,
 				            	 const gchar         *find, 

--- a/pluma/pluma-utils.c
+++ b/pluma/pluma-utils.c
@@ -1646,7 +1646,7 @@ pluma_gtk_text_iter_regex_search (const GtkTextIter *iter,
 	if (!found)
 		goto free_resources;
 
-	if(replace_text != NULL)
+	if((replace_text != NULL) && (*replace_text != NULL))
 	{
 		*replace_text = g_match_info_expand_references (match_info,
 								*replace_text,

--- a/pluma/pluma-utils.h
+++ b/pluma/pluma-utils.h
@@ -156,7 +156,9 @@ pluma_gtk_text_iter_regex_search (const GtkTextIter *iter,
 				  GtkTextSearchFlags flags,
 				  GtkTextIter       *match_start,
 				  GtkTextIter       *match_end,
-				  const GtkTextIter *limit, gboolean forward_search);
+				  const GtkTextIter *limit,
+				  gboolean forward_search,
+				  gchar            **replace_text);
 
 G_END_DECLS
 

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -802,7 +802,8 @@ run_search (PlumaView        *view,
 							       &start_iter,
 							       NULL,
 							       &match_start,
-							       &match_end);
+							       &match_end,
+							       NULL);
 		}						       
 		else if (!typing)
 		{
@@ -816,7 +817,8 @@ run_search (PlumaView        *view,
 							        NULL,
 							        &start_iter,
 							        &match_start,
-							        &match_end);
+							        &match_end,
+								NULL);
 		} 
 		else
 		{
@@ -832,13 +834,15 @@ run_search (PlumaView        *view,
 								       NULL,
 								       NULL, /* FIXME: set the end_inter */
 								       &match_start,
-								       &match_end);
+								       &match_end,
+								       NULL);
 			else
 				found = pluma_document_search_backward (doc,
 								        NULL, /* FIXME: set the start_inter */
 								        NULL, 
 								        &match_start,
-								        &match_end);
+								        &match_end,
+									NULL);
 		}
 	}
 	else

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -802,8 +802,7 @@ run_search (PlumaView        *view,
 							       &start_iter,
 							       NULL,
 							       &match_start,
-							       &match_end,
-							       NULL);
+							       &match_end);
 		}						       
 		else if (!typing)
 		{
@@ -817,8 +816,7 @@ run_search (PlumaView        *view,
 							        NULL,
 							        &start_iter,
 							        &match_start,
-							        &match_end,
-								NULL);
+							        &match_end);
 		} 
 		else
 		{
@@ -834,15 +832,13 @@ run_search (PlumaView        *view,
 								       NULL,
 								       NULL, /* FIXME: set the end_inter */
 								       &match_start,
-								       &match_end,
-								       NULL);
+								       &match_end);
 			else
 				found = pluma_document_search_backward (doc,
 								        NULL, /* FIXME: set the start_inter */
 								        NULL, 
 								        &match_start,
-								        &match_end,
-									NULL);
+								        &match_end);
 		}
 	}
 	else


### PR DESCRIPTION
resolves #254 

Seems to work correct. Some additional tests from @hanaokaiwa are appreciated.