### PR TITLE
put 'peas_engine_enable_loader' in the correct place

### DIFF
--- a/pluma/pluma-plugins-engine.c
+++ b/pluma/pluma-plugins-engine.c
@@ -60,13 +60,13 @@ pluma_plugins_engine_init (PlumaPluginsEngine *engine)
 
 	pluma_debug (DEBUG_PLUGINS);
 
+	peas_engine_enable_loader (PEAS_ENGINE (engine), "python");
+
 	engine->priv = G_TYPE_INSTANCE_GET_PRIVATE (engine,
 	                                            PLUMA_TYPE_PLUGINS_ENGINE,
 	                                            PlumaPluginsEnginePrivate);
 
 	engine->priv->plugin_settings = g_settings_new (PLUMA_SCHEMA);
-
-	peas_engine_enable_loader (PEAS_ENGINE (engine), "python");
 
 	/* This should be moved to libpeas */
 	if (!g_irepository_require (g_irepository_get_default (),

--- a/pluma/pluma-tab.c
+++ b/pluma/pluma-tab.c
@@ -1031,8 +1031,6 @@ document_loaded (PlumaDocument *document,
 			    	{
 			    		GtkWidget *w;
 
-			    		pluma_tab_get_view (tab);
-
 			    		tab->priv->not_editable = TRUE;
 
 			    		w = pluma_file_already_open_warning_message_area_new (uri);


### PR DESCRIPTION
and this commit reverts:
https://github.com/mate-desktop/pluma/commit/e81883304c118abc3f8b7198cdc336a9a10f6571

now it isn't needed

@monsta and with this PR, you can revert https://github.com/mate-desktop/pluma/commit/e86397d000d3d307cb425404c74f963c0073b99b and test, the list of recently used files works too!