### PR TITLE
pluma-sort-plugin: avoid extra empty line

### DIFF
--- a/plugins/sort/pluma-sort-plugin.c
+++ b/plugins/sort/pluma-sort-plugin.c
@@ -434,10 +434,12 @@ sort_real (SortDialog *dialog)
 					&start,
 					lines[i],
 					-1);
-		gtk_text_buffer_insert (GTK_TEXT_BUFFER (doc),
-					&start,
-					"\n",
-					-1);
+
+		if (i < (num_lines - 1))
+			gtk_text_buffer_insert (GTK_TEXT_BUFFER (doc),
+						&start,
+						"\n",
+						-1);
 
 		last_row = lines[i];
 	}


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/pluma/issues/153