### PR TITLE
pluma-file-browser-widget.c: avoid deprecated GtkImageMenuItem

### DIFF
--- a/plugins/filebrowser/pluma-file-browser-widget.c
+++ b/plugins/filebrowser/pluma-file-browser-widget.c
@@ -984,6 +984,9 @@ create_toolbar (PlumaFileBrowserWidget * obj,
 
 	/* Previous directory menu tool item */
 	obj->priv->location_previous_menu = gtk_menu_new ();
+
+	gtk_menu_set_reserve_toggle_size (GTK_MENU (obj->priv->location_previous_menu), FALSE);
+
 	gtk_widget_show (obj->priv->location_previous_menu);
 
 	widget = GTK_WIDGET (gtk_menu_tool_button_new (gtk_image_new_from_icon_name ("go-previous",
@@ -1007,6 +1010,9 @@ create_toolbar (PlumaFileBrowserWidget * obj,
 
 	/* Next directory menu tool item */
 	obj->priv->location_next_menu = gtk_menu_new ();
+
+	gtk_menu_set_reserve_toggle_size (GTK_MENU (obj->priv->location_next_menu), FALSE);
+
 	gtk_widget_show (obj->priv->location_next_menu);
 
 	widget = GTK_WIDGET (gtk_menu_tool_button_new (gtk_image_new_from_icon_name ("go-next",
@@ -1532,7 +1538,6 @@ create_goto_menu_item (PlumaFileBrowserWidget * obj, GList * item,
 		       GdkPixbuf * icon)
 {
 	GtkWidget *result;
-	GtkWidget *image;
 	gchar *unescape;
 	GdkPixbuf *pixbuf = NULL;
 	Location *loc;
@@ -1547,14 +1552,8 @@ create_goto_menu_item (PlumaFileBrowserWidget * obj, GList * item,
 	}
 
 	if (pixbuf) {
-		image = gtk_image_new_from_pixbuf (pixbuf);
+		result = pluma_image_menu_item_new_from_pixbuf (pixbuf, unescape);
 		g_object_unref (pixbuf);
-
-		gtk_widget_show (image);
-
-		result = gtk_image_menu_item_new_with_label (unescape);
-		gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (result),
-					       image);
 	} else {
 		result = gtk_menu_item_new_with_label (unescape);
 	}

--- a/pluma/pluma-utils.c
+++ b/pluma/pluma-utils.c
@@ -1698,3 +1698,27 @@ free_resources:
 	g_regex_unref (regex);
 	return found;
 }
+
+GtkWidget *
+pluma_image_menu_item_new_from_pixbuf (GdkPixbuf   *icon_pixbuf,
+				       const gchar *label_name)
+{
+	GtkWidget *icon;
+	GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+	if (icon_pixbuf)
+		icon = gtk_image_new_from_pixbuf (icon_pixbuf);
+	else
+		icon = gtk_image_new ();
+
+	GtkWidget *label_menu = gtk_label_new (g_strconcat (label_name, "     ", NULL));
+	GtkWidget *menuitem = gtk_menu_item_new ();
+
+	gtk_container_add (GTK_CONTAINER (box), icon);
+	gtk_container_add (GTK_CONTAINER (box), label_menu);
+
+	gtk_container_add (GTK_CONTAINER (menuitem), box);
+	gtk_widget_show_all (menuitem);
+
+	return menuitem;
+}

--- a/pluma/pluma-utils.h
+++ b/pluma/pluma-utils.h
@@ -160,6 +160,10 @@ pluma_gtk_text_iter_regex_search (const GtkTextIter *iter,
 				  gboolean forward_search,
 				  gchar            **replace_text);
 
+GtkWidget *
+pluma_image_menu_item_new_from_pixbuf (GdkPixbuf   *icon_pixbuf,
+				       const gchar *label_name);
+
 G_END_DECLS
 
 #endif /* __PLUMA_UTILS_H__ */


### PR DESCRIPTION
avoid deprecated:

gtk_image_menu_item_new_with_label
gtk_image_menu_item_set_image

![filebrowserpluma](https://user-images.githubusercontent.com/7734191/39023439-ed526fe2-443a-11e8-9f49-c5cedd13ed2e.png)