### PR TITLE
spell plugin: pluma-spell-setup-dialog.ui: avoid deprecated:

### DIFF
--- a/plugins/spell/pluma-spell-setup-dialog.ui
+++ b/plugins/spell/pluma-spell-setup-dialog.ui
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">help-browser</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">process-stop</property>
+  </object>
+  <object class="GtkImage" id="image3">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">gtk-ok</property>
+  </object>
   <object class="GtkDialog" id="spell_dialog">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">_Configure Spell Checker plugin...</property>
@@ -18,12 +35,13 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="yes">_Help</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="image">image1</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -33,12 +51,13 @@
             </child>
             <child>
               <object class="GtkButton" id="button3">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="image">image2</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -48,12 +67,13 @@
             </child>
             <child>
               <object class="GtkButton" id="button4">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="image">image3</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -70,7 +90,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="spell_dialog_content">
+          <object class="GtkBox" id="spell_dialog_content">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
@@ -157,5 +177,8 @@
       <action-widget response="0">button3</action-widget>
       <action-widget response="0">button4</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
avoid deprecated GtkVBox and GtkButton:use-stock

I noticed the buttons in the ui file: '`Help`', '`Cancel`', and '`OK`', never works without/with the PR

![spell_with_pr](https://user-images.githubusercontent.com/7734191/36926310-65b968bc-1e77-11e8-82af-0e8d7ebf0e10.png)