### PR TITLE
pluma-encodings-dialog.ui: avoid GtkButton:use-stock

### DIFF
--- a/pluma/dialogs/pluma-encodings-dialog.c
+++ b/pluma/dialogs/pluma-encodings-dialog.c
@@ -366,6 +366,9 @@ pluma_encodings_dialog_init (PlumaEncodingsDialog *dlg)
 	g_object_unref (content);
 	gtk_container_set_border_width (GTK_CONTAINER (content), 5);			     
 
+	gtk_button_set_image (GTK_BUTTON (dlg->priv->add_button), gtk_image_new_from_icon_name ("list-add", GTK_ICON_SIZE_BUTTON));
+	gtk_button_set_image (GTK_BUTTON (dlg->priv->remove_button), gtk_image_new_from_icon_name ("list-remove", GTK_ICON_SIZE_BUTTON));
+
 	g_signal_connect (dlg->priv->add_button,
 			  "clicked",
 			  G_CALLBACK (add_button_clicked_callback),

--- a/pluma/dialogs/pluma-encodings-dialog.ui
+++ b/pluma/dialogs/pluma-encodings-dialog.ui
@@ -1,8 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.20.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">help-browser</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">process-stop</property>
+  </object>
+  <object class="GtkImage" id="image3">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">gtk-ok</property>
+  </object>
   <object class="GtkDialog" id="encodings-dialog">
     <property name="width_request">650</property>
     <property name="height_request">400</property>
@@ -22,12 +37,13 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="yes">_Help</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="image">image1</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -37,12 +53,13 @@
             </child>
             <child>
               <object class="GtkButton" id="closebutton1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="image">image2</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -52,12 +69,13 @@
             </child>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="image">image3</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -129,11 +147,11 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkButton" id="add-button">
-                        <property name="label">gtk-add</property>
+                        <property name="label" translatable="yes">_Add</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_stock">True</property>
+                        <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -207,11 +225,11 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkButton" id="remove-button">
-                        <property name="label">gtk-remove</property>
+                        <property name="label" translatable="yes">_Remove</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_stock">True</property>
+                        <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -250,5 +268,8 @@
       <action-widget response="-6">closebutton1</action-widget>
       <action-widget response="-5">button1</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
seems the buttons `'help'`, `'cancel'` and `'ok'` are handled by code, because I see the `stock` property in the GtkImages in gtk-inspector witthout/with the PR

The buttons `'add'` and `'remove'`: I put the icon image in the code, in `pluma-encodings-dialog.c`, because in the .ui file don't work