### PR TITLE
pluma-utils: Fix memory leak

### DIFF
--- a/pluma/pluma-utils.c
+++ b/pluma/pluma-utils.c
@@ -1669,6 +1669,7 @@ GtkWidget *
 pluma_image_menu_item_new_from_pixbuf (GdkPixbuf   *icon_pixbuf,
 				       const gchar *label_name)
 {
+	gchar *concat;
 	GtkWidget *icon;
 	GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 
@@ -1677,7 +1678,9 @@ pluma_image_menu_item_new_from_pixbuf (GdkPixbuf   *icon_pixbuf,
 	else
 		icon = gtk_image_new ();
 
-	GtkWidget *label_menu = gtk_label_new (g_strconcat (label_name, "     ", NULL));
+	concat = g_strconcat (label_name, "     ", NULL);
+
+	GtkWidget *label_menu = gtk_label_new (concat);
 	GtkWidget *menuitem = gtk_menu_item_new ();
 
 	gtk_container_add (GTK_CONTAINER (box), icon);
@@ -1685,6 +1688,8 @@ pluma_image_menu_item_new_from_pixbuf (GdkPixbuf   *icon_pixbuf,
 
 	gtk_container_add (GTK_CONTAINER (menuitem), box);
 	gtk_widget_show_all (menuitem);
+
+	g_free (concat);
 
 	return menuitem;
 }


### PR DESCRIPTION
'g_strconcat' needs to be freed

![filebrowserpluma](https://user-images.githubusercontent.com/7734191/39023439-ed526fe2-443a-11e8-9f49-c5cedd13ed2e.png)