### PR TITLE
Add python comment

### DIFF
--- a/plugins/snippets/data/python.xml
+++ b/plugins/snippets/data/python.xml
@@ -112,35 +112,11 @@ $0]]></text>
 
   <snippet id="Toggle comments">
     <text><![CDATA[$<
-import re
+    from comment import toggle_lines
 
-def get_lines():
-    selected = $PLUMA_SELECTED_TEXT
-    if selected:
-        return selected
-    else:
-        return $PLUMA_CURRENT_LINE
+    lines = $PLUMA_SELECTED_TEXT or $PLUMA_CURRENT_LINE
+    return toggle_lines(lines, comment="#", after_leading_space=True, comment_empty=False)
 
-def toggle(selected_txt):
-    lines = []
-    for line in selected_txt.split("\n"):
-        if not line:
-            lines.append(line)
-            continue
-        try:
-            spaces, content = re.findall(r'^\s+|.+', line)
-        except:
-            spaces = ""
-            content = line
-
-        if content.startswith("#"):
-            lines.append("{}{}".format(spaces, content[1:]))
-        else:
-            lines.append("{}#{}".format(spaces, content))
-
-    return "\n".join(lines)
-
-return toggle(get_lines())
 >]]></text>
     <description>Toggle comment</description>
     <accelerator><![CDATA[<Primary>m]]></accelerator>

--- a/plugins/snippets/data/python.xml
+++ b/plugins/snippets/data/python.xml
@@ -112,7 +112,7 @@ $0]]></text>
 
   <snippet id="Toggle comments">
     <text><![CDATA[$<
-    from comment import toggle_lines
+    from snippets import toggle_lines
 
     lines = $PLUMA_SELECTED_TEXT or $PLUMA_CURRENT_LINE
     return toggle_lines(lines, comment="#", after_leading_space=True, comment_empty=False)

--- a/plugins/snippets/data/python.xml
+++ b/plugins/snippets/data/python.xml
@@ -112,11 +112,9 @@ $0]]></text>
 
   <snippet id="Toggle comments">
     <text><![CDATA[$<
-    from snippets import toggle_lines
-
-    lines = $PLUMA_SELECTED_TEXT or $PLUMA_CURRENT_LINE
-    return toggle_lines(lines, comment="#", after_leading_space=True, comment_empty=False)
-
+from snippets import toggle_lines
+lines = $PLUMA_SELECTED_TEXT or $PLUMA_CURRENT_LINE
+return toggle_lines(lines, comment="#", after_leading_space=True, comment_empty=False)
 >]]></text>
     <description>Toggle comment</description>
     <accelerator><![CDATA[<Primary>m]]></accelerator>

--- a/plugins/snippets/data/python.xml
+++ b/plugins/snippets/data/python.xml
@@ -109,4 +109,41 @@ $0]]></text>
     <description>main</description>
     <tag>main</tag>
   </snippet>
+
+  <snippet id="Toggle comments">
+    <text><![CDATA[$<
+import re
+
+def get_lines():
+    selected = $PLUMA_SELECTED_TEXT
+    if selected:
+        return selected
+    else:
+        return $PLUMA_CURRENT_LINE
+
+def toggle(selected_txt):
+    lines = []
+    for line in selected_txt.split("\n"):
+        if not line:
+            lines.append(line)
+            continue
+        try:
+            spaces, content = re.findall(r'^\s+|.+', line)
+        except:
+            spaces = ""
+            content = line
+
+        if content.startswith("#"):
+            lines.append("{}{}".format(spaces, content[1:]))
+        else:
+            lines.append("{}#{}".format(spaces, content))
+
+    return "\n".join(lines)
+
+return toggle(get_lines())
+>]]></text>
+    <description>Toggle comment</description>
+    <accelerator><![CDATA[<Primary>m]]></accelerator>
+  </snippet>
+
 </snippets>

--- a/plugins/snippets/snippets/Makefile.am
+++ b/plugins/snippets/snippets/Makefile.am
@@ -15,7 +15,8 @@ plugin_PYTHON = \
 	Importer.py \
 	Exporter.py \
 	LanguageManager.py \
-	Completion.py
+	Completion.py \
+	comment.py
 
 uidir = $(PLUMA_PLUGINS_DATA_DIR)/snippets/ui
 ui_DATA = snippets.ui

--- a/plugins/snippets/snippets/__init__.py
+++ b/plugins/snippets/snippets/__init__.py
@@ -21,6 +21,7 @@ from gi.repository import GObject, GLib, Gtk, Peas, Pluma
 from .WindowHelper import WindowHelper
 from .Library import Library
 from .Manager import Manager
+from .comment import toggle_lines
 
 class SnippetsPlugin(GObject.Object, Peas.Activatable):
     __gtype_name__ = "SnippetsPlugin"

--- a/plugins/snippets/snippets/comment.py
+++ b/plugins/snippets/snippets/comment.py
@@ -1,0 +1,57 @@
+#    Pluma comment functions
+#    Copyright (C) 2019 Andrew Fowlie
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+
+def split_leading_space(txt):
+    """
+    @returns Text split into leading spaces and content
+    """
+    index = len(txt.lstrip())
+    spaces = txt[:-index]
+    content = txt[-index:]
+    return spaces, content
+
+def toggle_line(line, comment="#", after_leading_space=True, comment_empty=False):
+    """
+    @param line Line of text to toggle comments
+    @param comment String used for inline comments
+    @param after_leading_space Whether to comment after any leading white space
+    @param comment_empty Whether to comment empty lines
+
+    @returns Text with comments toggled
+    """
+    if not comment_empty and not line.strip():
+        return line
+
+    spaces, content = split_leading_space(line)
+
+    if content.startswith(comment):
+        return "{}{}".format(spaces, content[len(comment):])
+    elif after_leading_space:
+        return "{}{}{}".format(spaces, comment, content)
+    else:
+        return "{}{}{}".format(comment, spaces, content)
+
+def toggle_lines(lines, **kwargs):
+    """
+    @param lines Multiple lines of text
+    @type lines str
+    @returns Text with comments toggled
+    """
+    lines = [toggle_line(line, **kwargs) for line in lines.split("\n")]
+    return "\n".join(lines)


### PR DESCRIPTION
This adds a snippet to comment/uncomment Python code with `Ctrl+m`.
* If no text selected, toggles comments for current line
* Preserves leading space in front of comment/text that is uncommented
* Depends on re (`import re`)

I think this is a very useful enhancement. It could be quickly generalized to other languges just by changing `#` to `//` or whatever, but I'm not sure about how to best achieve that without lots of duplication.



