### PR TITLE
remove type & url attr of ulink in translation

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -16,8 +16,12 @@
 -->
 <!-- =============Document Header ============================= -->
 <?db.chunk.max_depth 2?>
-<article id="index" lang="en">
+<article id="index" lang="en" xmlns:its="http://www.w3.org/2005/11/its" its:version="2.0">
 <!-- please do not change the id; for translations, change lang to -->
+         <its:rules version="2.0">
+           <its:translateRule translate="no" selector="//ulink/@type|//ulink/@url"/>
+           <its:withinTextRule withinText="no" selector="//ulink"/>
+         </its:rules>
 <!-- appropriate code -->
   <articleinfo>
 	 <title>Pluma Manual<!-- not using app entity because of lowercase ugliness --></title>


### PR DESCRIPTION
Example of generated file:

**help/pluma.pot before:**

msgid "To report a bug or make a suggestion regarding the &lt;application&gt;pluma&lt;/application&gt; application or this manual, follow the directions in the &lt;ulink url=\"help:mate-user-guide/feedback\" type=\"help\"&gt;MATE Feedback Page&lt;/ulink&gt;."
msgstr ""

**help/pluma.pot after:**

msgid "MATE Feedback Page"
msgstr ""

msgid "To report a bug or make a suggestion regarding the <application>pluma</application> application or this manual, follow the directions in the <_:ulink-1/>."
msgstr ""