### PR TITLE
addresses #391 - gets snippet window size before destroying it

### DIFF
--- a/plugins/snippets/snippets/Manager.py
+++ b/plugins/snippets/snippets/Manager.py
@@ -599,16 +599,17 @@ class Manager:
                 if self.snippets_doc:
                         self.snippets_doc.stop()
                 
-                alloc = dlg.get_allocation()
-                self.default_size = [alloc.width, alloc.height]
                 self.manager = None
-
                 self.unref_languages()        
                 self.snippet = None        
                 self.model = None
                 self.dlg = None                
         
-        def on_dialog_snippets_response(self, dlg, resp):                                
+        def on_dialog_snippets_response(self, dlg, resp):
+
+                alloc = dlg.get_allocation()
+                self.default_size = [alloc.width, alloc.height]
+
                 if resp == Gtk.ResponseType.HELP:
                         Pluma.help_display(self, 'pluma', 'pluma-snippets-plugin')
                         return


### PR DESCRIPTION
addresses #391.

You see I moved the code to get the window size to before the point where it's destroyed destroyed.

I could have done it the other way - move the destroyed bit to after the window size operations. But moving where something is destroyed seemed more dangerous than just moving something about the default window size, especially as I don't know the structure of the code.