### PR TITLE
pluma-view.c: Fix: GtkCheckMenuItem "Display line numbers" improved

### DIFF
--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -1997,17 +1997,6 @@ show_line_numbers_menu (GtkWidget      *view,
 static gboolean
 pluma_view_button_press_event (GtkWidget *widget, GdkEventButton *event)
 {
-	if ((event->button == 2) || (event->button == 3))
-	{
-		if (middle_or_right_down)
-		{
-			middle_or_right_down = FALSE;
-			return TRUE;
-		}
-		else
-			middle_or_right_down = TRUE;
-	}
-
 	if ((event->type == GDK_BUTTON_PRESS) && 
 	    (event->window == gtk_text_view_get_window (GTK_TEXT_VIEW (widget),
 						        GTK_TEXT_WINDOW_LEFT)))
@@ -2019,6 +2008,17 @@ pluma_view_button_press_event (GtkWidget *widget, GdkEventButton *event)
 		}
 		else if (event->button == 2)
 			return TRUE;
+	}
+
+	if ((event->button == 2) || (event->button == 3))
+	{
+		if (middle_or_right_down)
+		{
+			middle_or_right_down = FALSE;
+			return TRUE;
+		}
+		else
+			middle_or_right_down = TRUE;
 	}
 
 	if ((event->type == GDK_2BUTTON_PRESS) && (event->button == 1) &&


### PR DESCRIPTION
The issue: right click here:

![pumacloses](https://cloud.githubusercontent.com/assets/7734191/23591021/32f66d80-01ea-11e7-95d9-a04bc867dd79.png)

The expected:

![line_numbers](https://user-images.githubusercontent.com/7734191/39149779-8dd73d1e-4740-11e8-86a1-54859d72d847.png)

Sometimes right click here doesn't show the item, just right click some times, seems it needs two right clicks to show it

In the tests: make sure you can't reproduce the issues https://github.com/mate-desktop/pluma/issues/215 , https://github.com/mate-desktop/pluma/issues/250 and https://github.com/mate-desktop/pluma/issues/256