### PR TITLE
Font refactoring

### DIFF
--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -646,33 +646,12 @@ pluma_view_scroll_to_cursor (PlumaView *view)
 				      0.0);
 }
 
-static PangoFontDescription* get_system_font (void)
-{
-    PangoFontDescription *desc = NULL;
-    GSettings *settings;
-    char *name;
-
-    settings = g_settings_new ("org.mate.interface");
-    name = g_settings_get_string (settings, "font-name");
-
-    if (name) {
-    	desc = pango_font_description_from_string (name);
-    	g_free (name);
-    }
-
-    g_object_unref (settings);
-
-    return desc;
-}
-
 static void
-pluma_override_font (const gchar          *item,
-		     GtkWidget            *widget,
+pluma_override_font (GtkWidget            *widget,
 		     PangoFontDescription *font)
 {
 	static gboolean provider_added = FALSE;
 	GtkCssProvider *provider;
-	gchar          *prov_str;
 	gchar          *css;
 	gchar          *family;
 	gchar          *weight;
@@ -696,13 +675,7 @@ pluma_override_font (const gchar          *item,
 
 	provider = gtk_css_provider_get_default ();
 
-	prov_str = gtk_css_provider_to_string (provider);
-
-	if (g_str_has_prefix (prov_str, "textview") && g_str_has_prefix (item, ".context-menu"))
-		css = g_strdup_printf ("%s %s { %s %s %s %s }", prov_str, item, family, weight, style, size);
-	else
-		css = g_strdup_printf ("%s { %s %s %s %s }", item, family, weight, style, size);
-
+	css = g_strdup_printf ("textview { %s %s %s %s }", family, weight, style, size);
 	gtk_css_provider_load_from_data (provider, css, -1, NULL);
 
 	if (!provider_added) {
@@ -716,7 +689,6 @@ pluma_override_font (const gchar          *item,
 	g_free (family);
 	g_free (weight);
 	g_free (size);
-	g_free (prov_str);
 }
 
 /* FIXME this is an issue for introspection */
@@ -735,7 +707,6 @@ pluma_view_set_font (PlumaView   *view,
 		     const gchar *font_name)
 {
 	PangoFontDescription *font_desc = NULL;
-	PangoFontDescription *sys_font_desc = NULL;
 
 	pluma_debug (DEBUG_VIEW);
 
@@ -758,13 +729,7 @@ pluma_view_set_font (PlumaView   *view,
 
 	g_return_if_fail (font_desc != NULL);
 
-	pluma_override_font ("textview", GTK_WIDGET (view), font_desc);
-
-	sys_font_desc = get_system_font ();
-	if (sys_font_desc) {
-		pluma_override_font (".context-menu", GTK_WIDGET (view), sys_font_desc);
-		pango_font_description_free (sys_font_desc);
-	}
+	pluma_override_font (GTK_WIDGET (view), font_desc);
 
 	pango_font_description_free (font_desc);		
 }

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -675,7 +675,7 @@ contextmenu_font_changed_cb (GSettings *settings,
 	sys_font_desc = get_system_font ();
 	if (sys_font_desc)
 	{
-		pluma_override_font (".context-menu", NULL, sys_font_desc);
+		pluma_override_font (".context-menu", GTK_WIDGET (user_data), sys_font_desc);
 		pango_font_description_free (sys_font_desc);
 	}
 }
@@ -718,13 +718,10 @@ pluma_override_font (const gchar          *item,
 	{
 		if (strstr (prov_str, ".context-menu"))
 		{
-			g_strdelimit (prov_str, "}", '\0');
-			gchar *prov_new_str = g_strdup_printf ("%s}", prov_str);
-			css = g_strdup_printf ("%s %s { %s %s %s %s }", prov_new_str, item, family, weight, style, size);
-			g_free (prov_new_str);
+			prov_str = g_strdelimit (prov_str, "}", '\0');
+			prov_str = g_strdup_printf ("%s}", prov_str);
 		}
-		else
-			css = g_strdup_printf ("%s %s { %s %s %s %s }", prov_str, item, family, weight, style, size);
+		css = g_strdup_printf ("%s %s { %s %s %s %s }", prov_str, item, family, weight, style, size);
 	}
 	else
 		css = g_strdup_printf ("%s { %s %s %s %s }", item, family, weight, style, size);

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -651,11 +651,12 @@ pluma_override_font (GtkWidget            *widget,
 		     PangoFontDescription *font)
 {
 	static gboolean provider_added = FALSE;
-	GtkCssProvider *provider;
+	static GtkCssProvider *provider;
 	gchar          *css;
 	gchar          *family;
 	gchar          *weight;
 	const gchar    *style;
+	GString        *string;
 	gchar          *size;
 
 	family = g_strdup_printf ("font-family: %s;", pango_font_description_get_family (font));
@@ -672,10 +673,20 @@ pluma_override_font (GtkWidget            *widget,
 	size = g_strdup_printf ("font-size: %d%s;",
 				pango_font_description_get_size (font) / PANGO_SCALE,
 				pango_font_description_get_size_is_absolute (font) ? "px" : "pt");
+	if (!provider_added)
+		provider = gtk_css_provider_new ();
 
-	provider = gtk_css_provider_get_default ();
-
-	css = g_strdup_printf ("textview { %s %s %s %s }", family, weight, style, size);
+	/*Build a cssprovider that uses "initial" to exclude the context menu*/
+	string = g_string_new(NULL);
+	g_string_append (string, "textview menu {font-size: initial; font-family: initial; ");
+	g_string_append (string,"font-weight: initial; font-style: initial;}");
+	g_string_append (string, "textview {");
+	g_string_append (string,family);
+	g_string_append (string, weight);
+	g_string_append (string, style);
+	g_string_append (string,size);
+	g_string_append (string, "}");
+	css = g_string_free (string, FALSE);
 	gtk_css_provider_load_from_data (provider, css, -1, NULL);
 
 	if (!provider_added) {

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -648,39 +648,24 @@ pluma_view_scroll_to_cursor (PlumaView *view)
 
 static PangoFontDescription* get_system_font (void)
 {
-	PangoFontDescription *desc = NULL;
-	GSettings *settings;
-	char *name;
+    PangoFontDescription *desc = NULL;
+    GSettings *settings;
+    char *name;
 
-	settings = g_settings_new ("org.mate.interface");
-	name = g_settings_get_string (settings, "font-name");
+    settings = g_settings_new ("org.mate.interface");
+    name = g_settings_get_string (settings, "font-name");
 
-	if (name)
-	{
-		desc = pango_font_description_from_string (name);
-		g_free (name);
-	}
+    if (name) {
+    	desc = pango_font_description_from_string (name);
+    	g_free (name);
+    }
 
-	g_object_unref (settings);
+    g_object_unref (settings);
 
-	return desc;
+    return desc;
 }
 
 static void
-contextmenu_font_changed_cb (GSettings *settings,
-			     gchar     *key,
-			     gpointer   user_data)
-{
-	PangoFontDescription *sys_font_desc = NULL;
-	sys_font_desc = get_system_font ();
-	if (sys_font_desc)
-	{
-		pluma_override_font (".context-menu", GTK_WIDGET (user_data), sys_font_desc);
-		pango_font_description_free (sys_font_desc);
-	}
-}
-
-void
 pluma_override_font (const gchar          *item,
 		     GtkWidget            *widget,
 		     PangoFontDescription *font)
@@ -714,27 +699,13 @@ pluma_override_font (const gchar          *item,
 	prov_str = gtk_css_provider_to_string (provider);
 
 	if (g_str_has_prefix (prov_str, "textview") && g_str_has_prefix (item, ".context-menu"))
-	{
-		if (strstr (prov_str, ".context-menu"))
-		{
-			prov_str = g_strdelimit (prov_str, "}", '\0');
-			prov_str = g_strdup_printf ("%s}", prov_str);
-		}
 		css = g_strdup_printf ("%s %s { %s %s %s %s }", prov_str, item, family, weight, style, size);
-	}
 	else
 		css = g_strdup_printf ("%s { %s %s %s %s }", item, family, weight, style, size);
 
 	gtk_css_provider_load_from_data (provider, css, -1, NULL);
 
-	if (!provider_added)
-	{
-		GSettings *settings;
-		settings = g_settings_new ("org.mate.interface");
-		g_signal_connect (settings,
-				  "changed::" "font-name",
-				  G_CALLBACK (contextmenu_font_changed_cb), NULL);
-
+	if (!provider_added) {
 		gtk_style_context_add_provider_for_screen (gtk_widget_get_screen (widget),
 							   GTK_STYLE_PROVIDER (provider),
 							   GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -686,7 +686,7 @@ pluma_override_font (const gchar          *item,
 		     PangoFontDescription *font)
 {
 	static gboolean provider_added = FALSE;
-	static GtkCssProvider *provider; /*We need to keep this as long as Pluma is running*/
+	GtkCssProvider *provider;
 	gchar          *prov_str;
 	gchar          *css;
 	gchar          *family;
@@ -709,8 +709,7 @@ pluma_override_font (const gchar          *item,
 				pango_font_description_get_size (font) / PANGO_SCALE,
 				pango_font_description_get_size_is_absolute (font) ? "px" : "pt");
 
-	if (!provider_added)
-		provider = gtk_css_provider_new ();
+	provider = gtk_css_provider_get_default ();
 
 	prov_str = gtk_css_provider_to_string (provider);
 
@@ -730,7 +729,7 @@ pluma_override_font (const gchar          *item,
 
 	if (!provider_added)
 	{
-		static GSettings *settings; /*We need this for the life of the provider and program*/
+		GSettings *settings;
 		settings = g_settings_new ("org.mate.interface");
 		g_signal_connect (settings,
 				  "changed::" "font-name",

--- a/pluma/pluma-view.h
+++ b/pluma/pluma-view.h
@@ -99,10 +99,6 @@ void		 pluma_view_select_all		(PlumaView       *view);
 
 void		 pluma_view_scroll_to_cursor 	(PlumaView       *view);
 
-void		 pluma_override_font		(const gchar          *item,
-						 GtkWidget            *widget,
-						 PangoFontDescription *font);
-
 void 		 pluma_view_set_font		(PlumaView       *view,
 						 gboolean         def,
 						 const gchar     *font_name);


### PR DESCRIPTION
For the Pluma  context menus, use the "intial" cssvalue to return context menus to system font whatever they may be. Changes are applied immediately, requiring no new signal to be connected and removing the need for the  get_system_font function.

Revert the previous context menu work to get back to the starting point. Afterwards, clean things up a bit: create and add the static cssprovider in a single block, write to it afterwards. Shuffle some variable declarations to get a consistant block as when they are freed at the end. Document all this with comments in code.