### PR TITLE
pluma-notebook: pass event to gdk_seat_grab

### DIFF
--- a/pluma/pluma-notebook.c
+++ b/pluma/pluma-notebook.c
@@ -394,7 +394,7 @@ pluma_notebook_reorder_tab (PlumaNotebook *src,
 
 static void
 drag_start (PlumaNotebook *notebook,
-	    guint32        time)
+            GdkEvent      *event)
 {
 	GdkSeat    *seat;
 	GdkDevice  *device;
@@ -424,7 +424,7 @@ drag_start (PlumaNotebook *notebook,
 			       GDK_SEAT_CAPABILITY_POINTER,
 			       FALSE,
 			       cursor,
-			       NULL,
+			       event,
 			       NULL,
 			       NULL);
 	}
@@ -493,7 +493,7 @@ motion_notify_cb (PlumaNotebook  *notebook,
 					      event->x_root, 
 					      event->y_root))
 		{
-			drag_start (notebook, event->time);
+			drag_start (notebook, (GdkEvent *) event);
 			return TRUE;
 		}
 
@@ -570,7 +570,7 @@ move_current_tab_to_another_notebook (PlumaNotebook  *src,
 				  G_CALLBACK (motion_notify_cb),
 				  NULL);
 
-	drag_start (dest, event->time);
+	drag_start (dest, (GdkEvent *) event);
 }
 
 static gboolean


### PR DESCRIPTION
follow-up to d6d1cdb0e241ee3a07200ad0561a8105b6243c2b (see https://github.com/mate-desktop/pluma/pull/318#discussion_r190516342)