### PR TITLE
pluma-time-dialog.ui plugin: avoid deprecated:

### DIFF
--- a/plugins/time/pluma-time-dialog.ui
+++ b/plugins/time/pluma-time-dialog.ui
@@ -1,96 +1,110 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">help-browser</property>
+  </object>
+  <object class="GtkImage" id="image3">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">process-stop</property>
+  </object>
   <object class="GtkDialog" id="choose_format_dialog">
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Insert Date and Time</property>
-    <property name="type">GTK_WINDOW_TOPLEVEL</property>
-    <property name="window_position">GTK_WIN_POS_NONE</property>
-    <property name="modal">False</property>
     <property name="resizable">False</property>
     <property name="destroy_with_parent">True</property>
+    <property name="type_hint">normal</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox2">
+      <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area2">
+          <object class="GtkButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
+                <property name="label" translatable="yes">_Help</property>
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-help</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">image2</property>
+                <property name="use_underline">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="cancelbutton1">
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">image3</property>
+                <property name="use_underline">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="okbutton1">
                 <property name="visible">True</property>
-                <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
                 <child>
                   <object class="GtkAlignment" id="alignment1">
                     <property name="visible">True</property>
-                    <property name="xalign">0.5</property>
-                    <property name="yalign">0.5</property>
+                    <property name="can_focus">False</property>
                     <property name="xscale">0</property>
                     <property name="yscale">0</property>
                     <child>
-                      <object class="GtkHBox" id="hbox6">
+                      <object class="GtkBox" id="hbox6">
                         <property name="visible">True</property>
-                        <property name="homogeneous">False</property>
+                        <property name="can_focus">False</property>
                         <property name="spacing">2</property>
                         <child>
                           <object class="GtkImage" id="image1">
                             <property name="visible">True</property>
-                            <property name="stock">mate-stock-timer</property>
-                            <property name="icon_size">4</property>
-                            <property name="xalign">0.5</property>
-                            <property name="yalign">0.5</property>
-                            <property name="xpad">0</property>
-                            <property name="ypad">0</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">gtk-ok</property>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label7">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Insert</property>
                             <property name="use_underline">True</property>
-                            <property name="use_markup">False</property>
-                            <property name="justify">GTK_JUSTIFY_LEFT</property>
-                            <property name="wrap">False</property>
-                            <property name="selectable">False</property>
                             <property name="xalign">0.5</property>
                             <property name="yalign">0.5</property>
-                            <property name="xpad">0</property>
-                            <property name="ypad">0</property>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
@@ -98,192 +112,181 @@
                   </object>
                 </child>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox7">
-            <property name="border_width">5</property>
+          <object class="GtkBox" id="vbox7">
             <property name="visible">True</property>
-            <property name="homogeneous">False</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkVBox" id="vbox8">
+              <object class="GtkBox" id="vbox8">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkRadioButton" id="use_sel_format_radiobutton">
+                    <property name="label" translatable="yes">Use the _selected format</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Use the _selected format</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
                     <property name="use_underline">True</property>
-                    <property name="relief">GTK_RELIEF_NORMAL</property>
-                    <property name="active">False</property>
-                    <property name="inconsistent">False</property>
                     <property name="draw_indicator">True</property>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox4">
+                  <object class="GtkBox" id="hbox4">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
-                    <property name="spacing">0</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkLabel" id="label5">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">    </property>
-                        <property name="use_underline">False</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
                         <property name="xalign">0.5</property>
                         <property name="yalign">0.5</property>
-                        <property name="xpad">0</property>
-                        <property name="ypad">0</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow1">
-                        <property name="visible">True</property>
-                        <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
                         <property name="height_request">150</property>
-                        <property name="shadow_type">GTK_SHADOW_IN</property>
-                        <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">in</property>
                         <child>
                           <object class="GtkTreeView" id="choice_list">
                             <property name="visible">True</property>
+                            <property name="can_focus">True</property>
                             <property name="headers_visible">False</property>
-                            <property name="rules_hint">False</property>
-                            <property name="reorderable">False</property>
-                            <property name="enable_search">True</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkVBox" id="vbox9">
+              <object class="GtkBox" id="vbox9">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">2</property>
                 <child>
-                  <object class="GtkHBox" id="hbox5">
+                  <object class="GtkBox" id="hbox5">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">12</property>
                     <child>
                       <object class="GtkRadioButton" id="use_custom_radiobutton">
+                        <property name="label" translatable="yes">_Use custom format</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="label" translatable="yes">_Use custom format</property>
+                        <property name="receives_default">False</property>
                         <property name="use_underline">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
-                        <property name="active">False</property>
-                        <property name="inconsistent">False</property>
                         <property name="draw_indicator">True</property>
                         <property name="group">use_sel_format_radiobutton</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="custom_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="editable">True</property>
-                        <property name="visibility">True</property>
-                        <property name="max_length">0</property>
                         <property name="text" translatable="yes">%d/%m/%Y %H:%M:%S</property>
-                        <property name="has_frame">True</property>
-                        <property name="activates_default">False</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">2</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="padding">2</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="custom_format_example">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">01/11/2009 17:52:00</property>
-                    <property name="use_underline">False</property>
-                    <property name="justify">GTK_JUSTIFY_RIGHT</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
+                    <property name="justify">right</property>
                     <property name="xalign">1</property>
                     <property name="yalign">0.5</property>
-                    <property name="xpad">0</property>
-                    <property name="ypad">0</property>
                     <attributes>
-                      <attribute name="scale" value="0.8"/><!-- PANGO_SCALE_SMALL -->
+                      <attribute name="scale" value="0.80000000000000004"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -293,5 +296,8 @@
       <action-widget response="-6">cancelbutton1</action-widget>
       <action-widget response="-5">okbutton1</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
avoid deprecated:

GtkVBox
GtkHBox
GtkLabel:xpad/ypad
GtkImage:xalign/yalign/xpad/ypad/stock
GtkButton:use-stock

and add icon to the 'Insert' button

![time1](https://user-images.githubusercontent.com/7734191/37088160-ba09bb1e-21fc-11e8-8059-62f060329e31.png)

![time2](https://user-images.githubusercontent.com/7734191/37088164-be38fccc-21fc-11e8-8a20-ab59f699ca27.png)