### PR TITLE
Fix: Pluma crashes with mouse wheel over a tab

### DIFF
--- a/pluma/pluma-notebook.c
+++ b/pluma/pluma-notebook.c
@@ -864,16 +864,6 @@ close_button_clicked_cb (PlumaTabLabel *tab_label, PlumaNotebook *notebook)
 	g_signal_emit (notebook, signals[TAB_CLOSE_REQUEST], 0, tab);
 }
 
-static gboolean
-tab_label_scroll_cb (PlumaTabLabel  *tab_label,
-                     GdkEventScroll *event,
-                     PlumaNotebook  *notebook)
-{
-	g_signal_emit_by_name (notebook, "scroll-event", &event);
-	
-	return FALSE;
-}
-
 static GtkWidget *
 create_tab_label (PlumaNotebook *nb,
 		  PlumaTab      *tab)
@@ -885,10 +875,6 @@ create_tab_label (PlumaNotebook *nb,
 	g_signal_connect (tab_label,
 			  "close-clicked",
 			  G_CALLBACK (close_button_clicked_cb),
-			  nb);
-	g_signal_connect (tab_label,
-			  "scroll-event",
-			  G_CALLBACK (tab_label_scroll_cb),
 			  nb);
 
 	g_object_set_data (G_OBJECT (tab), "tab-label", tab_label);

--- a/pluma/pluma-tab-label.c
+++ b/pluma/pluma-tab-label.c
@@ -114,16 +114,6 @@ close_button_clicked_cb (GtkWidget     *widget,
 	g_signal_emit (tab_label, signals[CLOSE_CLICKED], 0, NULL);
 }
 
-static gboolean
-scroll_event_cb(GtkWidget      *widget,
-                GdkEventScroll *event,
-                PlumaTabLabel  *tab_label)
-{
-	g_signal_emit_by_name(tab_label, "scroll-event", &event);
-	
-	return FALSE;
-}
-
 static void
 sync_tip (PlumaTab *tab, PlumaTabLabel *tab_label)
 {
@@ -294,16 +284,6 @@ pluma_tab_label_init (PlumaTabLabel *tab_label)
 			  G_CALLBACK (close_button_clicked_cb),
 			  tab_label);
 			  
-	g_signal_connect (close_button,
-			  "scroll-event",
-			  G_CALLBACK (scroll_event_cb),
-			  tab_label);
-	
-	g_signal_connect (ebox,
-			  "scroll-event",
-			  G_CALLBACK (scroll_event_cb),
-			  tab_label);
-
 	spinner = gtk_spinner_new ();
 	gtk_box_pack_start (GTK_BOX (hbox), spinner, FALSE, FALSE, 0);
 	tab_label->priv->spinner = spinner;


### PR DESCRIPTION
Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898637

I can't reproduce the debian bug, but reporter says this PR fixes the problem

In the tests, make sure the PR https://github.com/mate-desktop/pluma/pull/276 is working as before