### PR TITLE
spell plugin: Autocheck spelling with [control + F7]

### DIFF
--- a/plugins/spell/pluma-spell-plugin.c
+++ b/plugins/spell/pluma-spell-plugin.c
@@ -117,7 +117,7 @@ static const GtkToggleActionEntry toggle_action_entries[] =
 	{ "AutoSpell",
 	  NULL,
 	  N_("_Autocheck Spelling"),
-	  NULL,
+	  "<control>F7",
 	  N_("Automatically spell-check the current document"),
 	  G_CALLBACK (auto_spell_cb),
 	  FALSE


### PR DESCRIPTION
Closes https://github.com/mate-desktop/pluma/issues/335