### PR TITLE
spell-checker.ui plugin: avoid deprecated:

### DIFF
--- a/plugins/spell/pluma-spell-checker-dialog.c
+++ b/plugins/spell/pluma-spell-checker-dialog.c
@@ -296,6 +296,9 @@ create_dialog (PlumaSpellCheckerDialog *dlg,
 
 	gtk_entry_set_activates_default (GTK_ENTRY (dlg->word_entry), TRUE);
 
+	gtk_button_set_image (GTK_BUTTON (dlg->close_button),
+			      gtk_image_new_from_icon_name ("window-close", GTK_ICON_SIZE_BUTTON));
+
 	/* Connect signals */
 	g_signal_connect (dlg->word_entry, "changed",
 			  G_CALLBACK (word_entry_changed_handler), dlg);

--- a/plugins/spell/spell-checker.ui
+++ b/plugins/spell/spell-checker.ui
@@ -1,482 +1,410 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.4 -->
 <!--*- mode: xml -*-->
 <interface>
-  <object class="GtkImage" id="check_word_image">
-    <property name="stock">gtk-spell-check</property>
-    <property name="icon_size">4</property>
-  </object>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="add_word_image">
-    <property name="stock">gtk-add</property>
-    <property name="icon_size">4</property>
-  </object>
-  <object class="GtkImage" id="ignore_image">
-     <property name="stock">gtk-go-down</property>
-     <property name="icon_size">4</property>
-  </object>
-  <object class="GtkImage" id="change_image">
-     <property name="stock">gtk-convert</property>
-     <property name="icon_size">4</property>
-  </object>
-  <object class="GtkImage" id="ignore_all_image">
-    <property name="stock">gtk-goto-bottom</property>
-    <property name="icon_size">4</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">list-add</property>
   </object>
   <object class="GtkImage" id="change_all_image">
-     <property name="stock">gtk-convert</property>
-     <property name="icon_size">4</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">gtk-convert</property>
+  </object>
+  <object class="GtkImage" id="change_image">
+    <property name="can_focus">False</property>
+    <property name="icon_name">gtk-convert</property>
+  </object>
+  <object class="GtkImage" id="check_word_image">
+    <property name="can_focus">False</property>
+    <property name="icon_name">tools-check-spelling</property>
+  </object>
+  <object class="GtkImage" id="ignore_all_image">
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-bottom</property>
+  </object>
+  <object class="GtkImage" id="ignore_image">
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-down</property>
   </object>
   <object class="GtkWindow" id="check_spelling_window">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Check spelling</property>
-    <property name="type">GTK_WINDOW_TOPLEVEL</property>
-    <property name="window_position">GTK_WIN_POS_NONE</property>
-    <property name="modal">False</property>
     <property name="resizable">False</property>
-    <property name="destroy_with_parent">False</property>
     <child>
-      <object class="GtkVBox" id="content">
-        <property name="border_width">12</property>
+      <object class="GtkBox" id="content">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkTable" id="table1">
+          <object class="GtkGrid" id="table1">
             <property name="visible">True</property>
-            <property name="n_rows">2</property>
-            <property name="n_columns">2</property>
-            <property name="homogeneous">False</property>
+            <property name="can_focus">False</property>
             <property name="row_spacing">6</property>
             <property name="column_spacing">12</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Misspelled word:</property>
-                <property name="use_underline">False</property>
-                <property name="use_markup">False</property>
-                <property name="justify">GTK_JUSTIFY_CENTER</property>
-                <property name="wrap">False</property>
-                <property name="selectable">False</property>
+                <property name="justify">center</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0.5</property>
-                <property name="xpad">0</property>
-                <property name="ypad">0</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="right_attach">1</property>
                 <property name="top_attach">0</property>
-                <property name="bottom_attach">1</property>
-                <property name="x_options">fill</property>
-                <property name="y_options"/>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="misspelled_word_label">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">word</property>
-                <property name="use_underline">False</property>
                 <property name="use_markup">True</property>
-                <property name="justify">GTK_JUSTIFY_CENTER</property>
-                <property name="wrap">False</property>
-                <property name="selectable">False</property>
+                <property name="justify">center</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0.5</property>
-                <property name="xpad">0</property>
-                <property name="ypad">0</property>
                 <attributes>
-                  <attribute name="weight" value="PANGO_WEIGHT_BOLD"/>
+                  <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
                 <property name="top_attach">0</property>
-                <property name="bottom_attach">1</property>
-                <property name="x_options">fill</property>
-                <property name="y_options"/>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Change _to:</property>
                 <property name="use_underline">True</property>
-                <property name="use_markup">False</property>
-                <property name="justify">GTK_JUSTIFY_CENTER</property>
-                <property name="wrap">False</property>
-                <property name="selectable">False</property>
+                <property name="justify">center</property>
+                <property name="mnemonic_widget">word_entry</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0.5</property>
-                <property name="xpad">0</property>
-                <property name="ypad">0</property>
-                <property name="mnemonic_widget">word_entry</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="right_attach">1</property>
                 <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options">fill</property>
-                <property name="y_options"/>
               </packing>
             </child>
             <child>
-              <object class="GtkHBox" id="hbox1">
+              <object class="GtkBox" id="hbox1">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
                 <property name="spacing">12</property>
                 <child>
                   <object class="GtkEntry" id="word_entry">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="editable">True</property>
-                    <property name="visibility">True</property>
-                    <property name="max_length">0</property>
-                    <property name="text" translatable="yes"/>
-                    <property name="has_frame">True</property>
-                    <property name="activates_default">False</property>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="check_word_button">
+                    <property name="label" translatable="yes">Check _Word</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="relief">GTK_RELIEF_NORMAL</property>
+                    <property name="receives_default">False</property>
                     <property name="image">check_word_image</property>
-                    <property name="label" translatable="yes">Check _Word</property>
                     <property name="use_underline">True</property>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
                 <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="y_options">fill</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="table2">
+          <object class="GtkGrid" id="table2">
             <property name="visible">True</property>
-            <property name="n_rows">3</property>
-            <property name="n_columns">2</property>
-            <property name="homogeneous">False</property>
+            <property name="can_focus">False</property>
             <property name="row_spacing">6</property>
             <property name="column_spacing">12</property>
             <child>
               <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">_Suggestions:</property>
                 <property name="use_underline">True</property>
-                <property name="use_markup">False</property>
-                <property name="justify">GTK_JUSTIFY_CENTER</property>
-                <property name="wrap">False</property>
-                <property name="selectable">False</property>
+                <property name="justify">center</property>
+                <property name="mnemonic_widget">suggestions_list</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0.5</property>
-                <property name="xpad">0</property>
-                <property name="ypad">0</property>
-                <property name="mnemonic_widget">suggestions_list</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="right_attach">1</property>
                 <property name="top_attach">0</property>
-                <property name="bottom_attach">1</property>
-                <property name="x_options">fill</property>
-                <property name="y_options"/>
               </packing>
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
-                <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                <property name="shadow_type">GTK_SHADOW_ETCHED_IN</property>
-                <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                <property name="can_focus">False</property>
+                <property name="shadow_type">etched-in</property>
                 <child>
                   <object class="GtkTreeView" id="suggestions_list">
                     <property name="width_request">200</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="headers_visible">False</property>
-                    <property name="rules_hint">False</property>
-                    <property name="reorderable">False</property>
-                    <property name="enable_search">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="right_attach">1</property>
                 <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
               </packing>
             </child>
             <child>
-              <object class="GtkVBox" id="vbox2">
+              <object class="GtkBox" id="vbox2">
                 <property name="visible">True</property>
-                <property name="homogeneous">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">12</property>
+                <property name="homogeneous">True</property>
                 <child>
-                  <object class="GtkTable" id="table3">
+                  <object class="GtkGrid" id="table3">
                     <property name="visible">True</property>
-                    <property name="n_rows">2</property>
-                    <property name="n_columns">2</property>
-                    <property name="homogeneous">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
                     <property name="row_spacing">12</property>
                     <property name="column_spacing">12</property>
+                    <property name="column_homogeneous">True</property>
                     <child>
                       <object class="GtkButton" id="ignore_button">
+                        <property name="label" translatable="yes">_Ignore</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
+                        <property name="receives_default">False</property>
                         <property name="image">ignore_image</property>
-                        <property name="label" translatable="yes">_Ignore</property>
                         <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="right_attach">1</property>
                         <property name="top_attach">0</property>
-                        <property name="bottom_attach">1</property>
-                        <property name="y_options">expand</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="change_button">
+                        <property name="label" translatable="yes">Cha_nge</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
+                        <property name="receives_default">False</property>
                         <property name="image">change_image</property>
-                        <property name="label" translatable="yes">Cha_nge</property>
                         <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="right_attach">1</property>
                         <property name="top_attach">1</property>
-                        <property name="bottom_attach">2</property>
-                        <property name="y_options">expand</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="ignore_all_button">
+                        <property name="label" translatable="yes">Ignore _All</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
+                        <property name="receives_default">False</property>
                         <property name="image">ignore_all_image</property>
-                        <property name="label" translatable="yes">Ignore _All</property>
                         <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
                         <property name="top_attach">0</property>
-                        <property name="bottom_attach">1</property>
-                        <property name="y_options">expand</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="change_all_button">
+                        <property name="label" translatable="yes">Change A_ll</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
+                        <property name="receives_default">False</property>
                         <property name="image">change_all_image</property>
-                        <property name="label" translatable="yes">Change A_ll</property>
                         <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
                         <property name="top_attach">1</property>
-                        <property name="bottom_attach">2</property>
-                        <property name="y_options">expand</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVBox" id="vbox3">
+                  <object class="GtkBox" id="vbox3">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">11</property>
                     <child>
                       <object class="GtkLabel" id="label6">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">User dictionary:</property>
-                        <property name="use_underline">False</property>
                         <property name="use_markup">True</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">7.45058e-09</property>
+                        <property name="xalign">7.4505801528346183e-09</property>
                         <property name="yalign">0.5</property>
-                        <property name="xpad">0</property>
-                        <property name="ypad">0</property>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbox2">
+                      <object class="GtkBox" id="hbox2">
                         <property name="visible">True</property>
-                        <property name="homogeneous">True</property>
+                        <property name="can_focus">False</property>
                         <property name="spacing">6</property>
+                        <property name="homogeneous">True</property>
                         <child>
                           <object class="GtkButton" id="add_word_button">
+                            <property name="label" translatable="yes">Add w_ord</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="relief">GTK_RELIEF_NORMAL</property>
+                            <property name="receives_default">False</property>
                             <property name="image">add_word_image</property>
-                            <property name="label" translatable="yes">Add w_ord</property>
                             <property name="use_underline">True</property>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">False</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
                 <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
               </packing>
             </child>
             <child>
-              <object class="GtkHBox" id="hbox32">
+              <object class="GtkBox" id="hbox32">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">12</property>
                 <child>
                   <object class="GtkLabel" id="label44">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Language:</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="justify">GTK_JUSTIFY_LEFT</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
                     <property name="xalign">0.5</property>
                     <property name="yalign">0.5</property>
-                    <property name="xpad">0</property>
-                    <property name="ypad">0</property>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="language_label">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Language</property>
-                    <property name="use_underline">False</property>
                     <property name="use_markup">True</property>
-                    <property name="justify">GTK_JUSTIFY_LEFT</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
                     <property name="xalign">0.5</property>
                     <property name="yalign">0.5</property>
-                    <property name="xpad">0</property>
-                    <property name="ypad">0</property>
                     <attributes>
-                      <attribute name="weight" value="PANGO_WEIGHT_BOLD"/>
+                      <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="right_attach">1</property>
                 <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="x_options">fill</property>
-                <property name="y_options">fill</property>
               </packing>
             </child>
             <child>
-              <object class="GtkHButtonBox" id="hbuttonbox1">
+              <object class="GtkButtonBox" id="hbuttonbox1">
                 <property name="visible">True</property>
-                <property name="layout_style">GTK_BUTTONBOX_END</property>
-                <property name="spacing">0</property>
+                <property name="can_focus">False</property>
+                <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="close_button">
+                    <property name="label">_Close</property>
                     <property name="visible">True</property>
-                    <property name="can_default">True</property>
                     <property name="can_focus">True</property>
-                    <property name="label">gtk-close</property>
-                    <property name="use_stock">True</property>
-                    <property name="relief">GTK_RELIEF_NORMAL</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_underline">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
                 <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="x_options">fill</property>
-                <property name="y_options">fill</property>
               </packing>
+            </child>
+            <child>
+              <placeholder/>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
avoid deprecated:

GtkLabel:xpad/ypad
GtkTable
GtkVBox
GtkHBox
GtkHButtonBox
GtkImage:stock
GtkButton:use-stock

![menu_spell](https://user-images.githubusercontent.com/7734191/37561298-71869ef0-2a4b-11e8-9f38-3f603de545cb.png)

![spell_with_pr](https://user-images.githubusercontent.com/7734191/37561299-7562dfca-2a4b-11e8-8bef-06729ccd0f55.png)