### PR TITLE
plugins: docinfo.ui: avoid GtkButton:use-stock and GtkImage:stock

### DIFF
--- a/plugins/docinfo/docinfo.ui
+++ b/plugins/docinfo/docinfo.ui
@@ -1,50 +1,60 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
+  <object class="GtkImage" id="update_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">view-refresh</property>
+  </object>
   <object class="GtkDialog" id="dialog">
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Document Statistics</property>
-    <property name="type">GTK_WINDOW_TOPLEVEL</property>
-    <property name="window_position">GTK_WIN_POS_NONE</property>
-    <property name="modal">False</property>
     <property name="resizable">False</property>
     <property name="destroy_with_parent">True</property>
-    <property name="decorated">True</property>
-    <property name="skip_taskbar_hint">False</property>
-    <property name="skip_pager_hint">False</property>
-    <property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
-    <property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
-    <property name="focus_on_map">True</property>
-    <property name="urgency_hint">False</property>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
+        <property name="can_focus">False</property>
         <property name="spacing">8</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="close_button">
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
-                <property name="focus_on_click">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">image1</property>
+                <property name="use_underline">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="update_button">
                 <property name="label" translatable="yes">_Update</property>
-                <property name="use_underline">True</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="image">update_image</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -54,556 +64,398 @@
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkVBox" id="docinfo_dialog_content">
-            <property name="border_width">5</property>
             <property name="visible">True</property>
-            <property name="homogeneous">False</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="file_name_label">
                 <property name="visible">True</property>
-                <property name="label" translatable="yes">File Name</property>
-                <property name="use_underline">False</property>
-                <property name="use_markup">True</property>
-                <property name="justify">GTK_JUSTIFY_LEFT</property>
-                <property name="wrap">False</property>
-                <property name="selectable">False</property>
-                <property name="xalign">0</property>
-                <property name="yalign">0.5</property>
+                <property name="can_focus">False</property>
                 <property name="xpad">0</property>
                 <property name="ypad">0</property>
-                <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                <property name="width_chars">-1</property>
-                <property name="single_line_mode">False</property>
-                <property name="angle">0</property>
+                <property name="label" translatable="yes">File Name</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0.5</property>
                 <attributes>
-                  <attribute name="weight" value="PANGO_WEIGHT_BOLD"/>
+                  <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkHBox" id="hbox1">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
-                <property name="spacing">0</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkLabel" id="label28">
                     <property name="visible">True</property>
-                    <property name="label" translatable="yes">    </property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="justify">GTK_JUSTIFY_LEFT</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="xalign">0.5</property>
-                    <property name="yalign">0.5</property>
+                    <property name="can_focus">False</property>
                     <property name="xpad">0</property>
                     <property name="ypad">0</property>
-                    <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
-                    <property name="angle">0</property>
+                    <property name="label" translatable="yes">    </property>
+                    <property name="xalign">0.5</property>
+                    <property name="yalign">0.5</property>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkTable" id="table1">
-                    <property name="border_width">6</property>
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="border_width">6</property>
                     <property name="n_rows">6</property>
                     <property name="n_columns">2</property>
-                    <property name="homogeneous">False</property>
-                    <property name="row_spacing">6</property>
                     <property name="column_spacing">18</property>
+                    <property name="row_spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label26">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">Bytes</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label" translatable="yes">Bytes</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="right_attach">1</property>
                         <property name="top_attach">5</property>
                         <property name="bottom_attach">6</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="bytes_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
                         <property name="top_attach">5</property>
                         <property name="bottom_attach">6</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label5">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">Characters (no spaces)</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label" translatable="yes">Characters (no spaces)</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="right_attach">1</property>
                         <property name="top_attach">4</property>
                         <property name="bottom_attach">5</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="chars_ns_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
                         <property name="top_attach">4</property>
                         <property name="bottom_attach">5</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label4">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">Characters (with spaces)</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label" translatable="yes">Characters (with spaces)</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="right_attach">1</property>
                         <property name="top_attach">3</property>
                         <property name="bottom_attach">4</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="chars_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
                         <property name="top_attach">3</property>
                         <property name="bottom_attach">4</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="words_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
                         <property name="top_attach">2</property>
                         <property name="bottom_attach">3</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">Words</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label" translatable="yes">Words</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="right_attach">1</property>
                         <property name="top_attach">2</property>
                         <property name="bottom_attach">3</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label6">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">Lines</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label" translatable="yes">Lines</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="right_attach">1</property>
                         <property name="top_attach">1</property>
                         <property name="bottom_attach">2</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="lines_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
                         <property name="top_attach">1</property>
                         <property name="bottom_attach">2</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label30">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">Document</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_markup">True</property>
-                        <property name="justify">GTK_JUSTIFY_CENTER</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label" translatable="yes">Document</property>
+                        <property name="use_markup">True</property>
+                        <property name="use_underline">True</property>
+                        <property name="justify">center</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
-                        <property name="top_attach">0</property>
-                        <property name="bottom_attach">1</property>
-                        <property name="x_options">fill</property>
+                        <property name="x_options">GTK_FILL</property>
                         <property name="y_options"/>
                       </packing>
                     </child>
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVBox" id="selection_vbox">
-                    <property name="border_width">6</property>
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
+                    <property name="can_focus">False</property>
+                    <property name="border_width">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="selection_label">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">Selection</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label" translatable="yes">Selection</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="selected_lines_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="selected_words_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="selected_chars_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="selected_chars_ns_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="selected_bytes_label">
                         <property name="visible">True</property>
-                        <property name="label">0</property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">1</property>
-                        <property name="yalign">0.5</property>
+                        <property name="can_focus">False</property>
                         <property name="xpad">0</property>
                         <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
+                        <property name="label">0</property>
+                        <property name="xalign">1</property>
+                        <property name="yalign">0.5</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">5</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -612,9 +464,8 @@
       <action-widget response="-7">close_button</action-widget>
       <action-widget response="-5">update_button</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
-  <object class="GtkImage" id="update_image">
-    <property name="visible">True</property>
-    <property name="stock">gtk-refresh</property>
-   </object>
 </interface>


### PR DESCRIPTION
the expected: the same look and behavior like before