### PR TITLE
Upgrade the manual to docbook 5.0

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="http://docbook.org/xml/5.0/rng/dbits.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <!--
       (Do not remove this comment block.)
   Maintained by the MATE Documentation Project
@@ -18,21 +19,21 @@
     <info>
         <title>Pluma Manual</title>
 
-        <copyright>
+        <copyright its:translate="no">
             <year>2015</year>
             <holder>MATE Documentation Project</holder> 
         </copyright>
-        <copyright>
+        <copyright its:translate="no">
             <year>2007</year>
             <holder>GNOME Documentation Project</holder> 
         </copyright>
-        <copyright>
+        <copyright its:translate="no">
             <year>2002</year>
             <year>2003</year>
             <year>2004</year>
             <holder>Sun Microsystems</holder> 
         </copyright>
-        <copyright>
+        <copyright its:translate="no">
             <year>2000</year>
             <holder>Eric Baudais</holder> 
         </copyright>
@@ -46,11 +47,11 @@
 
         <xi:include href="legal.xml"/>
 
-        <authorgroup>
+        <authorgroup its:translate="no">
             <author>
-                <orgname>MATE Documentation Project</orgname>
+                <orgname its:translate="yes">MATE Documentation Project</orgname>
                 <affiliation>
-                    <orgname>MATE Desktop</orgname>
+                    <orgname its:translate="yes">MATE Desktop</orgname>
                 </affiliation>
             </author>
             <author>
@@ -60,9 +61,9 @@
                 </personname>
             </author>
             <author>
-                <orgname>GNOME Documentation Project</orgname>
+                <orgname its:translate="yes">GNOME Documentation Project</orgname>
                 <affiliation>
-                    <orgname>GNOME</orgname>
+                    <orgname its:translate="yes">GNOME</orgname>
                 </affiliation>
             </author>
             <author>
@@ -70,12 +71,12 @@
                     <firstname>Hal</firstname>
                     <surname>Canary</surname>
                 </personname>
-                <contrib>Added the Shortcut Keys Table</contrib>
+                <contrib its:translate="yes">Added the Shortcut Keys Table</contrib>
             </author>
             <author>
-                <orgname>Sun Java Desktop System Documentation Team</orgname>
+                <orgname its:translate="yes">Sun Java Desktop System Documentation Team</orgname>
                 <affiliation>
-                    <orgname>Sun Microsystems</orgname>
+                    <orgname its:translate="yes">Sun Microsystems</orgname>
                 </affiliation>
                 <email>gdocteam@sun.com</email>
             </author>
@@ -85,7 +86,7 @@
                     <surname>Baudais</surname>
                 </personname>
                 <affiliation>
-                    <orgname>GNOME Documentation Project</orgname>
+                    <orgname its:translate="yes">GNOME Documentation Project</orgname>
                 </affiliation>
                 <email>baudais@okstate.edu</email> 
             </author>
@@ -94,116 +95,116 @@
                     <firstname>Baris</firstname>
                     <surname>Cicek</surname>
                 </personname>
-                <contrib>Provided information from earlier revisions of the pluma application.</contrib>
+                <contrib its:translate="yes">Provided information from earlier revisions of the pluma application.</contrib>
             </othercredit>
             <othercredit role="other">
                 <personname>
                     <firstname>George</firstname>
                     <surname>Ajit</surname>
                 </personname>
-                <contrib>Provided information about plugins.</contrib>
+                <contrib its:translate="yes">Provided information about plugins.</contrib>
             </othercredit>
         </authorgroup>
 
         <!-- According to GNU FDL, revision history is mandatory if you are
              modifying/reusing someone else's document.  If not, you can omit it. -->
-        <revhistory>
+        <revhistory its:translate="no">
             <!-- Remember to remove the &manrevision; entity from the revision
                  entries other than the current revision. -->
             <revision>
                 <revnumber>1.0</revnumber>
                 <date>2000</date>
                 <revdescription>
-                    <para role="author">Eric Baudais <email>baudais@okstate.edu</email></para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="no">Eric Baudais <email>baudais@okstate.edu</email></para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.0</revnumber>
-                <date>March 2002</date>
+                <date its:translate="yes">March 2002</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.1</revnumber>
-                <date>June 2002</date>
+                <date its:translate="yes">June 2002</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.2</revnumber>
-                <date>August 2002</date>
+                <date its:translate="yes">August 2002</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.3</revnumber>
-                <date>September 2002</date>
+                <date its:translate="yes">September 2002</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.4</revnumber>
-                <date>January 2003</date>
+                <date its:translate="yes">January 2003</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.5</revnumber>
-                <date>March 2003</date>
+                <date its:translate="yes">March 2003</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.6</revnumber>
-                <date>September 2003</date>
+                <date its:translate="yes">September 2003</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.7</revnumber>
-                <date>March 2004</date>
+                <date its:translate="yes">March 2004</date>
                 <revdescription>
-                    <para role="author">Sun GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.8</revnumber>
-                <date>July 2015</date>
+                <date its:translate="yes">July 2015</date>
                 <revdescription>
-                    <para role="author">Sun Java Desktop System Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">Sun Java Desktop System Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>2.9</revnumber>
-                <date>July 2006</date>
+                <date its:translate="yes">July 2006</date>
                 <revdescription>
-                    <para role="author">GNOME Documentation Team</para>
-                    <para role="publisher">GNOME Documentation Project</para>
+                    <para role="author" its:translate="yes">GNOME Documentation Team</para>
+                    <para role="publisher" its:translate="yes">GNOME Documentation Project</para>
                 </revdescription>
             </revision>
             <revision>
                 <revnumber>3.0</revnumber>
-                <date>July 2015</date>
+                <date its:translate="yes">July 2015</date>
                 <revdescription>
-                    <para role="author">MATE Documentation Team</para>
-                    <para role="publisher">MATE Documentation Project</para>
+                    <para role="author" its:translate="yes">MATE Documentation Team</para>
+                    <para role="publisher" its:translate="yes">MATE Documentation Project</para>
                 </revdescription>
             </revision>
         </revhistory>
@@ -267,9 +268,9 @@
             </info>
             <para>When you start <application>pluma</application>, the following window is displayed:</para>
 
-            <figure xml:id="pluma-window">
+            <figure xml:id="pluma-window" its:translate="no">
                 <info>
-                    <title>pluma Window</title>
+                    <title its:translate="yes">pluma Window</title>
                 </info>
                 <screenshot>
                     <mediaobject>
@@ -277,7 +278,7 @@
                             <imagedata fileref="figures/pluma_window.png" format="PNG"/>
                         </imageobject>
                         <textobject> 
-                            <phrase>Shows pluma main window.</phrase>
+                            <phrase its:translate="yes">Shows pluma main window.</phrase>
                         </textobject>
                     </mediaobject>
                 </screenshot>
@@ -370,12 +371,12 @@
                 <title>Opening a File</title>
             </info>
             <para>To open a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Open</guimenuitem> </menuchoice> to display the <guilabel>Open File</guilabel> dialog. Select the file that you want to open, then click <guibutton>Open</guibutton>. The file is displayed in the <application>pluma</application> window.</para>
-            <para>The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice> <guimenu>File</guimenu> </menuchoice> menu. You can also click on the <inlinemediaobject>
+            <para>The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice> <guimenu>File</guimenu> </menuchoice> menu. You can also click on the <inlinemediaobject its:translate="no">
                     <imageobject>
                         <imagedata fileref="figures/pluma_recent_files_menu_icon.png" format="PNG"/>
                     </imageobject>
                     <textobject>
-                        <phrase>Shows Recent Files menu icon.</phrase>
+                        <phrase its:translate="yes">Shows Recent Files menu icon.</phrase>
                     </textobject>
                 </inlinemediaobject> icon on the toolbar to display the list of recent files.</para>
             <note>

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1,1988 +1,2548 @@
-<?xml version="1.0"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY appversion "1.10">
-  <!ENTITY manrevision "3.0">
-  <!ENTITY date "July 2015">
-  <!ENTITY app "pluma">
-]>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
       (Do not remove this comment block.)
   Maintained by the MATE Documentation Project
   http://wiki.mate-desktop.org/dev-doc:doc-team-guide
   Template version: 2.0 beta
   Template last modified Jan 30, 2002
-
 -->
-<!-- =============Document Header ============================= -->
 <?db.chunk.max_depth 2?>
-<article id="index" lang="en" xmlns:its="http://www.w3.org/2005/11/its" its:version="2.0">
-<!-- please do not change the id; for translations, change lang to -->
-         <its:rules version="2.0">
-           <its:translateRule translate="no" selector="//ulink/@type|//ulink/@url"/>
-           <its:withinTextRule withinText="no" selector="//ulink"/>
-         </its:rules>
-<!-- appropriate code -->
-  <articleinfo>
-	 <title>Pluma Manual<!-- not using app entity because of lowercase ugliness --></title>
-	 <copyright>
-		<year>2015</year>
-		<holder>MATE Documentation Project</holder> </copyright>
-	 <copyright>
-		<year>2007</year>
-		<holder>GNOME Documentation Project</holder> </copyright>
-	 <copyright>
-		<year>2002</year>
-		<year>2003</year>
-		<year>2004</year>
-		<holder>Sun Microsystems</holder> </copyright>
-	 <copyright>
-		<year>2000</year>
-		<holder>Eric Baudais</holder> </copyright>
+<article xmlns="http://docbook.org/ns/docbook"
+         xmlns:db="http://docbook.org/ns/docbook"
+         xmlns:its="http://www.w3.org/2005/11/its"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0" xml:id="index" xml:lang="en">
+    <!-- please do not change the id; for translations, change lang to -->
+    <!-- appropriate code -->
+    <info>
+        <title>Pluma Manual</title>
 
-<!-- translators: uncomment this:
+        <copyright>
+            <year>2015</year>
+            <holder>MATE Documentation Project</holder> 
+        </copyright>
+        <copyright>
+            <year>2007</year>
+            <holder>GNOME Documentation Project</holder> 
+        </copyright>
+        <copyright>
+            <year>2002</year>
+            <year>2003</year>
+            <year>2004</year>
+            <holder>Sun Microsystems</holder> 
+        </copyright>
+        <copyright>
+            <year>2000</year>
+            <holder>Eric Baudais</holder> 
+        </copyright>
 
-  <copyright>
-   <year>2003</year>
-   <holder>ME-THE-TRANSLATOR (Latin translation)</holder>
-  </copyright>
+        <publisher>
+            <publishername>MATE Documentation Project</publishername>
+        </publisher>
+        <publisher>
+            <publishername>GNOME Documentation Project</publishername>
+        </publisher>
 
-   -->
-	 <publisher role="maintainer">
-		<publishername>MATE Documentation Project</publishername>
-	 </publisher>
-	 <publisher>
-		<publishername>GNOME Documentation Project</publishername>
-	 </publisher>
+        <xi:include href="legal.xml"/>
 
-	 <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+        <authorgroup>
+            <author>
+                <orgname>MATE Documentation Project</orgname>
+                <affiliation>
+                    <orgname>MATE Desktop</orgname>
+                </affiliation>
+            </author>
+            <author>
+                <personname>
+                    <firstname>Joachim</firstname>
+                    <surname>Noreiko</surname>
+                </personname>
+            </author>
+            <author>
+                <orgname>GNOME Documentation Project</orgname>
+                <affiliation>
+                    <orgname>GNOME</orgname>
+                </affiliation>
+            </author>
+            <author>
+                <personname>
+                    <firstname>Hal</firstname>
+                    <surname>Canary</surname>
+                </personname>
+                <contrib>Added the Shortcut Keys Table</contrib>
+            </author>
+            <author>
+                <orgname>Sun Java Desktop System Documentation Team</orgname>
+                <affiliation>
+                    <orgname>Sun Microsystems</orgname>
+                </affiliation>
+                <email>gdocteam@sun.com</email>
+            </author>
+            <author>
+                <personname>
+                    <firstname>Eric</firstname>
+                    <surname>Baudais</surname>
+                </personname>
+                <affiliation>
+                    <orgname>GNOME Documentation Project</orgname>
+                </affiliation>
+                <email>baudais@okstate.edu</email> 
+            </author>
+            <othercredit role="other">
+                <personname>
+                    <firstname>Baris</firstname>
+                    <surname>Cicek</surname>
+                </personname>
+                <contrib>Provided information from earlier revisions of the pluma application.</contrib>
+            </othercredit>
+            <othercredit role="other">
+                <personname>
+                    <firstname>George</firstname>
+                    <surname>Ajit</surname>
+                </personname>
+                <contrib>Provided information about plugins.</contrib>
+            </othercredit>
+        </authorgroup>
 
-	 <authorgroup>
-		<author>
-		  <firstname>MATE Documentation Project</firstname>
-		  <surname></surname>
-		  <affiliation>
-			 <orgname>MATE Desktop</orgname>
-		  </affiliation>
-		</author>
-           <author>
-             <firstname>Joachim</firstname>
-             <surname>Noreiko</surname>
-           </author>
-		<author>
-		  <firstname>GNOME Documentation Project</firstname>
-		  <surname></surname>
-		  <affiliation>
-			 <orgname>GNOME</orgname>
-		  </affiliation>
-		</author>
-		<author>
-			<firstname>Hal</firstname>
-			<surname>Canary</surname>
-			<contrib>Added the Shortcut Keys Table</contrib>
-		</author>
-		<author>
-		  <firstname>Sun Java Desktop System Documentation Team</firstname>
-		  <surname></surname>
-		  <affiliation>
-			 <orgname>Sun Microsystems</orgname>
-			 <address><email>gdocteam@sun.com</email></address>
-		  </affiliation>
-		</author>
-		<author>
-		  <firstname>Eric</firstname>
-		  <surname>Baudais</surname>
-		  <affiliation>
-			 <orgname>GNOME Documentation Project</orgname>
-			 <address> <email>baudais@okstate.edu</email> </address>
-		  </affiliation>
-		</author>
-		<othercredit role="reviewer">
-			<firstname>Baris</firstname>
-			<surname>Cicek provided information from earlier revisions of the pluma application.</surname>
-			<contrib>Acknowledgments</contrib>
-    </othercredit>
-		<othercredit role="reviewer">
-			<firstname>Ajit</firstname>
-			<surname>George provided information about plugins.</surname>
-			<contrib>Acknowledgments</contrib>
-    </othercredit>
+        <!-- According to GNU FDL, revision history is mandatory if you are
+             modifying/reusing someone else's document.  If not, you can omit it. -->
+        <revhistory>
+            <!-- Remember to remove the &manrevision; entity from the revision
+                 entries other than the current revision. -->
+            <revision>
+                <revnumber>1.0</revnumber>
+                <date>2000</date>
+                <revdescription>
+                    <para role="author">Eric Baudais <email>baudais@okstate.edu</email></para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.0</revnumber>
+                <date>March 2002</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.1</revnumber>
+                <date>June 2002</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.2</revnumber>
+                <date>August 2002</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.3</revnumber>
+                <date>September 2002</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.4</revnumber>
+                <date>January 2003</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.5</revnumber>
+                <date>March 2003</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.6</revnumber>
+                <date>September 2003</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.7</revnumber>
+                <date>March 2004</date>
+                <revdescription>
+                    <para role="author">Sun GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.8</revnumber>
+                <date>July 2015</date>
+                <revdescription>
+                    <para role="author">Sun Java Desktop System Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>2.9</revnumber>
+                <date>July 2006</date>
+                <revdescription>
+                    <para role="author">GNOME Documentation Team</para>
+                    <para role="publisher">GNOME Documentation Project</para>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>3.0</revnumber>
+                <date>July 2015</date>
+                <revdescription>
+                    <para role="author">MATE Documentation Team</para>
+                    <para role="publisher">MATE Documentation Project</para>
+                </revdescription>
+            </revision>
+        </revhistory>
 
+        <releaseinfo>This manual describes version 1.10 of pluma.</releaseinfo>
 
-<!-- This is appropriate place for other contributors: translators,
-      maintainers,  etc. Commented out by default.
-       <othercredit role="translator">
-	<firstname>Latin</firstname>
-	<surname>Translator 1</surname>
-	<affiliation>
-	  <orgname>Latin Translation Team</orgname>
-	  <address> <email>translator@gnome.org</email> </address>
-	</affiliation>
-	<contrib>Latin translation</contrib>
-      </othercredit>
--->
-	 </authorgroup>
+    </info>
 
-<!-- According to GNU FDL, revision history is mandatory if you are -->
-<!-- modifying/reusing someone else's document.  If not, you can omit it. -->
-	 <revhistory>
-<!-- Remember to remove the &manrevision; entity from the revision entries other
-   than the current revision. -->
-		<revision>
-		  <revnumber>pluma V1.0</revnumber>
-		  <date>2000</date>
-		  <revdescription>
-			 <para role="author">Eric Baudais <email>baudais@okstate.edu</email>
-				</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.0</revnumber>
-		  <date>March 2002</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.1</revnumber>
-		  <date>June 2002</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.2</revnumber>
-		  <date>August 2002</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.3</revnumber>
-		  <date>September 2002</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.4</revnumber>
-		  <date>January 2003</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.5</revnumber>
-		  <date>March 2003</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.6</revnumber>
-		  <date>September 2003</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>pluma Manual V2.7</revnumber>
-		  <date>March 2004</date>
-		  <revdescription>
-			 <para role="author">Sun GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-   	<revision>
-		  <revnumber>&app; Manual V2.8</revnumber>
-		  <date>&date;</date>
-		  <revdescription>
-			 <para role="author">Sun Java Desktop System Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-		<revision>
-		  <revnumber>&app; Manual V2.9;</revnumber>
-		  <date>July 2006;</date>
-		  <revdescription>
-			 <para role="author">GNOME Documentation Team</para>
-			 <para role="publisher">GNOME Documentation Project</para>
-		  </revdescription>
-		</revision>
-   		<revision>
-		  <revnumber>&app; Manual V&manrevision;</revnumber>
-		  <date>&date;</date>
-		  <revdescription>
-			 <para role="author">MATE Documentation Team</para>
-			 <para role="publisher">MATE Documentation Project</para>
-		  </revdescription>
-		</revision>
-	 </revhistory>
-	 <releaseinfo> This manual describes version &appversion; of &app;.
-		</releaseinfo>
-	 <legalnotice>
-		<title>Feedback</title>
-		<para>To report a bug or make a suggestion regarding the <application>&app;</application> application or this manual, follow the directions in the <ulink url="help:mate-user-guide/feedback" type="help">MATE Feedback Page</ulink>.
-      </para>
-<!-- Translators may also add here feedback address for translations -->
-	 </legalnotice>
-    <abstract role="description">
-      <para>&app; is a text editor for the MATE Desktop featuring basic yet
-      robust capabilities such as printing, spell checking, find and replace,
-      and syntax highlighting. More advanced features are available as plugins.</para>
-    </abstract>
-  </articleinfo>
-  <indexterm><primary>pluma</primary></indexterm>
-  <indexterm><primary>text editor</primary></indexterm>
+    <indexterm>
+        <primary>pluma</primary>
+    </indexterm>
+    <indexterm>
+        <primary>text editor</primary>
+    </indexterm>
 
-<!-- ============= Document Body ============================= -->
-<!-- ============= Introduction ============================== -->
-  <sect1 id="pluma-intro">
-	 <title>Introduction</title>
+    <!-- ============= Document Body ========================================= -->
+    <!-- ============= Introduction ========================================== -->
+    <section xml:id="pluma-intro">
+        <info>
+            <title>Introduction</title>
+        </info>
+        <!-- removed ids, here as anchors to prevent possible breakage -->
+        <anchor xml:id="pluma-customize-toolbar"/>
+        <para>The <application>pluma</application> application enables you to create and edit text files.</para>
+        <para>The aim of <application>pluma</application> is to be a simple and easy to use text editor. More powerful features can be enabled with different <firstterm>plugins</firstterm>, allowing a variety of tasks related to text-editing.</para>
+    </section>
 
-   <!-- removed ids, here as anchors to prevent possible breakage -->
-	 <anchor id="pluma-customize-toolbar"/>
+    <!-- ============= Getting Started ======================================= -->
+    <section xml:id="pluma-getting-started">
+        <info>
+            <title>Getting Started</title>
+        </info>
 
-	 <para>The <application>&app;</application> application enables you to create and edit text files.</para>
+        <!-- ============= To Start pluma ==================================== -->
+        <section xml:id="pluma-to-start">
+            <info>
+                <title>Starting pluma</title>
+            </info>
+            <para>You can start <application>pluma</application> in the following ways:</para>
+            <variablelist>
+                <varlistentry>
+                    <term>
+                        <guimenu>Applications</guimenu> menu</term>
+                    <listitem>
+                        <para>Choose <menuchoice> <guisubmenu>Accessories</guisubmenu> <guimenuitem>Text Editor</guimenuitem> </menuchoice>.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>Command line</term>
+                    <listitem>
+                        <para>Execute the following command: <command>pluma</command></para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+            <para>By default, when you open a text document in the file manager, pluma will start, and display the document.</para>
+        </section>
 
-	 <para>The aim of <application>&app;</application> is to be a simple and easy to use text editor. More powerful features can be enabled with different <firstterm>plugins</firstterm>, allowing a variety of tasks related to text-editing.</para>
-  </sect1>
-<!-- ============= Getting Started =========================== -->
-  <sect1 id="pluma-getting-started">
-	 <title>Getting Started</title>
+        <section xml:id="pluma-when-you-start">
+            <info>
+                <title>The pluma Window</title>
+            </info>
+            <para>When you start <application>pluma</application>, the following window is displayed:</para>
 
-<!-- ============= To Start pluma ============================ -->
-	 <sect2 id="pluma-to-start">
-		<title>Starting &app;</title>
-		<para>You can start <application>&app;</application> in the following ways:</para>
-		<variablelist>
-    		<varlistentry>
-    		<term><guimenu>Applications</guimenu> menu</term>
-    		<listitem>
-    		<para>Choose <menuchoice><guisubmenu>Accessories</guisubmenu><guimenuitem>Text Editor</guimenuitem></menuchoice>. </para>
-    		</listitem>
-    		</varlistentry>
-    		<varlistentry>
-    		<term>Command line</term>
-    		<listitem>
-    		<para>Execute the following command: <command>pluma</command></para>
-    		</listitem>
-    		</varlistentry>
-    		</variablelist>
-    <para>By default, when you open a text document in the file manager, pluma will start, and display the document.</para>
-	</sect2>
+            <figure xml:id="pluma-window">
+                <info>
+                    <title>pluma Window</title>
+                </info>
+                <screenshot>
+                    <mediaobject>
+                        <imageobject>
+                            <imagedata fileref="figures/pluma_window.png" format="PNG"/>
+                        </imageobject>
+                        <textobject> 
+                            <phrase>Shows pluma main window.</phrase>
+                        </textobject>
+                    </mediaobject>
+                </screenshot>
+            </figure>
 
-	<sect2 id="pluma-when-you-start">
+            <para>The <application>pluma</application> window contains the following elements:</para>
+            <variablelist>
+                <varlistentry> 
+                    <term>Menubar</term>
+                    <listitem>
+                        <para>The menus on the menubar contain all the commands you need to work with files in <application>pluma</application>.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry> 
+                    <term>Toolbar</term>
+                    <listitem>
+                        <para>The toolbar contains a subset of the commands that you can access from the menubar.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry> 
+                    <term>Display area</term>
+                    <listitem>
+                        <para>The display area contains the text of the file that you are editing.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry> 
+                    <term>Statusbar</term>
+                    <listitem>
+                        <para>The statusbar displays information about current <application>pluma</application> activity and contextual information about the menu items. The statusbar also displays the following information:</para>
+                        <itemizedlist>
+                            <listitem>
+                                <para>Cursor position: the line number and column number where the cursor is located.</para>
+                            </listitem>
+                            <listitem>
+                                <para>Edit mode: If the editor is in insert mode, the statusbar contains the text <guilabel>INS</guilabel>. If the editor is in overwrite mode, the statusbar contains the text <guilabel>OVR</guilabel>. Press the <keycap>Insert</keycap> key to change edit mode.</para>
+                            </listitem>
+                        </itemizedlist>
+                    </listitem>
+                </varlistentry>
+                <varlistentry> 
+                    <term>Side Pane</term>
+                    <listitem>
+                        <para>The side pane displays a list of open documents, and other information depending on which plugins are enabled.</para>
+                        <para>By default, the side pane is not shown. To show it, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice>.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry> 
+                    <term>Bottom Pane</term>
+                    <listitem>
+                        <para>The bottom pane is used by programming tools such as the <application>Python Console</application> plugin to display output.</para>
+                        <para>By default, the bottom pane is not shown. To show it, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Bottom Pane</guimenuitem> </menuchoice>.</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+            <para>When you right-click in the <application>pluma</application> window, the application displays a popup menu. The popup menu contains the most common text editing commands.</para>
+            <para>Like other MATE applications, actions in <application>pluma</application> can be performed in several ways: with the menu, with the toolbar, or with shortcut keys. Shortcuts keys common to all applications are listed in the <link xlink:href="help:mate-user-guide/shortcuts-apps">User Guide</link>.</para>
+        </section>
 
-		<title>The &app; Window</title>
-		<para>When you start <application>&app;</application>, the following window is displayed:</para>
+        <!-- ============= To Open Multiple Files from the Command Line ====== -->
+        <section xml:id="pluma-run-from-cmd-line">
+            <info>
+                <title>Running pluma from a Command Line</title>
+            </info>
+            <para>You can run <application>pluma</application> from a command line and open a single file or multiple files. To open multiple files from a command line, type the following command, then press <keycap>Return</keycap>:</para>
+            <para>
+                <command>pluma <replaceable>file1.txt file2.txt file3.txt</replaceable></command>
+            </para>
+            <para>Alternatively, you can specify a URI instead of a filename.</para>
+            <para>Refer to the <link xlink:href="man:pluma"> <citerefentry> <refentrytitle>pluma</refentrytitle> <manvolnum>1</manvolnum> </citerefentry> </link> man page for more information on how to run <application>pluma</application> from a command line.</para>
+        </section>
+    </section>
 
-		<figure id="pluma-window">
-		  <title>&app; Window</title>
-		  <screenshot>
-			 <mediaobject>
-				<imageobject>
-				  <imagedata fileref="figures/pluma_window.png" format="PNG"/>
-					 </imageobject>
-				<textobject> <phrase>Shows pluma main window.</phrase>
-				</textobject>
-			</mediaobject>
-		  </screenshot>
-		</figure>
+    <!-- ================ Usage ============================================== -->
+    <section xml:id="pluma-usage">
+        <info>
+            <title>Working with Files</title>
+        </info>
 
-		<para>The <application>&app;</application> window contains the following
-		  elements: </para>
-		<variablelist>
-		  <varlistentry> <term>Menubar</term>
-			 <listitem>
-				<para>The menus on the menubar contain all the commands you need to work with files in <application>&app;</application>.</para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term>Toolbar</term>
-			 <listitem>
-				<para> The toolbar contains a subset of the commands that you can access from the menubar.</para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term>Display area</term>
-			 <listitem>
-				<para> The display area contains the text of the file that you are editing. </para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term>Statusbar</term>
-			 <listitem>
-				<para>The statusbar displays information about current <application>&app;</application> activity and contextual information about the menu items. The statusbar also displays the following information:</para>
-		  <itemizedlist>
-		  <listitem>
-		  <para>Cursor position: the line number and column number where the cursor is located.</para>
-		  </listitem>
-		  <listitem>
-		  <para>Edit mode: If the editor is in insert mode, the statusbar contains the text <guilabel>INS</guilabel>. If the editor is in overwrite mode, the statusbar contains the text <guilabel>OVR</guilabel>. Press the <keycap>Insert</keycap> key to change edit mode.</para>
-		  </listitem>
-		  </itemizedlist>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term>Side Pane</term>
-			 <listitem>
-				<para>The side pane displays a list of open documents, and other information depending on which plugins are enabled.</para>
-				<para>By default, the side pane is not shown. To show it, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice>.</para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term>Bottom Pane</term>
-			 <listitem>
-				<para>The bottom pane is used by programming tools such as the <application>Python Console</application> plugin to display output.</para>
-				<para>By default, the bottom pane is not shown. To show it, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Bottom Pane</guimenuitem></menuchoice>.</para>
-			 </listitem>
-		  </varlistentry>
-		</variablelist>
-		<para>When you right-click in the <application>&app;</application> window, the application displays a popup menu. The popup menu contains the most common text editing commands. </para>
+        <!-- ============= To Create a New File ============================== -->
+        <section xml:id="pluma-create-new-file">
+            <info>
+                <title>Creating a New Document</title>
+            </info>
+            <para>To create a new document, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>New</guimenuitem> </menuchoice>. The application displays a new blank document in the <application>pluma</application> window.</para>
+        </section>
 
-		<para>Like other MATE applications, actions in <application>&app;</application> can be performed in several ways: with the menu, with the toolbar, or with shortcut keys. Shortcuts keys common to all applications are listed in the <ulink type="help" url="help:mate-user-guide/shortcuts-apps">User Guide</ulink>.</para>
-	 </sect2>
+        <!-- ============= To Open a File ==================================== -->
+        <section xml:id="pluma-open-file">
+            <info>
+                <title>Opening a File</title>
+            </info>
+            <para>To open a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Open</guimenuitem> </menuchoice> to display the <guilabel>Open File</guilabel> dialog. Select the file that you want to open, then click <guibutton>Open</guibutton>. The file is displayed in the <application>pluma</application> window.</para>
+            <para>The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice> <guimenu>File</guimenu> </menuchoice> menu. You can also click on the <inlinemediaobject>
+                    <imageobject>
+                        <imagedata fileref="figures/pluma_recent_files_menu_icon.png" format="PNG"/>
+                    </imageobject>
+                    <textobject>
+                        <phrase>Shows Recent Files menu icon.</phrase>
+                    </textobject>
+                </inlinemediaobject> icon on the toolbar to display the list of recent files.</para>
+            <note>
+                <para>You can open multiple files in <application>pluma</application>. The application adds a tab for each open file to the window. For more on this see <xref linkend="pluma-tabs"/>.</para>
+            </note>
+        </section>
 
-<!-- ============= To Open Multiple Files from the Command Line ========= -->
-	 <sect2 id="pluma-run-from-cmd-line">
-		<title>Running &app; from a Command Line</title>
-		<para>You can run <application>&app;</application> from a command line and open a single file or multiple files. To open multiple files from a command line, type the following command, then press <keycap>Return</keycap>:</para>
-		<para><command>pluma <replaceable>file1.txt file2.txt file3.txt</replaceable></command></para>
-		<para>Alternatively, you can specify a URI instead of a filename.</para>
-    <para>Refer to the <ulink url="man:pluma" type="man"><citerefentry><refentrytitle>&app;</refentrytitle><manvolnum>1</manvolnum></citerefentry></ulink> man page for more information on how to run <application>&app;</application> from a command line.</para>
-	 </sect2>
-  </sect1>
-<!-- ================ Usage ================================ -->
-  <sect1 id="pluma-usage">
-	 <title>Working with Files</title>
+        <!-- ============= To Save a File ==================================== -->
+        <section xml:id="pluma-save-file">
+            <info>
+                <title>Saving a File</title>
+            </info>
+            <para>You can save files in the following ways:</para>
+            <itemizedlist>
+                <listitem>
+                    <para>To save changes to an existing file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Save</guimenuitem> </menuchoice>.</para>
+                </listitem>
+                <listitem>
+                    <para>To save a new file or to save an existing file under a new filename, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Save As</guimenuitem> </menuchoice>. Enter a name for the file in the <guilabel>Save As</guilabel> dialog, then click <guibutton>Save</guibutton>.</para>
+                </listitem>
+                <listitem>
+                    <para>To save all the files that are currently open in <application>pluma</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Save All</guimenuitem> </menuchoice>.</para>
+                </listitem>
+            </itemizedlist>
+            <para>To close all the files that are currently open in <application>pluma</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Close All</guimenuitem> </menuchoice>.</para>
+        </section>
 
-<!-- ============= To Create a New File ======================== -->
-	 <sect2 id="pluma-create-new-file">
-		<title>Creating a New Document</title>
-		<para>To create a new document, choose <menuchoice><guimenu>File</guimenu><guimenuitem>New</guimenuitem></menuchoice>. The application displays a new blank document in the <application>&app;</application> window.</para>
-	 </sect2>
+        <!-- ============= Working with tabs ================================= -->
+        <section xml:id="pluma-tabs">
+            <info>
+                <title>Working With Tabs</title>
+            </info>
+            <para>When more than one file is open, <application>pluma</application> shows a <firstterm>tab</firstterm> for each document above the display area. To switch to another document, click on its tab.</para>
+            <para>To move a document to another <application> pluma</application> window, drag the tab corresponding to the file to the window you want to move it to.</para>
+            <para>To move a document to a new <application> pluma</application> window, either drag its tab to the desktop, or choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Move to New Window</guimenuitem> </menuchoice>.</para>
+        </section>
 
-<!-- ============= To Open a File ============================= -->
-	 <sect2 id="pluma-open-file">
-		<title>Opening a File</title>
-		<para>To open a file, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Open</guimenuitem></menuchoice> to display the <guilabel>Open File</guilabel> dialog. Select the file that you want to open, then click <guibutton>Open</guibutton>. The file is displayed in the <application>&app;</application> window. </para>
+    </section>
 
-		<para>The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice><guimenu>File</guimenu></menuchoice> menu. You can also click on the <inlinemediaobject><imageobject><imagedata fileref="figures/pluma_recent_files_menu_icon.png" format="PNG"/></imageobject><textobject><phrase>Shows Recent Files menu icon.</phrase></textobject></inlinemediaobject>  icon on the toolbar to display the list of recent files.  </para>
+    <section xml:id="working-with-text">
+        <info>
+            <title>Working with Text</title>
+        </info>
 
-		<note><para>You can open multiple files in <application>&app;</application>. The application adds a tab for each open file to the window. For more on this see <xref linkend="pluma-tabs"/>.</para></note>
+        <!-- ============= To Edit Text ====================================== -->
+        <section xml:id="pluma-edit-text">
+            <info>
+                <title>Editing Text</title>
+            </info>
+            <para>You can edit the text of a file in the following ways:</para>
+            <itemizedlist>
+                <listitem>
+                    <para>Type new text from the keyboard. The blinking <firstterm>insertion cursor</firstterm> marks the point where new text appears. To change this, use the arrow keys on the keyboard or click with the mouse.</para>
+                </listitem>
+                <listitem>
+                    <para>To copy the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Copy</guimenuitem> </menuchoice>.</para>
+                </listitem>
+                <listitem>
+                    <para>To delete the selected text from the file and move the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Cut</guimenuitem> </menuchoice>.</para>
+                </listitem>
+                <listitem>
+                    <para>To permanently delete the selected text from the file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Delete</guimenuitem> </menuchoice>.</para>
+                </listitem>
+                <listitem>
+                    <para>To insert the contents of the clipboard at the cursor position, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Paste</guimenuitem> </menuchoice>. You must cut or copy text before you can paste text into the file, either from pluma or another application.</para>
+                </listitem>
+                <listitem>
+                    <para>To select all the text in a file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Select All</guimenuitem> </menuchoice>.</para>
+                </listitem>
+            </itemizedlist>
+        </section>
 
-	 </sect2>
+        <!-- ============== To Undo or Redo Edits ============================ -->
+        <section xml:id="pluma-undo-redo-edits">
+            <info>
+                <title>Undoing and Redoing Changes</title>
+            </info>
+            <para>To undo a change you have made, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Undo</guimenuitem> </menuchoice>. To reverse this action, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Redo</guimenuitem> </menuchoice>.</para>
+        </section>
+    </section>
 
-<!-- ============= To Save a File ============================== -->
-	 <sect2 id="pluma-save-file">
-		<title>Saving a File</title>
-		<para>You can save files in the following ways:</para>
-		<itemizedlist>
-		  <listitem><para>To save changes to an existing file, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Save</guimenuitem></menuchoice>. </para>
-		  </listitem>
-		  <listitem><para>To save a new file or to save an existing file under a new filename, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Save As</guimenuitem> </menuchoice>. Enter a name for the file in the <guilabel>Save As</guilabel> dialog, then click <guibutton>Save</guibutton>. </para>
-		  </listitem>
-		  <listitem><para>To save all the files that are currently open in <application>&app;</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Save All</guimenuitem> </menuchoice>.</para>
-		  </listitem>
-		</itemizedlist>
-		<para>To close all the files that are currently open in <application>&app;</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Close All</guimenuitem> </menuchoice>.</para>
-	 </sect2>
+    <section xml:id="pluma-find">
+        <info>
+            <title>Finding and Replacing</title>
+        </info>
+        <para>In <application>pluma</application>, there are two ways of searching for text. You can use the <guilabel>Find</guilabel> dialog to search for a specific piece of text, or <guilabel>Incremental Search</guilabel> to highlight matching text as you type it.</para>
 
-<!-- ============= Working with tabs ======================== -->
-	 <sect2 id="pluma-tabs">
-	   <title>Working With Tabs</title>
+        <!-- ============= To Find Text ================================ -->
+        <section xml:id="pluma-find-text">
+            <info>
+                <title>Finding Text</title>
+            </info>
+		
+            <para>To search a file for a string of text, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Choose <menuchoice> 
+                            <guimenu>Search</guimenu> 
+                            <guimenuitem>Find</guimenuitem> 
+                        </menuchoice> to display the <guilabel>Find</guilabel> dialog.</para>
+                </listitem>
+                <listitem>
+                    <para>Type the string that you want to find in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend="pluma-find-escapes"/>.</para>
+                </listitem>
+                <listitem>
+                    <para>Click <guibutton>Find</guibutton> to search the file for the first occurrence of the string after your current cursor position. If <application>pluma</application> finds the string, the application selects first occurrence of the string. Other occurrences of the string are highlighted.</para>
+                </listitem>
+                <listitem>
+                    <para>To find the next occurrence of the string, click <guibutton>Find</guibutton> or choose <menuchoice> 
+                            <guimenu>Search</guimenu> 
+                            <guimenuitem>Find Next</guimenuitem> 
+                        </menuchoice>. To find the previous occurrence of the text, choose <menuchoice> 
+                            <guimenu>Search</guimenu> 
+                            <guimenuitem>Find Previous</guimenuitem> 
+                        </menuchoice>.</para>
+                </listitem>
+            </orderedlist>
+            <para>After you have closed the <guilabel>Find</guilabel> dialog, you can still move the selection to other occurrences of the text by choosing  <menuchoice> 
+                    <guimenu>Search</guimenu> 
+                    <guimenuitem>Find Next</guimenuitem> 
+                </menuchoice> and  <menuchoice> 
+                    <guimenu>Search</guimenu> 
+                    <guimenuitem>Find Previous</guimenuitem> 
+                </menuchoice>.</para>
+            <para>To remove the highlighting from the text, choose  <menuchoice> 
+                    <guimenu>Search</guimenu> 
+                    <guimenuitem>Clear Highlight</guimenuitem> 
+                </menuchoice>.</para>
+        </section>
 
-		 <para>When more than one file is open, <application>&app;</application> shows a <firstterm>tab</firstterm> for each document above the display area. To switch to another document, click on its tab.</para>
-		 <para>To move a document to another <application> &app;</application> window, drag the tab corresponding to the file to the window you want to move it to.</para>
-		 <para>To move a document to a new <application> &app;</application> window, either drag its tab to the desktop, or choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Move to New Window</guimenuitem> </menuchoice>.</para>
-	 </sect2>
+        <section xml:id="pluma-find-incremental">
+            <info>
+                <title>Incremental Search</title>
+            </info>
+	   
 
-  </sect1>
+            <para>Incremental search highlights matching text in the document as you type it letter by letter. (This is similar to the search feature in several web browsers.)</para>
+            <para>To start an incremental search, choose <menuchoice> 
+                    <guimenu>Search</guimenu> 
+                    <guimenuitem>Incremental Search</guimenuitem> 
+                </menuchoice>. The search box appears at the top of the display area. </para>
+            <para>Begin typing, and text that matches will be highlighted in the document. The first instance after the cursor position is also selected.</para>
+            <para>To advance the selection to the next match while keeping the incremental search box open, press <keycombo>
+                    <keycap>Ctrl</keycap>
+                    <keycap>G</keycap>
+                </keycombo>. Press <keycombo>
+                    <keycap>Ctrl</keycap>
+                    <keycap>Shift</keycap>
+                    <keycap>G</keycap>
+                </keycombo> to go back to the previous match.</para>
+            <tip>
+                <para>You can also use the up and down arrow keys or the mouse wheel to move the selection between matches.</para>
+            </tip>
+        </section>
 
-  <sect1 id="working-with-text">
-    <title>Working with Text</title>
+        <!-- ============= To Find and Replace Text ========================== -->
+        <section xml:id="pluma-find-replace-text">
+            <info>
+                <title>Replacing Text</title>
+            </info>
+            <para>To search a file for a string, and replace the string with an alternative string, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Choose <menuchoice> 
+                            <guimenu>Search</guimenu> 
+                            <guimenuitem>Replace</guimenuitem> 
+                        </menuchoice> to display the <guilabel>Replace</guilabel> dialog.</para>
+                </listitem>
+                <listitem>
+                    <para>Type the string that you want to find, in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend="pluma-find-escapes"/>.</para>
+                </listitem>
+                <listitem>
+                    <para>Type the string that you want to use to replace the string that you find, in the <guilabel>Replace with</guilabel> field.</para>
+                </listitem>
+            </orderedlist>
 
-<!-- ============= To Edit Text ================================ -->
-	 <sect2 id="pluma-edit-text">
-		<title>Editing Text</title>
-		<para>You can edit the text of a file in the following ways:</para>
-		<itemizedlist>
-		  <listitem><para>Type new text from the keyboard. The blinking <firstterm>insertion cursor</firstterm> marks the point where new text appears. To change this, use the arrow keys on the keyboard or click with the mouse.</para>
-		  </listitem>
-		  <listitem><para>To copy the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Copy</guimenuitem> </menuchoice>.</para>
-		  </listitem>
-		  <listitem><para>To delete the selected text from the file and move the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Cut</guimenuitem> </menuchoice>.</para>
-		  </listitem>
-		  <listitem><para>To permanently delete the selected text from the file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Delete</guimenuitem> </menuchoice>.</para>
-		  </listitem>
-		  <listitem><para>To insert the contents of the clipboard at the cursor position, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Paste</guimenuitem> </menuchoice>. You must cut or copy text before you can paste text into the file, either from &app; or another application.</para>
-		  </listitem>
-		  <listitem><para>To select all the text in a file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Select All</guimenuitem> </menuchoice>. </para>
-		  </listitem>
-		</itemizedlist>
-	 </sect2>
-<!-- ============== To Undo or Redo Edits ====================== -->
-	 <sect2 id="pluma-undo-redo-edits">
-		<title>Undoing and Redoing Changes</title>
-		<para>To undo a change you have made, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Undo</guimenuitem> </menuchoice>. To reverse this action, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Redo</guimenuitem> </menuchoice>.</para>
-	 </sect2>
+            <para>To examine each occurrence of the string before replacing it, click <guibutton>Find</guibutton>. If <application>pluma</application> finds the string, the application selects the string. Click <guibutton>Replace</guibutton> to replace the selected occurrence of the string. To find the next occurrence of the string, click <guibutton>Find</guibutton> again.</para>
+            <para>To replace all occurrences of the string throughout the document, click <guibutton>Replace All</guibutton>.</para>
+        </section>
 
-	</sect1>
-	<sect1 id="pluma-find">
-		<title>Finding and Replacing</title>
+        <!-- ============= Find and Replace Options ============================ -->
+        <section xml:id="pluma-find-options">
+            <info>
+                <title>Find and Replace Options</title>
+            </info>
+		
+            <para>The <guilabel>Find</guilabel> dialog and the <guilabel>Replace</guilabel> dialog both have the following options:</para>
+            <itemizedlist>
+                <listitem>
+                    <para>Select the <guilabel>Match case</guilabel> option to only find occurrences of the string that match the case of the text that you type. For example, with <guilabel>Match case</guilabel> selected, "TEXT" will not match "text".</para>
+                </listitem>
+                <listitem>
+                    <para>Select the <guilabel>Match entire word only</guilabel> option to only find occurrences of the string that match the entire words of the text that you type. For example, with <guilabel>Match entire word only</guilabel> selected, "text" will not match "texture". <!-- translators, please make up your own example ;) --></para>
+                </listitem>
+                <listitem>
+                    <para>Select the <guilabel>Search backwards</guilabel> option to search backwards towards the beginning of the document. </para>
+                </listitem>
+                <listitem>
+                    <para>Select the <guilabel>Wrap around</guilabel> option to search to one end of the document and then continue the search from the other end of the file. </para>
+                </listitem>
+            </itemizedlist>
+        </section>
 
-		<para>In <application>&app;</application>, there are two ways of searching for text. You can use the <guilabel>Find</guilabel> dialog to search for a specific piece of text, or <guilabel>Incremental Search</guilabel> to highlight matching text as you type it.
-		</para>
+        <!-- ============= Special Characters ============================ -->
+        <section xml:id="pluma-find-escapes">
+            <info>
+                <title>Special Characters</title>
+            </info>
+	   
+            <para>You can include the following escape sequences in the text to find or replace to represent special characters:</para>
+            <variablelist>
+                <varlistentry>
+                    <term>
+                        <literal>\n</literal>
+                    </term>
+                    <listitem>
+                        <para>Specifies a new line.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <literal>\t</literal>
+                    </term>
+                    <listitem>
+                        <para>Specifies a tab character.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <literal>\r</literal>
+                    </term>
+                    <listitem>
+                        <para>Specifies a carriage return.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <literal>\\</literal>
+                    </term>
+                    <listitem>
+                        <para>The backslash character itself must be escaped if it is being searched for.
+                            For example, if you are looking for the "<literal>\n</literal>" literal, you will
+                            have to type "\\n" in the <guilabel>Search for</guilabel> field. Or if you are
+                            looking for a sequence of backslashes, you will have to double the number of
+                            searched backslashes.</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+        </section>
 
-<!-- ============= To Find Text ================================ -->
-	 <sect2 id="pluma-find-text">
-		<title>Finding Text</title>
-		<para>To search a file for a string of text, perform the following steps:</para>
-		<orderedlist>
-		  <listitem><para>Choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find</guimenuitem> </menuchoice> to display the <guilabel>Find</guilabel> dialog.</para>
-		  </listitem>
-		  <listitem><para>Type the string that you want to find in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend="pluma-find-escapes"/>.</para>
-		  </listitem>
-		  <listitem><para>Click <guibutton>Find</guibutton> to search the file for the first occurrence of the string after your current cursor position. If <application>&app;</application> finds the string, the application selects first occurrence of the string. Other occurrences of the string are highlighted.</para>
-		  </listitem>
-		  <listitem><para>To find the next occurrence of the string, click <guibutton>Find</guibutton> or choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Next</guimenuitem> </menuchoice>. To find the previous occurrence of the text, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Previous</guimenuitem> </menuchoice>.</para>
-		  </listitem>
-		</orderedlist>
-		<para>After you have closed the <guilabel>Find</guilabel> dialog, you can still move the selection to other occurrences of the text by choosing  <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Next</guimenuitem> </menuchoice> and  <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Previous</guimenuitem> </menuchoice>.</para>
-		<para>To remove the highlighting from the text, choose  <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Clear Highlight</guimenuitem> </menuchoice>.</para>
-	 </sect2>
+        <!-- ============= To Position the Cursor on a Specific Line ========= -->
+        <section xml:id="pluma-goto-line">
+            <info>
+                <title>Positioning the Cursor on a Specific Line</title>
+            </info>
+            <para>To position the cursor on a specific line in the current file, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Go to Line</guimenuitem> </menuchoice>. The line number box appears at the top of the display area.</para>
+            <para>Begin typing the number of the line that you want to move the cursor to and the document will scroll to the specified line.</para>
+            <para>To dismiss the box and move the cursor to the specified line, press <keycap>Return</keycap>.</para>
+        </section>
+    </section>
 
-	 <sect2 id="pluma-find-incremental">
-	   <title>Incremental Search</title>
+    <section xml:id="pluma-printing">
+        <info>
+            <title>Printing</title>
+        </info>
 
-	   <para>Incremental search highlights matching text in the document as you type it letter by letter. (This is similar to the search feature in several web browsers.)</para>
-	   <para>To start an incremental search, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Incremental Search</guimenuitem> </menuchoice>. The search box appears at the top of the display area. </para>
-	   <para>Begin typing, and text that matches will be highlighted in the document. The first instance after the cursor position is also selected.</para>
-	   <para>To advance the selection to the next match while keeping the incremental search box open, press <keycombo><keycap>Ctrl</keycap><keycap>G</keycap></keycombo>. Press <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap><keycap>G</keycap></keycombo> to go back to the previous match.</para>
-	   <tip><para>You can also use the up and down arrow keys or the mouse wheel to move the selection between matches.</para></tip>
-	 </sect2>
+        <!-- ============= To Set the Page Options =========================== -->
+        <section xml:id="pluma-page-setup">
+            <info>
+                <title>Setting the Page Options</title>
+            </info>
 
-<!-- ============= To Find and Replace Text =================== -->
-	 <sect2 id="pluma-find-replace-text">
-		<title>Replacing Text</title>
+            <para>To set the page options, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Page Setup</guimenuitem> </menuchoice> to display the <guilabel>Page Setup</guilabel> dialog.</para>
 
-		<para>To search a file for a string, and replace the string with an alternative string, perform the following steps:</para>
-		<orderedlist>
-		  <listitem><para>Choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Replace</guimenuitem> </menuchoice> to display the <guilabel>Replace</guilabel> dialog.</para>
-		  </listitem>
-		  <listitem><para>Type the string that you want to find, in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend="pluma-find-escapes"/>.</para></listitem>
-		  <listitem><para>Type the string that you want to use to replace the string that you find, in the <guilabel>Replace with</guilabel> field.</para>
-		  </listitem>
-		</orderedlist>
+            <para>The <guilabel>Page Setup</guilabel> dialog enables you to specify the following print options:</para>
 
-		<para>To examine each occurrence of the string before replacing it, click <guibutton>Find</guibutton>. If <application>&app;</application> finds the string, the application selects the string. Click <guibutton>Replace</guibutton> to replace the selected occurrence of the string. To find the next occurrence of the string, click <guibutton>Find</guibutton> again.</para>
-		<para>To replace all occurrences of the string throughout the document, click <guibutton>Replace All</guibutton>.</para>
-	 </sect2>
+            <section xml:id="pluma-page-setup-general">
+                <info>
+                    <title>General Tabbed Section</title>
+                </info>
+                <variablelist>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Print syntax highlighting</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Select this option to print syntax highlighting. For more information about syntax highlighting, see <xref linkend="pluma-set-highlightmode"/>.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Print page headers</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Select this option to include a header on each page that you print. You cannot configure the header. </para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Line Numbers</guilabel>
+                        </term>
+                        <listitem>
+                            <para>Select the <guilabel>Print line numbers</guilabel> option to include line numbers when you print a file.</para>
+                            <para>Use the <guilabel>Number every ... lines </guilabel> spin box to specify how often to print the line numbers, for example every 5 lines, every 10 lines, and so on.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Text Wrapping</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Select the <guilabel>Enable text wrapping</guilabel> option to wrap text onto the next line, at a character level, when you print a file. The application counts wrapped lines as one line for line numbering purposes.</para>
+                            <para>Select the <guilabel>Do not split words over two lines</guilabel> option to wrap text onto the next line, at a word level, when you print a file.</para>
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
 
-<!-- ============= Find and Replace Options ============================ -->
-  <sect2 id="pluma-find-options">
-		<title>Find and Replace Options</title>
-		<para>The <guilabel>Find</guilabel> dialog and the <guilabel>Replace</guilabel> dialog both have the following options:</para>
-		<itemizedlist>
-		  <listitem><para>Select the <guilabel>Match case</guilabel> option to only find occurrences of the string that match the case of the text that you type. For example, with <guilabel>Match case</guilabel> selected, "TEXT" will not match "text".</para>
-		  </listitem>
-		  <listitem><para>Select the <guilabel>Match entire word only</guilabel> option to only find occurrences of the string that match the entire words of the text that you type. For example, with <guilabel>Match entire word only</guilabel> selected, "text" will not match "texture". <!-- translators, please make up your own example ;) --></para>
-		  </listitem>
-		  <listitem><para>Select the <guilabel>Search backwards</guilabel> option to search backwards towards the beginning of the document. </para>
-		  </listitem>
-		  <listitem><para>Select the <guilabel>Wrap around</guilabel> option to search to one end of the document and then continue the search from the other end of the file. </para>
-		  </listitem>
-		</itemizedlist>
-  </sect2>
+            <section xml:id="pluma-page-setup-fonts">
+                <info>
+                    <title>Fonts</title>
+                </info>
+                <variablelist>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Body</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Click on this button to select the font used to print the body text of a file.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Line numbers</guilabel>
+                        </term>
+                        <listitem>
+                            <para>Click on this button to select the font used to print line numbers.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Headers and footers</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Click on this button to select the font to use to print the headers and footers in a file.  </para>
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+                <para>To reset the fonts to the default fonts for printing a file from <application>pluma</application>, click <guibutton>Restore Default Fonts</guibutton>.</para>
+            </section>
+        </section>
 
-<!-- ============= Special Characters ============================ -->
-	 <sect2 id="pluma-find-escapes">
-	   <title>Special Characters</title>
-	     <para>You can include the following escape sequences in the text to find or replace to represent special characters:</para>
-			 <variablelist>
-        <varlistentry>
-          <term><literal>\n</literal></term>
-    				<listitem>
-              <para>Specifies a new line.</para>
-    				</listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><literal>\t</literal></term>
-    				<listitem>
-              <para>Specifies a tab character.</para>
-    				</listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><literal>\r</literal></term>
-    				<listitem>
-              <para>Specifies a carriage return.</para>
-    				</listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><literal>\\</literal></term>
-    				<listitem>
-              <para>The backslash character itself must be escaped if it is being searched for.
-                    For example, if you are looking for the "<literal>\n</literal>" literal, you will
-                    have to type "\\n" in the <guilabel>Search for</guilabel> field. Or if you are
-                    looking for a sequence of backslashes, you will have to double the number of
-                    searched backslashes.</para>
-    				</listitem>
-        </varlistentry>
-			 </variablelist>
-    </sect2>
+        <!-- ============= To Print a File ============================ -->
+        <section xml:id="pluma-print-file">
+            <info>
+                <title>Printing a Document</title>
+            </info>
+            <para>You can use <application>pluma</application> to perform the following print operations:</para>
+            <itemizedlist>
+                <listitem>
+                    <para>Print a document to a printer. </para>
+                </listitem>
+                <listitem>
+                    <para>Print the output of the print command to a file.</para>
+                </listitem>
+            </itemizedlist>
+            <para>If you print to a file, <application>pluma</application> sends the output of the file to a pre-press format file. The most common pre-press formats are PostScript and Portable Document Format (PDF).</para>
+            <para>To preview the pages that you want to print, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print Preview</guimenuitem> </menuchoice>.</para>
+            <para>To print the current file to a printer or a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print</guimenuitem> </menuchoice> to display the <guilabel>Print</guilabel> dialog.</para>
+            <para>The <guilabel>Print</guilabel> dialog enables you to specify the following print options:</para>
 
-<!-- ============= To Position the Cursor on a Specific Line ======================= -->
-    <sect2 id="pluma-goto-line">
-      <title>Positioning the Cursor on a Specific Line</title>
+            <section xml:id="print-dialog-job">
+                <info>
+                    <title>Job Tabbed Section</title>
+                </info>
+                <variablelist>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Print range</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Select one of the following options to determine how many pages to print:</para>
+                            <itemizedlist>
+                                <listitem>
+                                    <para>
+                                        <guilabel>All</guilabel>
+                                    </para>
+                                    <para>Select this option to print all the pages in the file.</para>
+                                </listitem>
+                                <listitem>
+                                    <para>
+                                        <guilabel>Lines</guilabel>
+                                    </para>
+                                    <para>Select this option to print the specified lines only. Use the <guilabel>From</guilabel> and <guilabel>To</guilabel> spin boxes to specify the line range.</para>
+                                </listitem>
+                                <listitem>
+                                    <para>
+                                        <guilabel>Selection</guilabel>
+                                    </para>
+                                    <para>Select this option to print the selected text only. This option is only available if you select text.</para>
+                                </listitem>
+                            </itemizedlist>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Copies</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use the <guilabel>Number of copies</guilabel> spin box to specify the number of copies of the file that you want to print.</para>
+                            <para>If you print multiple copies of the file, select the <guilabel>Collate</guilabel> option to collate the printed copies.</para>
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
 
-      <para>To position the cursor on a specific line in the current file, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Go to Line</guimenuitem> </menuchoice>. The line number box appears at the top of the display area.</para>
-      <para>Begin typing the number of the line that you want to move the cursor to and the document will scroll to the specified line.</para>
-      <para>To dismiss the box and move the cursor to the specified line, press <keycap>Return</keycap>.</para>
-    </sect2>
+            <section xml:id="print-dialog-printer">
+                <info>
+                    <title>Printer Tabbed Section</title>
+                </info>
+		
+                <variablelist>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Printer</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select the printer to which you want to print the file.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Settings</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select the printer settings.</para>
+                            <para>To configure the printer, click <guibutton>Configure</guibutton>. For example, you can enable or disable duplex printing, or schedule delayed printing, if this functionality is supported by the printer.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Location</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select one of the following print destinations:</para>
+                            <variablelist>
+                                <varlistentry>
+                                    <term>
+                                        <guilabel>CUPS</guilabel>
+                                    </term>
+                                    <listitem>
+                                        <para>Print the file to a CUPS printer.</para>
+                                        <note>
+                                            <para>If the selected printer is a CUPS printer, <guilabel>CUPS</guilabel> is the only entry in this drop-down list.</para>
+                                        </note>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>
+                                        <guilabel>lpr</guilabel>
+                                    </term>
+                                    <listitem>
+                                        <para>Print the file to a printer.</para>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>
+                                        <guilabel>File</guilabel>
+                                    </term>
+                                    <listitem>
+                                        <para>Print the file to a PostScript file.</para>
+                                        <para>Click <guibutton>Save As</guibutton> to display a dialog where you specify the name and location of the PostScript file.</para>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>
+                                        <guilabel>Custom</guilabel>
+                                    </term>
+                                    <listitem>
+                                        <para>Use the specified command to print the file.</para>
+                                        <para>Type the name of the command in the text box. Include all command-line arguments.</para>
+                                    </listitem>
+                                </varlistentry>
+                            </variablelist>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>State</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>This functionality is not supported in this version of pluma.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Type</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>This functionality is not supported in this version of pluma.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Comment</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>This functionality is not supported in this version of pluma.</para>
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
 
-  </sect1>
+            <section xml:id="print-dialog-paper">
+                <info>
+                    <title>Paper Tabbed Section</title>
+                </info>
+		
+                <variablelist>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Paper size</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select the size of the paper to which you want to print the file.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Width</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this spin box to specify the width of the paper. Use the adjacent drop-down list to change the measurement unit.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Height</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this spin box to specify the height of the paper.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Feed orientation</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select the orientation of the paper in the printer.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Page orientation</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select the page orientation.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Layout</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select the page layout. A preview of each layout that you select is displayed in the <guilabel>Preview</guilabel> area.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry> 
+                        <term>
+                            <guilabel>Paper tray</guilabel> 
+                        </term>
+                        <listitem>
+                            <para>Use this drop-down list to select the paper tray.</para>             
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
+        </section>
+    </section>
 
-  <sect1 id="pluma-printing">
-    <title>Printing</title>
+    <section xml:id="pluma-programming-features">
+        <info>
+            <title>Programming Features</title>
+        </info>
+        <para>Several of <application>pluma</application>'s features for programming are provided with plugins. For example, the Tag List plugin provides a list of commonly-used tags for different markup languages: see <xref linkend="pluma-tag-list-plugin"/>.</para>
 
-<!-- ============= To Set the Page Options ============================ -->
-	 <sect2 id="pluma-page-setup">
-		<title>Setting the Page Options</title>
+        <!-- ============= Syntax Highlighting ============================== -->
+        <section xml:id="pluma-set-highlightmode">
+            <info>
+                <title>Syntax Highlighting</title>
+            </info>
+	 
+            <para>Syntax highlighting makes source code easier to read by showing different parts of the text in different colors.</para>
+            <para><application>pluma</application> chooses an appropriate syntax highlighting mode based on a document's type. To override the syntax highlighting mode, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Highlight Mode</guimenuitem> </menuchoice>, then choose one of the following menu items:</para>
+            <variablelist>
+                <varlistentry>
+                    <term>
+                        <guimenuitem>Normal</guimenuitem>
+                    </term>
+                    <listitem>
+                        <para>Do not display any syntax highlighting.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guisubmenu>Sources</guisubmenu>
+                    </term>
+                    <listitem>
+                        <para>Display syntax highlighting to edit source code. Use the <guisubmenu>Sources</guisubmenu> submenu to select the source code type.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guisubmenu>Markup</guisubmenu>
+                    </term>
+                    <listitem>
+                        <para>Display syntax highlighting to edit markup code. Use the <guisubmenu>Markup</guisubmenu> submenu to select the markup code type.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guisubmenu>Scripts</guisubmenu>
+                    </term>
+                    <listitem>
+                        <para>Display syntax highlighting to edit script code. Use the <guisubmenu>Scripts</guisubmenu> submenu to select the script code type.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guisubmenu>Others</guisubmenu>
+                    </term>
+                    <listitem>
+                        <para>Display syntax highlighting to edit other types of code. Use the <guisubmenu>Others</guisubmenu> submenu to select the code type.</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+        </section>
 
-		<para>To set the page options, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Page Setup</guimenuitem> </menuchoice> to display the <guilabel>Page Setup</guilabel> dialog.</para>
+        <!-- ============= To Pipe the Output of a Command to a File ========= -->
+        <section xml:id="pluma-pipe-output">
+            <info>
+                <title>Piping the Output of a Command to a File</title>
+            </info>
+            <para>You can use <application>pluma</application> to pipe the output of a command to a text file. For example, to pipe the output of an <command>ls</command> command to a text file, type <command>ls | pluma</command>, then press <keycap>Return</keycap>.</para>
+            <para>The output of the <command>ls</command> command is displayed in a new text file in the <application>pluma</application> window.</para>
+            <para>Alternatively, you can use the <application>External tools</application> plugin to pipe command output to the current file. <!-- fixme: xref needed! --></para>
+        </section>
+    </section>
 
-		<para>The <guilabel>Page Setup</guilabel> dialog enables you to specify the following print options:</para>
+    <!-- ================ Shortcut Keys ====================================== -->
+    <section xml:id="pluma-shortcutkeys">
+        <info>
+            <title>Shortcut Keys</title>
+        </info>
+        <para>Use shortcut keys to perform common tasks more quickly than with the mouse and menus. The following tables list all of <application>pluma</application>'s shortcut keys.</para>
+        <para>For more on shortcut keys, see the <link xlink:href="help:mate-user-guide/keyboard-skills">Desktop User Guide</link>.</para>
 
-		<sect3 id="pluma-page-setup-general">
-		<title>General Tabbed Section</title>
-	 	<variablelist>
-		  <varlistentry> <term><guilabel>Print syntax highlighting</guilabel> </term>
-			 <listitem>
-				<para>Select this option to print syntax highlighting. For more information about syntax highlighting, see <xref linkend="pluma-set-highlightmode"/>.  </para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term><guilabel>Print page headers</guilabel> </term>
-			 <listitem>
-				<para>Select this option to include a header on each page that you print. You cannot configure the header. </para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term><guilabel>Line Numbers</guilabel>
-			 </term>
-			 <listitem>
-				<para>Select the <guilabel>Print line numbers</guilabel> option to include line numbers when you print a file. </para>
-				<para>Use the <guilabel>Number every ... lines </guilabel> spin box to specify how often to print the line numbers, for example every 5 lines, every 10 lines, and so on. </para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term><guilabel>Text Wrapping</guilabel> </term>
-			 <listitem>
-                            <para>Select the <guilabel>Enable text wrapping</guilabel> option to wrap text onto the next line, at a character level, when you print a file. The application counts wrapped lines as one line for line numbering purposes.
-				  </para>
-				<para>Select the <guilabel>Do not split words over two lines</guilabel> option to wrap text onto the next line, at a word level, when you print a file.
-				  </para>
-			 </listitem>
-		  </varlistentry>
-		</variablelist>
-		</sect3>
+        <!-- ============= Tabs ======================== -->
+        <bridgehead>Tabs</bridgehead>
+        <para>Shortcuts for tabs:</para>
+        <informaltable frame="all">
+            <tgroup cols="2" colsep="1" rowsep="1">
+                <colspec colname="COLSPEC0" colwidth="50*"/>
+                <colspec colname="COLSPEC1" colwidth="50*"/>
+                <thead>
+                    <row valign="top">
+                        <entry colname="COLSPEC0">
+                            <para>Shortcut Key</para>
+                        </entry>
+                        <entry colname="COLSPEC1" align="left">
+                            <para>Command</para>
+                        </entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Alt + PageUp</para>
+                        </entry>
+                        <entry>
+                            <para>Switches to the next tab to the left.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Alt + PageDown</para>
+                        </entry>
+                        <entry>
+                            <para>Switches to the next tab to the right.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + W</para>
+                        </entry>
+                        <entry>
+                            <para>Close tab.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + L</para>
+                        </entry>
+                        <entry>
+                            <para>Save all tabs.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + W</para>
+                        </entry>
+                        <entry>
+                            <para>Close all tabs. </para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Alt + n</para>
+                        </entry>
+                        <entry>
+                            <para>Jump to nth tab.</para>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
 
-		<sect3 id="pluma-page-setup-fonts">
-	 		<title>Fonts</title>
-	 	<variablelist>
-		  <varlistentry> <term><guilabel>Body</guilabel> </term>
-			 <listitem>
-				<para>Click on this button to select the font used to print the body text of a file.</para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term><guilabel>Line numbers</guilabel>
-			 </term>
-			 <listitem>
-				<para>Click on this button to select the font used to print line numbers.</para>
-			 </listitem>
-		  </varlistentry>
-		  <varlistentry> <term><guilabel>Headers and footers</guilabel> </term>
-			 <listitem>
-				<para>Click on this button to select the font to use to print the headers and footers in a file.  </para>
-			 </listitem>
-		  </varlistentry>
-		</variablelist>
-		<para>To reset the fonts to the default fonts for printing a file from <application>&app;</application>, click <guibutton>Restore Default Fonts</guibutton>.</para>
-		</sect3>
+        <!-- ============= Files ======================== -->
+        <bridgehead>Files</bridgehead>
+        <para>Shortcuts for working with files:</para>
+        <informaltable frame="all">
+            <tgroup cols="2" colsep="1" rowsep="1">
+                <colspec colname="COLSPEC0" colwidth="50*"/>
+                <colspec colname="COLSPEC1" colwidth="50*"/>
+                <thead>
+                    <row valign="top">
+                        <entry colname="COLSPEC0">
+                            <para>Shortcut Key</para>
+                        </entry>
+                        <entry colname="COLSPEC1" align="left">
+                            <para>Command</para>
+                        </entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + N</para>
+                        </entry>
+                        <entry>
+                            <para>Create a new document.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + O</para>
+                        </entry>
+                        <entry>
+                            <para>Open a document.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + L</para>
+                        </entry>
+                        <entry>
+                            <para>Open a location.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + S</para>
+                        </entry>
+                        <entry>
+                            <para>Save the current document to disk.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + S</para>
+                        </entry>
+                        <entry>
+                            <para>Save the current document with a new filename.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + P</para>
+                        </entry>
+                        <entry>
+                            <para>Print the current document.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + P</para>
+                        </entry>
+                        <entry>
+                            <para>Print preview.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + W</para>
+                        </entry>
+                        <entry>
+                            <para>Close the current document.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Q</para>
+                        </entry>
+                        <entry>
+                            <para>Quit Pluma.</para>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
 
-	 </sect2>
+        <!-- ============= Edit ======================= -->
+        <bridgehead>Edit</bridgehead>
+        <para>Shortcuts for editing documents:</para>
+        <informaltable frame="all">
+            <tgroup cols="2" colsep="1" rowsep="1">
+                <colspec colname="COLSPEC0" colwidth="50*"/>
+                <colspec colname="COLSPEC1" colwidth="50*"/>
+                <thead>
+                    <row valign="top">
+                        <entry colname="COLSPEC0">
+                            <para>Shortcut Key</para>
+                        </entry>
+                        <entry colname="COLSPEC1" align="left">
+                            <para>Command</para>
+                        </entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Z</para>
+                        </entry>
+                        <entry>
+                            <para>Undo the last action.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + Z</para>
+                        </entry>
+                        <entry>
+                            <para>Redo the last undone action .</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + X</para>
+                        </entry>
+                        <entry>
+                            <para>Cut the selected text or region and place it on the clipboard.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + C</para>
+                        </entry>
+                        <entry>
+                            <para>Copy the selected text or region onto the clipboard.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + V</para>
+                        </entry>
+                        <entry>
+                            <para>Paste the contents of the clipboard.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + A</para>
+                        </entry>
+                        <entry>
+                            <para>Select all.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + D</para>
+                        </entry>
+                        <entry>
+                            <para>Delete current line.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Alt + Up</para>
+                        </entry>
+                        <entry>
+                            <para>Move the selected line up one line.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Alt + Down</para>
+                        </entry>
+                        <entry>
+                            <para>Move the selected line down one line.</para>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
 
-<!-- ============= To Print a File ============================ -->
-	 <sect2 id="pluma-print-file">
-		<title>Printing a Document</title>
-		<para>You can use <application>&app;</application> to perform the following print operations:</para>
-		<itemizedlist>
-		  <listitem><para>Print a document to a printer. </para>
-		  </listitem>
-		  <listitem><para>Print the output of the print command to a file.</para>
-		  </listitem>
-		</itemizedlist>
-		<para>If you print to a file, <application>&app;</application> sends the output of the file to a pre-press format file. The most common pre-press formats are PostScript and Portable Document Format (PDF).</para>
+        <!-- ============= Panes ======================= -->
+        <bridgehead>Panes</bridgehead>
+        <para>Shortcuts for showing and hiding panes:</para>
+        <informaltable frame="all">
+            <tgroup cols="2" colsep="1" rowsep="1">
+                <colspec colname="COLSPEC0" colwidth="50*"/>
+                <colspec colname="COLSPEC1" colwidth="50*"/>
+                <thead>
+                    <row valign="top">
+                        <entry colname="COLSPEC0">
+                            <para>Shortcut Key</para>
+                        </entry>
+                        <entry colname="COLSPEC1" align="left">
+                            <para>Command</para>
+                        </entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row valign="top">
+                        <entry>
+                            <para>F9</para>
+                        </entry>
+                        <entry>
+                            <para>Show/hide the side pane.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + F9</para>
+                        </entry>
+                        <entry>
+                            <para>Show/hide the bottom pane.</para>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
 
-		<para>To preview the pages that you want to print, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print Preview</guimenuitem> </menuchoice>.</para>
+        <!-- ============= Search ======================= -->
+        <bridgehead>Search</bridgehead>
+        <para>Shortcuts for searching:</para>
+        <informaltable frame="all">
+            <tgroup cols="2" colsep="1" rowsep="1">
+                <colspec colname="COLSPEC0" colwidth="50*"/>
+                <colspec colname="COLSPEC1" colwidth="50*"/>
+                <thead>
+                    <row valign="top">
+                        <entry colname="COLSPEC0">
+                            <para>Shortcut Key</para>
+                        </entry>
+                        <entry colname="COLSPEC1" align="left">
+                            <para>Command</para>
+                        </entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + F</para>
+                        </entry>
+                        <entry>
+                            <para>Find a string.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + G</para>
+                        </entry>
+                        <entry>
+                            <para>Find the next instance of the string.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + G</para>
+                        </entry>
+                        <entry>
+                            <para>Find the previous instance of the string.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + K</para>
+                        </entry>
+                        <entry>
+                            <para>Interactive search.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + H</para>
+                        </entry>
+                        <entry>
+                            <para>Search and replace.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + K</para>
+                        </entry>
+                        <entry>
+                            <para>Clear highlight.</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + I</para>
+                        </entry>
+                        <entry>
+                            <para>Goto line.</para>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
 
-		<para>To print the current file to a printer or a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print</guimenuitem> </menuchoice> to display the <guilabel>Print</guilabel> dialog.</para>
+        <!-- ============= Tools ======================= -->
+        <bridgehead>Tools</bridgehead>
+        <para>Shortcuts for tools:</para>
+        <informaltable frame="all">
+            <tgroup cols="2" colsep="1" rowsep="1">
+                <colspec colname="COLSPEC0" colwidth="50*"/>
+                <colspec colname="COLSPEC1" colwidth="50*"/>
+                <thead>
+                    <row valign="top">
+                        <entry colname="COLSPEC0">
+                            <para>Shortcut Key</para>
+                        </entry>
+                        <entry colname="COLSPEC1" align="left">
+                            <para>Command</para>
+                        </entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row valign="top">
+                        <entry>
+                            <para>Shift + F7</para>
+                        </entry>
+                        <entry>
+                            <para>Check spelling (with plugin).</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Alt + F12</para>
+                        </entry>
+                        <entry>
+                            <para>Remove trailing spaces (with plugin).</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + T</para>
+                        </entry>
+                        <entry>
+                            <para>Indent (with plugin).</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + T</para>
+                        </entry>
+                        <entry>
+                            <para>Remove Indent (with plugin).</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>F8</para>
+                        </entry>
+                        <entry>
+                            <para>Run "make" in current directory (with plugin).</para>
+                        </entry>
+                    </row>
+                    <row valign="top">
+                        <entry>
+                            <para>Ctrl + Shift + D</para>
+                        </entry>
+                        <entry>
+                            <para>Directory listing (with plugin).</para>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
 
-		<para>The <guilabel>Print</guilabel> dialog enables you to specify the following print options:</para>
+        <!-- ============= Help ======================= -->
+        <bridgehead>Help</bridgehead>
+        <para>Shortcuts for help:</para>
+        <informaltable frame="all">
+            <tgroup cols="2" colsep="1" rowsep="1">
+                <colspec colname="COLSPEC0" colwidth="50*"/>
+                <colspec colname="COLSPEC1" colwidth="50*"/>
+                <thead>
+                    <row valign="top">
+                        <entry colname="COLSPEC0">
+                            <para>Shortcut Key</para>
+                        </entry>
+                        <entry colname="COLSPEC1" align="left">
+                            <para>Command</para>
+                        </entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row valign="top">
+                        <entry>
+                            <para>F1</para>
+                        </entry>
+                        <entry>
+                            <para>Open <application>pluma</application>'s user manual.</para>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
+    </section>
 
-		<sect3 id="print-dialog-job">
-		<title>Job Tabbed Section</title>
-		<variablelist>
-	 		<varlistentry> <term><guilabel>Print range</guilabel> </term>
-			 <listitem>
-				<para>Select one of the following options to determine how many pages to print:</para>
-				<itemizedlist>
-				<listitem>
-				<para><guilabel>All</guilabel></para>
-				<para>Select this option to print all the pages in the file.</para>
-				</listitem>
-				<listitem>
-				<para><guilabel>Lines</guilabel></para>
-				<para>Select this option to print the specified lines only. Use the <guilabel>From</guilabel> and <guilabel>To</guilabel> spin boxes to specify the line range.</para>
-				</listitem>
-				<listitem>
-				<para><guilabel>Selection</guilabel></para>
-				<para>Select this option to print the selected text only. This option is only available if you select text.</para>
-				</listitem>
-
-				</itemizedlist>
-			 </listitem>
-		  	</varlistentry>
-		  	<varlistentry> <term><guilabel>Copies</guilabel> </term>
-			 <listitem>
-				<para>Use the <guilabel>Number of copies</guilabel> spin box to specify the number of copies of the file that you want to print.</para>
-				<para>If you print multiple copies of the file, select the <guilabel>Collate</guilabel> option to collate the printed copies.</para>
-			 </listitem>
-		  	</varlistentry>
-			</variablelist>
-		</sect3>
-
-		<sect3 id="print-dialog-printer">
-		<title>Printer Tabbed Section</title>
-	<variablelist>
-	  <varlistentry> <term><guilabel>Printer</guilabel> </term>
-	    <listitem>
-	      <para>Use this drop-down list to select the printer to which you want to print the file.</para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry> <term><guilabel>Settings</guilabel> </term>
-	    <listitem>
-	      <para>Use this drop-down list to select the printer settings.
-              </para>
-	      <para>To configure the printer, click <guibutton>Configure</guibutton>. For example, you can enable or disable duplex printing, or schedule delayed printing, if this functionality is supported by the printer.
-              </para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry> <term><guilabel>Location</guilabel> </term>
-	    <listitem>
-	      <para>
-                Use this drop-down list to select one of the following print destinations:
-	      </para>
-	      <variablelist>
-	        <varlistentry>
-	          <term><guilabel>CUPS</guilabel></term>
-	          <listitem>
-	            <para>
-                      Print the file to a CUPS printer.
-	            </para>
-	            <note>
-	              <para>
-                        If the selected printer is a CUPS printer, <guilabel>CUPS</guilabel> is the only entry in this drop-down list.
-	              </para>
-	            </note>
-	          </listitem>
-	        </varlistentry>
-	        <varlistentry>
-	          <term><guilabel>lpr</guilabel></term>
-	          <listitem>
-	            <para>
-                      Print the file to a printer.
-	            </para>
-	          </listitem>
-	        </varlistentry>
-	        <varlistentry>
-	          <term><guilabel>File</guilabel></term>
-	          <listitem>
-	            <para>
-                      Print the file to a PostScript file.
-	            </para>
-	            <para>
-                      Click <guibutton>Save As</guibutton> to display a dialog where you specify the name and location of the PostScript file.
-	            </para>
-	          </listitem>
-	        </varlistentry>
-	        <varlistentry>
-	          <term><guilabel>Custom</guilabel></term>
-	          <listitem>
-	            <para>
-                      Use the specified command to print the file.
-	            </para>
-	            <para>
-                      Type the name of the command in the text box. Include all command-line arguments.
-	            </para>
-	          </listitem>
-	        </varlistentry>
-	      </variablelist>
-            </listitem>
-	  </varlistentry>
-	  <varlistentry> <term><guilabel>State</guilabel> </term>
-	    <listitem>
-	      <para>This functionality is not supported in this version of &app;.
-              </para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry> <term><guilabel>Type</guilabel> </term>
-	    <listitem>
-	      <para>This functionality is not supported in this version of &app;.
-              </para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry> <term><guilabel>Comment</guilabel> </term>
-	    <listitem>
-	      <para>This functionality is not supported in this version of &app;.
-              </para>
-	    </listitem>
-	  </varlistentry>
-	</variablelist>
-	</sect3>
-
-		<sect3 id="print-dialog-paper">
-		<title>Paper Tabbed Section</title>
-		<variablelist>
-	 		<varlistentry> <term><guilabel>Paper size</guilabel> </term>
-			 <listitem>
-				<para>Use this drop-down list to select the size of the paper to which you want to print the file.</para>
-			 </listitem>
-		  	</varlistentry>
-		  	<varlistentry> <term><guilabel>Width</guilabel> </term>
-			 <listitem>
-				<para>Use this spin box to specify the width of the paper. Use the adjacent drop-down list to change the measurement unit.</para>
-			 </listitem>
-		  	</varlistentry>
-		  	<varlistentry> <term><guilabel>Height</guilabel> </term>
-			 <listitem>
-				<para>Use this spin box to specify the height of the paper.</para>
-			 </listitem>
-		  	</varlistentry>
-		  	<varlistentry> <term><guilabel>Feed orientation</guilabel> </term>
-			 <listitem>
-				<para>Use this drop-down list to select the orientation of the paper in the printer.</para>
-			 </listitem>
-		  	</varlistentry>
-		  	<varlistentry> <term><guilabel>Page orientation</guilabel> </term>
-			 <listitem>
-				<para>Use this drop-down list to select the page orientation.</para>
-			 </listitem>
-		  	</varlistentry>
-		  	<varlistentry> <term><guilabel>Layout</guilabel> </term>
-			 <listitem>
-				<para>Use this drop-down list to select the page layout. A preview of each layout that you select is displayed in the <guilabel>Preview</guilabel> area.</para>
-			 </listitem>
-		  	</varlistentry>
-          <varlistentry> <term><guilabel>Paper tray</guilabel> </term>
+    <!-- ============= Preferences ============================= -->
+    <section xml:id="pluma-prefs">
+        <info>
+            <title>Preferences</title>
+        </info>
+        <para>To configure <application>pluma</application>, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>. The <guilabel>Preferences</guilabel> dialog contains the following categories:</para>
+        <itemizedlist>
             <listitem>
-              <para>Use this drop-down list to select the paper tray.
-              </para>             </listitem>
-          </varlistentry>
-		</variablelist>
-		</sect3>
+                <para>
+                    <xref linkend="pluma-prefs-view"/>
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    <xref linkend="pluma-prefs-editor"/>
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    <xref linkend="pluma-prefs-fontsandcolors"/>
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    <xref linkend="pluma-prefs-plugins"/>
+                </para>
+            </listitem>
+        </itemizedlist>
 
-	 </sect2>
-
-  </sect1>
-
-  <sect1 id="pluma-programming-features">
-	  <title>Programming Features</title>
-
-	  <para>Several of <application>&app;</application>'s features for programming are provided with plugins. For example, the Tag List plugin provides a list of commonly-used tags for different markup languages: see <xref linkend="pluma-tag-list-plugin"/>.</para>
-
-<!-- ============= Syntax Highlighting =================== -->
-	 <sect2 id="pluma-set-highlightmode">
-	 <title>Syntax Highlighting</title>
-	 <para>Syntax highlighting makes source code easier to read by showing different parts of the text in different colors.</para>
-
-	 <para><application>&app;</application> chooses an appropriate syntax highlighting mode based on a document's type. To override the syntax highlighting mode, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Highlight Mode</guimenuitem> </menuchoice>, then choose one of the following menu items:</para>
-		  <variablelist>
-		    <varlistentry>
-		      <term><guimenuitem>Normal</guimenuitem></term>
-		      <listitem>
-		        <para>Do not display any syntax highlighting.</para>
-		      </listitem>
-		    </varlistentry>
-		    <varlistentry>
-		      <term><guisubmenu>Sources</guisubmenu></term>
-		      <listitem>
-		        <para>Display syntax highlighting to edit source code. Use the <guisubmenu>Sources</guisubmenu> submenu to select the source code type.</para>
-		      </listitem>
-		    </varlistentry>
-		    <varlistentry>
-		      <term><guisubmenu>Markup</guisubmenu></term>
-		      <listitem>
-		        <para>Display syntax highlighting to edit markup code. Use the <guisubmenu>Markup</guisubmenu> submenu to select the markup code type.</para>
-		      </listitem>
-		    </varlistentry>
-		    <varlistentry>
-		      <term><guisubmenu>Scripts</guisubmenu></term>
-		      <listitem>
-		        <para>Display syntax highlighting to edit script code. Use the <guisubmenu>Scripts</guisubmenu> submenu to select the script code type.</para>
-		      </listitem>
-		    </varlistentry>
-		    <varlistentry>
-		      <term><guisubmenu>Others</guisubmenu></term>
-		      <listitem>
-		        <para>Display syntax highlighting to edit other types of code. Use the <guisubmenu>Others</guisubmenu> submenu to select the code type.</para>
-		      </listitem>
-		    </varlistentry>
-		  </variablelist>
-	 </sect2>
-
-<!-- ============= To Pipe the Output of a Command to a File ======= -->
-	 <sect2 id="pluma-pipe-output">
-		<title>Piping the Output of a Command to a File</title>
-		<para>You can use <application>&app;</application> to pipe the output of a command to a text file. For example, to pipe the output of an <command>ls</command> command to a text file, type <command>ls | pluma</command>, then press <keycap>Return</keycap>.</para>
-		<para>The output of the <command>ls</command> command is displayed in a new text file in the <application>&app;</application> window.</para>
-		<para>Alternatively, you can use the <application>External tools</application> plugin to pipe command output to the current file. <!-- fixme: xref needed! --></para>
-	 </sect2>
-  </sect1>
-
-<!-- ================ Shortcut Keys ============================= -->
-<sect1 id="pluma-shortcutkeys">
-  <title>Shortcut Keys</title>
-  <para>Use shortcut keys to perform common tasks more quickly than with the mouse and menus. The following tables list all of <application>&app;</application>'s shortcut keys.</para>
-  <para>For more on shortcut keys, see the <ulink type="help" url="help:mate-user-guide/keyboard-skills">Desktop User Guide</ulink>.</para>
-
-  <!-- ============= Tabs ======================== -->
-	<bridgehead>Tabs</bridgehead>
-	<para>Shortcuts for tabs:</para>
-  <informaltable frame="all">
-    <tgroup cols="2" colsep="1" rowsep="1">
-      <colspec colname="COLSPEC0" colwidth="50*"/>
-      <colspec colname="COLSPEC1" colwidth="50*"/>
-      <thead>
-        <row valign="top">
-          <entry colname="COLSPEC0">
-            <para>Shortcut Key</para></entry>
-          <entry colname="COLSPEC1" align="left">
-            <para>Command</para></entry>
-        </row>
-      </thead>
-      <tbody>
-        <row valign="top">
-          <entry><para>Ctrl + Alt + PageUp</para></entry>
-          <entry><para>Switches to the next tab to the left.</para></entry>
-        </row>
-        <row valign="top">
-          <entry><para>Ctrl + Alt + PageDown</para></entry>
-          <entry><para>Switches to the next tab to the right.</para></entry>
-        </row>
-        <row valign="top">
-          <entry><para>Ctrl + W</para></entry>
-          <entry><para>Close tab.</para></entry>
-        </row>
-        <row valign="top">
-          <entry><para>Ctrl + Shift + L</para></entry>
-          <entry><para>Save all tabs.</para></entry>
-        </row>
-        <row valign="top">
-          <entry><para>Ctrl + Shift + W</para></entry>
-          <entry><para>Close all tabs. </para></entry>
-        </row>
-        <row valign="top">
-          <entry><para>Alt + n</para></entry>
-          <entry><para>Jump to nth tab.</para></entry>
-        </row>
-      </tbody>
-    </tgroup>
-  </informaltable>
-
-  <!-- ============= Files ======================== -->
-	<bridgehead>Files</bridgehead>
-	<para>Shortcuts for working with files:</para>
-  <informaltable frame="all">
-                  <tgroup cols="2" colsep="1" rowsep="1">
-                    <colspec colname="COLSPEC0" colwidth="50*"/>
-                    <colspec colname="COLSPEC1" colwidth="50*"/>
-                    <thead>
-                      <row valign="top">
-                        <entry colname="COLSPEC0">
-                          <para>Shortcut Key</para></entry>
-                        <entry colname="COLSPEC1" align="left">
-                          <para>Command</para></entry>
-                      </row>
-                    </thead>
-                    <tbody>
-                      <row valign="top">
-                        <entry><para>Ctrl + N</para></entry>
-                        <entry><para>Create a new document.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + O</para></entry>
-                        <entry><para>Open a document.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + L</para></entry>
-                        <entry><para>Open a location.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + S</para></entry>
-                        <entry><para>Save the current document to disk.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Shift + S</para></entry>
-                        <entry><para>Save the current document with a new filename.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + P</para></entry>
-                        <entry><para>Print the current document.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Shift + P</para></entry>
-                        <entry><para>Print preview.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + W</para></entry>
-                        <entry><para>Close the current document.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Q</para></entry>
-                        <entry><para>Quit Pluma.</para></entry>
-                      </row>
-                    </tbody>
-                  </tgroup>
-                </informaltable>
-
-  <!-- ============= Edit ======================= -->
-	<bridgehead>Edit</bridgehead>
-	<para>Shortcuts for editing documents:</para>
-	  <informaltable frame="all">
-                  <tgroup cols="2" colsep="1" rowsep="1">
-                    <colspec colname="COLSPEC0" colwidth="50*"/>
-                    <colspec colname="COLSPEC1" colwidth="50*"/>
-                    <thead>
-                      <row valign="top">
-                        <entry colname="COLSPEC0">
-                          <para>Shortcut Key</para></entry>
-                        <entry colname="COLSPEC1" align="left">
-                          <para>Command</para></entry>
-                      </row>
-                    </thead>
-                    <tbody>
-                      <row valign="top">
-                        <entry><para>Ctrl + Z</para></entry>
-                        <entry><para>Undo the last action.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Shift + Z</para></entry>
-                        <entry><para>Redo the last undone action .</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + X</para></entry>
-                        <entry><para>Cut the selected text or region and place it on the clipboard.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + C</para></entry>
-                        <entry><para>Copy the selected text or region onto the clipboard.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + V</para></entry>
-                        <entry><para>Paste the contents of the clipboard.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + A</para></entry>
-                        <entry><para>Select all.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + D</para></entry>
-                        <entry><para>Delete current line.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Alt + Up</para></entry>
-                        <entry><para>Move the selected line up one line.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Alt + Down</para></entry>
-                        <entry><para>Move the selected line down one line.</para></entry>
-                      </row>
-                    </tbody>
-                  </tgroup>
-                </informaltable>
-
-  <!-- ============= Panes ======================= -->
-	<bridgehead>Panes</bridgehead>
-	<para>Shortcuts for showing and hiding panes:</para>
-	  <informaltable frame="all">
-                  <tgroup cols="2" colsep="1" rowsep="1">
-                    <colspec colname="COLSPEC0" colwidth="50*"/>
-                    <colspec colname="COLSPEC1" colwidth="50*"/>
-                    <thead>
-                      <row valign="top">
-                        <entry colname="COLSPEC0">
-                          <para>Shortcut Key</para></entry>
-                        <entry colname="COLSPEC1" align="left">
-                          <para>Command</para></entry>
-                      </row>
-                    </thead>
-                    <tbody>
-                      <row valign="top">
-                        <entry><para>F9</para></entry>
-                        <entry><para>Show/hide the side pane.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + F9</para></entry>
-                        <entry><para>Show/hide the bottom pane.</para></entry>
-                      </row>
-                    </tbody>
-                  </tgroup>
-                </informaltable>
-
-  <!-- ============= Search ======================= -->
-	<bridgehead>Search</bridgehead>
-	<para>Shortcuts for searching:</para>
-	  <informaltable frame="all">
-                  <tgroup cols="2" colsep="1" rowsep="1">
-                    <colspec colname="COLSPEC0" colwidth="50*"/>
-                    <colspec colname="COLSPEC1" colwidth="50*"/>
-                    <thead>
-                      <row valign="top">
-                        <entry colname="COLSPEC0">
-                          <para>Shortcut Key</para></entry>
-                        <entry colname="COLSPEC1" align="left">
-                          <para>Command</para></entry>
-                      </row>
-                    </thead>
-                    <tbody>
-                      <row valign="top">
-                        <entry><para>Ctrl + F</para></entry>
-                        <entry><para>Find a string.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + G</para></entry>
-                        <entry><para>Find the next instance of the string.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Shift + G</para></entry>
-                        <entry><para>Find the previous instance of the string.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + K</para></entry>
-                        <entry><para>Interactive search.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + H</para></entry>
-                        <entry><para>Search and replace.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Shift + K</para></entry>
-                        <entry><para>Clear highlight.</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + I</para></entry>
-                        <entry><para>Goto line.</para></entry>
-                      </row>
-                    </tbody>
-                  </tgroup>
-                </informaltable>
-  <!-- ============= Tools ======================= -->
-	<bridgehead>Tools</bridgehead>
-	<para>Shortcuts for tools:</para>
-	  <informaltable frame="all">
-                  <tgroup cols="2" colsep="1" rowsep="1">
-                    <colspec colname="COLSPEC0" colwidth="50*"/>
-                    <colspec colname="COLSPEC1" colwidth="50*"/>
-                    <thead>
-                      <row valign="top">
-                        <entry colname="COLSPEC0">
-                          <para>Shortcut Key</para></entry>
-                        <entry colname="COLSPEC1" align="left">
-                          <para>Command</para></entry>
-                      </row>
-                    </thead>
-                    <tbody>
-                      <row valign="top">
-                        <entry><para>Shift + F7</para></entry>
-                        <entry><para>Check spelling (with plugin).</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Alt + F12</para></entry>
-                        <entry><para>Remove trailing spaces (with plugin).</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + T</para></entry>
-                        <entry><para>Indent (with plugin).</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Shift + T</para></entry>
-                        <entry><para>Remove Indent (with plugin).</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>F8</para></entry>
-                        <entry><para>Run "make" in current directory (with plugin).</para></entry>
-                      </row>
-                      <row valign="top">
-                        <entry><para>Ctrl + Shift + D</para></entry>
-                        <entry><para>Directory listing (with plugin).</para></entry>
-                      </row>
-                    </tbody>
-                  </tgroup>
-                </informaltable>
-  <!-- ============= Help ======================= -->
-	<bridgehead>Help</bridgehead>
-	<para>Shortcuts for help:</para>
-  <informaltable frame="all">
-    <tgroup cols="2" colsep="1" rowsep="1">
-      <colspec colname="COLSPEC0" colwidth="50*"/>
-      <colspec colname="COLSPEC1" colwidth="50*"/>
-      <thead>
-        <row valign="top">
-          <entry colname="COLSPEC0">
-            <para>Shortcut Key</para></entry>
-          <entry colname="COLSPEC1" align="left">
-            <para>Command</para></entry>
-        </row>
-      </thead>
-      <tbody>
-        <row valign="top">
-          <entry><para>F1</para></entry>
-          <entry><para>Open <application>&app;</application>'s user manual.</para></entry>
-        </row>
-      </tbody>
-    </tgroup>
-  </informaltable>
-
-</sect1>
-
-
-
-<!-- ============= Preferences ============================= -->
-  <sect1 id="pluma-prefs">
-    <title>Preferences</title>
-
-    <para>To configure <application>&app;</application>, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>. The <guilabel>Preferences</guilabel> dialog contains the following categories:</para>
-    <itemizedlist>
-      <listitem><para><xref linkend="pluma-prefs-view"/></para></listitem>
-      <listitem><para><xref linkend="pluma-prefs-editor"/></para></listitem>
-      <listitem><para><xref linkend="pluma-prefs-fontsandcolors"/></para></listitem>
-      <listitem><para><xref linkend="pluma-prefs-plugins"/></para></listitem>
-    </itemizedlist>
-
-    <sect2 id="pluma-prefs-view">
-      <title>View Preferences</title>
-      <variablelist>
-        <varlistentry>
-          <term><guilabel>Text Wrapping</guilabel> </term>
-          <listitem>
-            <para>Select the <guilabel>Enable text wrapping</guilabel> option to have long lines of text flow into paragraphs instead of running off the edge of the text window. This avoids having to scroll horizontally</para>
-            <para>Select the <guilabel>Do not split words over two lines</guilabel> option to have the text wrapping option preserve whole words when flowing text to the next line. This makes text easier to read.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><guilabel>Line Numbers</guilabel></term>
-          <listitem>
-            <para>Select the <guilabel>Display line numbers</guilabel> option to display line numbers on the left side of the <application>&app;</application> window. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><guilabel>Current Line</guilabel></term>
-          <listitem>
-            <para>Select the <guilabel>Highlight current line</guilabel> option to highlight the line where the cursor is placed. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><guilabel>Right Margin</guilabel></term>
-          <listitem>
-            <para>Select the <guilabel>Display right margin</guilabel> option to display a vertical line that indicates the right margin. </para>
-            <para>Use the <guilabel>Right margin at column</guilabel> spin box to specify the location of the vertical line. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><guilabel>Bracket Matching</guilabel></term>
-          <listitem>
-            <para>Select the <guilabel>Highlight matching bracket</guilabel> option to highlight the corresponding bracket when the cursor is positioned on a bracket character. </para>
-          </listitem>
-        </varlistentry>
-
-      </variablelist>
-    </sect2>
-
-    <sect2 id="pluma-prefs-editor">
-      <title>Editor Preferences</title>
-      <variablelist>
-        <varlistentry>
-          <term><guilabel>Tabs</guilabel> </term>
-          <listitem>
-            <para>Use the <guilabel>Tab width</guilabel> spin box to specify the width of the space that <application> &app;</application> inserts when you press the <keycap>Tab</keycap> key. </para>
-            <para>Select the <guilabel>Insert spaces instead of tabs</guilabel> option to specify that <application> &app;</application> inserts spaces instead of a tab character when you press the <keycap>Tab</keycap> key. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><guilabel>Auto Indentation</guilabel> </term>
-          <listitem>
-            <para>Select the <guilabel>Enable auto indentation</guilabel> option to specify that the next line starts at the indentation level of the current line.  </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><guilabel>File Saving</guilabel> </term>
-          <listitem>
-            <para>Select the <guilabel>Create a backup copy of files before saving</guilabel> option to create a backup copy of a file each time you save the file. The backup copy of the file contains a ~ at the end of the filename.</para>
-            <para>Select the <guilabel>Autosave files every ... minutes</guilabel> option to automatically save the current file at regular intervals. Use the spin box to specify how often you want to save the file.</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-    </sect2>
-
-    <sect2 id="pluma-prefs-fontsandcolors">
-      <title>Font &amp; Colors Preferences</title>
-      <variablelist>
-        <varlistentry>
-          <term><guilabel>Font</guilabel> </term>
-          <listitem>
-            <para>Select the <guilabel>Use default theme font</guilabel> option to use the default system font for the text in the <application>&app;</application> text window. </para>
-            <para>The <guilabel>Editor font</guilabel> field displays the font that <application>&app;</application> uses to display text. Click on the button to specify the font type, style, and size to use for text. </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term><guilabel>Color Scheme</guilabel></term>
-          <listitem>
-            <para>You can choose a color scheme from the list of color schemes. By default, the following color schemes are installed:</para>
+        <section xml:id="pluma-prefs-view">
+            <info>
+                <title>View Preferences</title>
+            </info>
             <variablelist>
-              <varlistentry>
-                <term><guilabel>Classic</guilabel></term>
-                <listitem>
-                  <para>Classic color scheme based on the gvim color scheme.</para>
-                </listitem>
-              </varlistentry>
-              <varlistentry>
-                <term><guilabel>Cobalt</guilabel></term>
-                <listitem>
-                  <para>Blue based color scheme.</para>
-                </listitem>
-              </varlistentry>
-              <varlistentry>
-                <term><guilabel>Kate</guilabel></term>
-                <listitem>
-                  <para>Color scheme used in the Kate text editor.</para>
-                </listitem>
-              </varlistentry>
-              <varlistentry>
-                <term><guilabel>Oblivion</guilabel></term>
-                <listitem>
-                  <para>Dark color scheme using the Tango color palette.</para>
-                </listitem>
-              </varlistentry>
-              <varlistentry>
-                <term><guilabel>Tango</guilabel></term>
-                <listitem>
-                  <para>Color scheme using the Tango color scheme.</para>
-                </listitem>
-              </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>Text Wrapping</guilabel> 
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Enable text wrapping</guilabel> option to have long lines of text flow into paragraphs instead of running off the edge of the text window. This avoids having to scroll horizontally</para>
+                        <para>Select the <guilabel>Do not split words over two lines</guilabel> option to have the text wrapping option preserve whole words when flowing text to the next line. This makes text easier to read.</para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>Line Numbers</guilabel>
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Display line numbers</guilabel> option to display line numbers on the left side of the <application>pluma</application> window. </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>Current Line</guilabel>
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Highlight current line</guilabel> option to highlight the line where the cursor is placed. </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>Right Margin</guilabel>
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Display right margin</guilabel> option to display a vertical line that indicates the right margin. </para>
+                        <para>Use the <guilabel>Right margin at column</guilabel> spin box to specify the location of the vertical line. </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>Bracket Matching</guilabel>
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Highlight matching bracket</guilabel> option to highlight the corresponding bracket when the cursor is positioned on a bracket character. </para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
-            <para>You can add a new color scheme by clicking on <guilabel>Add...</guilabel>, and selecting a color scheme file</para>
-            <para>You can remove the selected color scheme by clicking on <guilabel>Remove</guilabel></para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-    </sect2>
+        </section>
 
-    <sect2 id="pluma-prefs-plugins">
-      <title>Plugins Preferences</title>
-      <para>Plugins add extra features to <application>&app;</application>. For more information on plugins and how to use the built-in plugins, see <xref linkend="pluma-plugins-overview"/>.</para>
+        <section xml:id="pluma-prefs-editor">
+            <info>
+                <title>Editor Preferences</title>
+            </info>
+            <variablelist>
+                <varlistentry>
+                    <term>
+                        <guilabel>Tabs</guilabel> 
+                    </term>
+                    <listitem>
+                        <para>Use the <guilabel>Tab width</guilabel> spin box to specify the width of the space that <application> pluma</application> inserts when you press the <keycap>Tab</keycap> key. </para>
+                        <para>Select the <guilabel>Insert spaces instead of tabs</guilabel> option to specify that <application> pluma</application> inserts spaces instead of a tab character when you press the <keycap>Tab</keycap> key. </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>Auto Indentation</guilabel> 
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Enable auto indentation</guilabel> option to specify that the next line starts at the indentation level of the current line.  </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>File Saving</guilabel> 
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Create a backup copy of files before saving</guilabel> option to create a backup copy of a file each time you save the file. The backup copy of the file contains a ~ at the end of the filename.</para>
+                        <para>Select the <guilabel>Autosave files every ... minutes</guilabel> option to automatically save the current file at regular intervals. Use the spin box to specify how often you want to save the file.</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+        </section>
 
-<!-- ============= To Load pluma Plugins ========================= -->
-	 <sect3 id="pluma-install-plugins">
-		<title>Enabling a Plugin</title>
-		<para>To enable a <application>&app;</application> plugin, perform the following steps:</para>
-                <orderedlist>
-                  <listitem>
-                    <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>. </para>
-                  </listitem>
-                  <listitem>
-                    <para>Select the <guilabel>Plugins</guilabel> tab. </para>
-                  </listitem>
-                  <listitem>
-                    <para>Select the check box next to the name of the plugin that you want to enable.</para>
-                  </listitem>
-                  <listitem>
-                    <para>Click <guibutton>Close</guibutton> to close the <guilabel>Preferences</guilabel> dialog. </para>
-                  </listitem>
+        <section xml:id="pluma-prefs-fontsandcolors">
+            <info>
+                <title>Font &amp; Colors Preferences</title>
+            </info>
+      
+            <variablelist>
+                <varlistentry>
+                    <term>
+                        <guilabel>Font</guilabel> 
+                    </term>
+                    <listitem>
+                        <para>Select the <guilabel>Use default theme font</guilabel> option to use the default system font for the text in the <application>pluma</application> text window. </para>
+                        <para>The <guilabel>Editor font</guilabel> field displays the font that <application>pluma</application> uses to display text. Click on the button to specify the font type, style, and size to use for text. </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term>
+                        <guilabel>Color Scheme</guilabel>
+                    </term>
+                    <listitem>
+                        <para>You can choose a color scheme from the list of color schemes. By default, the following color schemes are installed:</para>
+                        <variablelist>
+                            <varlistentry>
+                                <term>
+                                    <guilabel>Classic</guilabel>
+                                </term>
+                                <listitem>
+                                    <para>Classic color scheme based on the gvim color scheme.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                <term>
+                                    <guilabel>Cobalt</guilabel>
+                                </term>
+                                <listitem>
+                                    <para>Blue based color scheme.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                <term>
+                                    <guilabel>Kate</guilabel>
+                                </term>
+                                <listitem>
+                                    <para>Color scheme used in the Kate text editor.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                <term>
+                                    <guilabel>Oblivion</guilabel>
+                                </term>
+                                <listitem>
+                                    <para>Dark color scheme using the Tango color palette.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                <term>
+                                    <guilabel>Tango</guilabel>
+                                </term>
+                                <listitem>
+                                    <para>Color scheme using the Tango color scheme.</para>
+                                </listitem>
+                            </varlistentry>
+                        </variablelist>
+                        <para>You can add a new color scheme by clicking on <guilabel>Add...</guilabel>, and selecting a color scheme file</para>
+                        <para>You can remove the selected color scheme by clicking on <guilabel>Remove</guilabel></para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+        </section>
+
+        <section xml:id="pluma-prefs-plugins">
+            <info>
+                <title>Plugins Preferences</title>
+            </info>
+            <para>Plugins add extra features to <application>pluma</application>. For more information on plugins and how to use the built-in plugins, see <xref linkend="pluma-plugins-overview"/>.</para>
+
+            <!-- ============= To Load pluma Plugins ========================= -->
+            <section xml:id="pluma-install-plugins">
+                <info>
+                    <title>Enabling a Plugin</title>
+                </info>
+                <para>To enable a <application>pluma</application> plugin, perform the following steps:</para>
+                <orderedlist inheritnum="ignore" continuation="restarts">
+                    <listitem>
+                        <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>.</para>
+                    </listitem>
+                    <listitem>
+                        <para>Select the <guilabel>Plugins</guilabel> tab.</para>
+                    </listitem>
+                    <listitem>
+                        <para>Select the check box next to the name of the plugin that you want to enable.</para>
+                    </listitem>
+                    <listitem>
+                        <para>Click <guibutton>Close</guibutton> to close the <guilabel>Preferences</guilabel> dialog.</para>
+                    </listitem>
                 </orderedlist>
-	 </sect3>
+            </section>
 
-<!-- ============= To Remove pluma Plugins ========================= -->
-  	 <sect3 id="pluma-remove-plugins">
-  		<title>Disabling a Plugin</title>
-  		<para>A plugin remains enabled when you quit <application>&app;</application>. </para>
-  		<para>To disable a <application>&app;</application> plugin, perform the following steps:</para>
-                  <orderedlist>
+            <!-- ============= To Remove pluma Plugins ========================= -->
+            <section xml:id="pluma-remove-plugins">
+                <info>
+                    <title>Disabling a Plugin</title>
+                </info>
+  		
+                <para>A plugin remains enabled when you quit <application>pluma</application>. </para>
+                <para>To disable a <application>pluma</application> plugin, perform the following steps:</para>
+                <orderedlist inheritnum="ignore" continuation="restarts">
                     <listitem>
-                      <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>. </para>
+                        <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>.</para>
                     </listitem>
                     <listitem>
-                      <para>Select the <guilabel>Plugins</guilabel> tab. </para>
+                        <para>Select the <guilabel>Plugins</guilabel> tab. </para>
                     </listitem>
                     <listitem>
-                      <para>Deselect the check box next to the name of the plugin that you want to disable.</para>
+                        <para>Deselect the check box next to the name of the plugin that you want to disable.</para>
                     </listitem>
                     <listitem>
-                      <para>Click <guibutton>Close</guibutton> to close the <guilabel>Preferences</guilabel> dialog. </para>
+                        <para>Click <guibutton>Close</guibutton> to close the <guilabel>Preferences</guilabel> dialog. </para>
                     </listitem>
-                  </orderedlist>
-  	 </sect3>
-	 </sect2>
+                </orderedlist>
+            </section>
+        </section>
+    </section>
 
- </sect1>
-<!-- ============= To Use the pluma Plugins ========================= -->
-	 <sect1 id="pluma-plugins">
-		<title>Plugins</title>
-		<sect2 id="pluma-plugins-overview">
-		  <title>Working with Plugins</title>
-  		<para>You can add extra features to <application>&app;</application> by enabling <firstterm>plugins</firstterm>. A plugin is a supplementary program that enhances the functionality of an application. Plugins add new items to the <application>&app;</application> menus for the new features they provide.
-  		</para>
-  		<para>Several plugins come built-in with <application>&app;</application>, and you can install more. The <ulink type="http" url="http://live.gnome.org/Pluma/Plugins">pluma website</ulink> lists third-party plugins.</para>
-  		<para>To enable and disable plugins, or see which plugins are currently enabled, use the <link linkend="pluma-prefs-plugins">Plugins Preferences</link>.</para>
-  		<para>The following plugins come built-in with <application>&app;</application>:</para>
-  		<!-- Not yet documented:
-  		File browser
-  		-->
-  		<itemizedlist>
-  		  <listitem>
-  		    <para><link linkend="pluma-change-case-plugin"><application>Change Case</application></link> allows you to change the case of the selected text.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-document-statistics-plugin">Document Statistics</link></application> shows the number of lines, words, and characters in the document. </para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-external-tools-plugin">External Tools</link></application> allows you to execute external commands from <application>&app;</application>.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><!-- <link linkend="pluma-file-browser-plugin">File Browser</link>-->File Browser</application> allows you to browse your files and folders in the side pane.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-indent-lines-plugin">Indent Lines</link></application> adds or removes indentation from the selected lines.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-insert-date-time-plugin">Insert Date/Time</link></application> adds the current date and time into a document.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-modelines-plugin">Modelines</link></application> allows you to set editing preferences for individual documents, and supports <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>-style modelines.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-python-console-plugin">Python Console</link></application> allows you to run commands in the python programming language.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-snippets-plugin">Snippets</link></application> allows you to store frequently-used pieces of text and insert them quickly into a document.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-sort-plugin">Sort</link></application> arranges selected lines of text into alphabetical order.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-spell-checker-plugin">Spell Checker</link></application> corrects the spelling in the selected text, or marks errors automatically in the document.</para>
-  		  </listitem>
-  		  <listitem>
-  		    <para><application><link linkend="pluma-tag-list-plugin">Tag List</link></application> lets you insert commonly-used tags for HTML and other languages from a list in the side pane.</para>
-  		  </listitem>
-  		</itemizedlist>
+    <!-- ============= To Use the pluma Plugins ========================= -->
+    <section xml:id="pluma-plugins">
+        <info>
+            <title>Plugins</title>
+        </info>
 
-	<note><para>For more information on creating plugins, see the <ulink type="http" url="http://live.gnome.org/Pluma/Plugins"><application>&app;</application> website</ulink>.</para></note>
-  	</sect2>
-
-<sect2 id="pluma-change-case-plugin">
-<title>Change Case Plugin</title>
-	<para>The <application>Change Case</application> plugin changes the case of the selected text.</para>
-	 <para>The following items are added to the <guimenu>Edit</guimenu> menu when the <application>Change Case</application> plugin is enabled:</para>
-
-  <informaltable frame="all">
-    <tgroup cols="3" colsep="1" rowsep="1">
-      <colspec colname="COLSPEC0" colwidth="33*"/>
-      <colspec colname="COLSPEC1" colwidth="33*"/>
-      <colspec colname="COLSPEC2" colwidth="33*"/>
-      <thead>
-        <row valign="top">
-          <entry colname="COLSPEC0">
-            <para>Menu Item</para></entry>
-          <entry colname="COLSPEC1">
-            <para>Action</para></entry>
-          <entry colname="COLSPEC2">
-            <para>Example</para></entry>
-        </row>
-      </thead>
-      <tbody>
-        <row valign="top">
-          <entry><para><menuchoice><guimenu>Edit</guimenu>
-<guisubmenu>Change Case</guisubmenu><guimenuitem>All Upper Case</guimenuitem></menuchoice></para></entry>
-          <entry><para>Change each character to uppercase. </para></entry>
-          <entry><para><literal>This text</literal> becomes <literal>THIS TEXT</literal> </para></entry>
-        </row>
-        <row valign="top">
-          <entry><para><menuchoice><guimenu>Edit</guimenu>
-<guisubmenu>Change Case</guisubmenu><guimenuitem>All Lower Case</guimenuitem></menuchoice></para></entry>
-          <entry><para>Change each character to lowercase. </para></entry>
-          <entry><para><literal>This Text</literal> becomes <literal>this text</literal> </para></entry>
-        </row>
-        <row valign="top">
-          <entry><para><menuchoice><guimenu>Edit</guimenu>
-<guisubmenu>Change Case</guisubmenu><guimenuitem>Invert Case</guimenuitem></menuchoice></para></entry>
-          <entry><para>Change each lowercase character to uppercase, and change each uppercase character to lowercase. </para></entry>
-          <entry><para><literal>This Text</literal> becomes <literal>tHIS tEXT</literal> </para></entry>
-        </row>
-        <row valign="top">
-          <entry><para><menuchoice><guimenu>Edit</guimenu>
-<guisubmenu>Change Case</guisubmenu><guimenuitem>Title Case</guimenuitem></menuchoice></para></entry>
-          <entry><para>Change the first character of each word to uppercase. </para></entry>
-          <entry><para><literal>this text</literal> becomes <literal>This Text</literal> </para></entry>
-        </row>
-      </tbody>
-    </tgroup>
-  </informaltable>
-
-</sect2>
-
-<sect2 id="pluma-document-statistics-plugin">
-<title>Document Statistics Plugin</title>
-	<para>The <application>Document Statistics</application> plugin counts the number of lines, words, characters with spaces, characters without spaces, and bytes in the current file. The plugin displays the results in a <guilabel>Document Statistics</guilabel> dialog. To use the Document Statistics plugin, perform the following steps:</para>
-		<orderedlist>
-		  <listitem><para>Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Document Statistics</guimenuitem> </menuchoice> to display the <guilabel>Document Statistics</guilabel> dialog. The <guilabel>Document Statistics</guilabel> dialog displays the following information about the file:
-				</para>
-		      <itemizedlist>
-		      <listitem><para>Number of lines in the current document.
-		                </para>
-		      </listitem>
-		      <listitem><para>Number of words in the current document.
-		                </para>
-		      </listitem>
-		      <listitem><para>Number of characters, including spaces, in the current document.
-		                </para>
-		      </listitem>
-		      <listitem><para>Number of characters, not including spaces, in the current document.
-		                </para>
-		      </listitem>
-		      <listitem><para>Number of bytes in the current document.
-		                </para>
-		      </listitem>
-		      </itemizedlist>
-		  </listitem>
-		  <listitem><para>You can continue to update the <application>&app;</application> file while the <guilabel>Document Statistics</guilabel> dialog is open. To refresh the contents of the <guilabel>Document Statistics</guilabel> dialog, click <guibutton>Update</guibutton>.
-                           </para>
-		  </listitem>
-		</orderedlist>
-</sect2>
-
-<sect2 id="pluma-external-tools-plugin">
-  <title>External Tools Plugin</title>
-  <para>The <application>External Tools</application> plugin allows you to execute external commands from <application>&app;</application>. You can pipe some content into a command and exploit its output (for example, <application>sed</application>), or launch a predefined command (for example, <application>make</application>).</para>
-  <para>Use the <guilabel>External Tools Manager</guilabel> to create and edit commands. To run an external command, choose it from the <guimenu>Tools</guimenu> menu.</para>
-
-  <sect3 id="pluma-external-tools-plugin-builtin">
-    <title>Built-in Commands</title>
-    <para>The following commands are provided with the <application>External Tools</application> plugin:</para>
-    <variablelist>
-      <varlistentry><term>Build</term>
-        <listitem>
-          <para>Runs <application>make</application> in the current document's directory.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Directory Listing</term>
-        <listitem>
-          <para>Lists the contents of the current document's directory in a new document.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Environment Variables</term>
-        <listitem>
-          <para>Displays the environment variables list in the bottom pane.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Grep</term>
-        <listitem>
-          <para>Searches for a term in all files in the current document directory, using pattern matching. Results are shown in the bottom pane.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Remove Trailing Spaces</term>
-        <listitem>
-          <para>Removes all spaces from the end of lines in the document.</para>
-        </listitem>
-      </varlistentry>
-    </variablelist>
-  </sect3>
-
-  <sect3 id="pluma-external-tools-plugin-define">
-    <title>Defining a Command</title>
-    <para>To add an external command, choose <menuchoice><guimenu>Tools</guimenu><guimenuitem>External Tools</guimenuitem></menuchoice>.</para>
-    <para>In the <guilabel>External Tools Manager</guilabel> window, click <guibutton>New</guibutton>. You can specify the following details for the new command:</para>
-    <variablelist>
-      <varlistentry><term>Description</term>
-        <listitem>
-          <para>This description is shown in the statusbar when the menu command is chosen.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Accelerator</term>
-        <listitem>
-          <para>Enter a keyboard shortcut for the command.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Commands</term>
-        <listitem>
-          <para>The actual commands to be run. Several <application>&app;</application> environment variables can be used to pass content to these commands: see <xref linkend="pluma-external-tools-plugin-variables"/>.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Input</term>
-        <listitem>
-          <para>The content to give to the commands (as <systemitem>stdin</systemitem>): the entire text of the current document, the current selection, line, or word.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Output</term>
-        <listitem>
-          <para>What to do with the output of the commands: display in the bottom pane, put in a new document, or place in the current document, at the end, at the cursor position, or replacing the selection or the entire document.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry><term>Applicability</term>
-        <listitem>
-          <para>Determines which sort of documents can be affected by the command, for example whether saved or not, and local or remote.</para>
-        </listitem>
-      </varlistentry>
-    </variablelist>
-
-  </sect3>
-
-  <sect3 id="pluma-external-tools-plugin-edit">
-    <title>Editing and Removing Tools</title>
-    <para>To edit a tool, select it in the list and make changes to its properties.</para>
-    <para>To rename a tool, click it again in the list.</para>
-    <para>To restore a built-in tool that you have changed, press <guilabel>Revert</guilabel>.</para>
-    <para>To remove a tool, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in tools, only those you have created yourself.</para>
-  </sect3>
-
-  <sect3 id="pluma-external-tools-plugin-variables">
-    <title>Variables</title>
-    <para>You can use the following variables in the <guilabel>Commands</guilabel> field of the command definition:</para>
-    <itemizedlist>
-      <listitem>
-        <para>PLUMA_CURRENT_DOCUMENT_URI</para>
-      </listitem>
-      <listitem>
-        <para>PLUMA_CURRENT_DOCUMENT_NAME</para>
-      </listitem>
-      <listitem>
-        <para>PLUMA_CURRENT_DOCUMENT_SCHEME</para>
-      </listitem>
-      <listitem>
-        <para>PLUMA_CURRENT_DOCUMENT_PATH</para>
-      </listitem>
-      <listitem>
-        <para>PLUMA_CURRENT_DOCUMENT_DIR</para>
-      </listitem>
-      <listitem>
-        <para>PLUMA_DOCUMENTS_URI</para>
-      </listitem>
-      <listitem>
-        <para>PLUMA_DOCUMENTS_PATH</para>
-      </listitem>
-    </itemizedlist>
-  </sect3>
-</sect2>
-
-<sect2 id="pluma-file-browser-plugin">
-  <title>File Browser Plugin</title>
-  <para>The <application>File Browser</application> Plugin shows your files and folders in the side pane, allowing you to quickly open files.</para>
-  <para>To view the File Browser, choose <menuchoice><guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice> and then click on the tab showing the File Browser icon at the bottom of the side pane.</para>
-  <sect3 id="pluma-file-browser-plugin-browsing">
-    <title>Browsing your Files</title>
-    <para>The File Browser tab initially shows your file manager bookmarks. To browse the contents of any item, double-click it.</para>
-    <para>To show a parent folder, choose from the drop-down list, or press the up arrow on the File Browser's toolbar.</para>
-    <para>To show the folder that contains the document you are currently working on, right-click in the file list and choose <guimenuitem>Set root to active document</guimenuitem>.</para>
-  </sect3>
-  <sect3 id="pluma-file-browser-plugin-open">
-    <title>Opening a File</title>
-    <para>To open a file in <application>&app;</application>, double-click it in the file list.</para>
-  </sect3>
-  <sect3 id="pluma-file-browser-plugin-create">
-    <title>Creating Files and Folders</title>
-    <para>To create a new, empty text file in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New File</guimenuitem>.</para>
-    <para>To create a new folder in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New Folder</guimenuitem>.</para>
-    </sect3>
-</sect2>
-
-<sect2 id="pluma-indent-lines-plugin">
-<title>Indent Lines Plugin</title>
-	<para>The <application>Indent Lines</application> plugin adds or removes space from the beginning of lines of text.</para>
-	<para>To indent or unindent text, perform the following steps:</para>
-  	<orderedlist>
-		  <listitem><para>Select the lines that you want to indent. To indent or unindent a single line, place the cursor anywhere on that line.</para>
-		  </listitem>
-		  <listitem>
-		    <itemizedlist>
-		      <listitem>
-		        <para>To indent the text, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Indent</guimenuitem> </menuchoice>.</para>
-		      </listitem>
-		      <listitem>
-		        <para>To remove the indentation, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Unindent</guimenuitem> </menuchoice>.</para>
-		      </listitem>
-		    </itemizedlist>
-		  </listitem>
-		</orderedlist>
-	<para>The amount of space used, and whether tab character or space characters are used, depends on the <guilabel>Tab Stops</guilabel> settings in the Editor Preferences: see <xref linkend="pluma-prefs-editor"/>.</para>
-
-</sect2>
-
-<sect2 id="pluma-insert-date-time-plugin">
-<title>Insert Date/Time Plugin</title>
-	<para>The <application>Insert Date/Time</application> plugin inserts the current date and time into a document. To use the Insert Date/Time plugin, perform the following steps:</para>
-		<orderedlist>
-		  <listitem><para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>. </para>
-        <para>If you have not configured the Insert Date/Time plugin to automatically insert the date/time without prompting you for the format, <application>&app;</application> displays the <guilabel>Insert Date and Time</guilabel> dialog. Select the appropriate date/time format from the list. Click <guibutton>Insert</guibutton> to close the <guilabel>Insert Date and Time</guilabel> dialog. <application>&app;</application> inserts the date/time at the cursor position in the current file. </para>
-				<para>If you have configured <application>&app;</application> to use one particular date/time format, the <guilabel>Insert Date and Time</guilabel> dialog is not displayed. The date/time is automatically entered at the cursor position in the current file. </para>
-		  </listitem>
-		</orderedlist>
-
-<sect3 id="pluma-date-time-configure">
-<title>Configuring the Insert Date/Time Plugin</title>
-<para>To configure the Insert Date/Time plugin, perform the following steps:</para>
-		<orderedlist>
-		  <listitem> <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>.
-                    </para>
-		  </listitem>
-		  <listitem> <para>Select the <guilabel>Plugins</guilabel> tab.
-                    </para>
-		  </listitem>
-		  <listitem> <para>Select the <guilabel>Insert Date/Time</guilabel> plugin.
-                    </para>
-		  </listitem>
-		  <listitem> <para>Click <guibutton>Configure Plugin</guibutton> to display the <guilabel>Configure insert date/time plugin</guilabel> dialog.
-                    </para>
-		  </listitem>
-		  <listitem> <para>Select one of the options, as follows: </para>
-		      <itemizedlist>
-		      <listitem><para>To specify the date/time format each time you insert the date/time, select the <guilabel>Prompt for a format</guilabel> option.
-		                </para>
-		      </listitem>
-		      <listitem><para>To use the same <application>&app;</application>-provided date/time format each time you insert the date/time, select the <guilabel>Use the selected format</guilabel> option, then select the appropriate format from the list. When you select this option, <application>&app;</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>.
-		                </para>
-		      </listitem>
-		      <listitem><para>To use the same customized date/time format each time you insert the date/time, select the <guilabel>Use custom format</guilabel> option, then enter the appropriate format in the text box. Refer to the <ulink url="man:strftime" type="man"><citerefentry><refentrytitle>strftime</refentrytitle><manvolnum>3</manvolnum></citerefentry></ulink> for more information on how to specify a custom format. When you select this option, <application>&app;</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>.
-		                </para>
-		      </listitem>
-		      </itemizedlist>
-		  </listitem>
-		  <listitem> <para>Click <guibutton>OK</guibutton> to close the <guilabel>Configure insert date/time plugin</guilabel> dialog.
-                    </para>
-		  </listitem>
-		  <listitem> <para>To close the <guilabel>Preferences</guilabel> dialog, click <guibutton>Close</guibutton>.</para>
-		  </listitem>
-		</orderedlist>
-</sect3>
-</sect2>
-
-<sect2 id="pluma-modelines-plugin">
-  <title>Modelines Plugin</title>
-    <para>The <application>Modelines</application> plugin allows you to set preferences for individual documents. A <firstterm>modeline</firstterm> is a line of text at the start or end of the document with settings that <application>&app;</application> recognizes.</para>
-    <para>Preferences set using modelines take precedence over the ones specified in the preference dialog.</para>
-    <para>You can set the following preferences with modelines:</para>
-    <itemizedlist>
-      <listitem>
-        <para>Tab width</para>
-      </listitem>
-      <listitem>
-        <para>Indent width</para>
-      </listitem>
-      <listitem>
-        <para>Insert spaces instead of tabs</para>
-      </listitem>
-      <listitem>
-        <para>Text Wrapping</para>
-      </listitem>
-      <listitem>
-        <para>Right margin width</para>
-      </listitem>
-    </itemizedlist>
-
-    <para>The <application>Modelines</application> plugin supports a subset of the options used by other text editors <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>.</para>
-
-    <sect3 id="pluma-modelines-plugin-emacs">
-      <title>Emacs Modelines</title>
-      <para>The first two lines of a document are scanned for <application>Emacs</application> modelines.</para>
-      <para>The <application>Emacs</application> options for tab-width, indent-offset, indent-tabs-mode and autowrap are supported. For more information, see the <ulink type="http" url="http://www.delorie.com/gnu/docs/emacs/emacs_486.html">GNU Emacs Manual</ulink>.</para>
-    </sect3>
-    <sect3 id="pluma-modelines-plugin-kate">
-      <title>Kate Modelines</title>
-      <para>The first and last ten lines a document are scanned for <application>Kate</application> modelines.</para>
-      <para>The <application>Kate</application> options for tab-width, indent-width, space-indent, word-wrap and word-wrap-column are supported. For more information, see the <ulink type="http" url="http://www.kate-editor.org/article/katepart_modelines">Kate website</ulink>.</para>
-    </sect3>
-    <sect3 id="pluma-modelines-plugin-vim">
-      <title>Vim Modelines</title>
-      <para>The first and last three lines a document are scanned for <application>Vim</application> modelines.</para>
-      <para>The <application>Vim</application> options for et, expandtab, ts, tabstop, sw, shiftwidth, wrap, and textwidth are supported. For more information, see the <ulink type="http" url="http://vimdoc.sourceforge.net/htmldoc/options.html#modeline">Vim website</ulink>.</para>
-    </sect3>
-</sect2>
-
-<sect2 id="pluma-python-console-plugin">
-  <title>Python Console Plugin</title>
-  <para>The <application>Python Console</application> Plugin allows you to run commands in the python programming language from <application>&app;</application>. Enabling the plugin adds a tab to the bottom pane. This shows recent output and a command prompt field.</para>
-  <caution><para>Commands entered into the python console are not checked before they are run. It is therefore possible to hang <application>&app;</application>, for example by entering an infinite loop.</para></caution>
-</sect2>
-
-<sect2 id="pluma-snippets-plugin">
-<title>Snippets Plugin</title>
-  <para>The <application>Snippets</application> plugin allows you to store frequently-used pieces of text, called <firstterm>snippets</firstterm>, and insert them quickly into a document.</para>
-    <para>Snippets are specific to the language syntax of the current document. For example, when you are working with an HTML document, you can choose from a list of snippets that are useful for HTML. In addition, some snippets are global, and are available in all documents.</para>
-    <para>A number of built-in snippets are installed with <application>&app;</application>, which can be modified.</para>
-
-  <sect3 id="pluma-snippets-plugin-insert">
-    <title>Inserting Snippets</title>
-    <para>To insert a snippet into a document, type its <firstterm>tab trigger</firstterm> and press <keycap>Tab</keycap>. A snippet's tab trigger is usually the first few letters of the snippet, or something else that is short and easy to remember.</para>
-    <para>Alternatively, press <keycombo><keycap>Ctrl</keycap><keycap>Space</keycap></keycombo> to see a list of snippets you can insert.</para>
-  </sect3>
-
-  <sect3 id="pluma-snippets-plugin-add">
-    <title>Adding Snippets</title>
-    <para>To create a new snippet, do the following:</para>
-      <orderedlist>
-        <listitem>
-          <para>Choose <menuchoice><guimenu>Tools</guimenu><guimenuitem>Manage Snippets</guimenuitem></menuchoice>. The <guilabel>Snippets Manager</guilabel> window opens.</para>
-        </listitem>
-        <listitem>
-          <para>The list of snippets is grouped by language. Select the language you want to add a snippet to, or a snippet in that language group. To add a snippet for all languages, choose Global at the top of the list. The syntax of the document you are currently working with is shown by default.</para>
-        </listitem>
-        <listitem>
-          <para>Click <guibutton>New</guibutton>. A new snippet appears in the list.</para>
-        </listitem>
-        <listitem>
-          <para>Enter the following information for the new snippet:</para>
-          <variablelist>
-            <varlistentry><term>Name</term>
-              <listitem>
-                <para>Enter a name for the snippet in the text field within the snippet list. The name of a snippet serves only as a reminder of its purpose. You can change name of a snippet you create by clicking on it in the list.</para>
-              </listitem>
-            </varlistentry>
-            <varlistentry><term>Snippet text</term>
-              <listitem>
-                <para>Enter the text of the snippet in the <guilabel>Edit snippet</guilabel> text box. For special codes you can use, see <xref linkend="pluma-snippets-plugin-syntax"/>.</para>
-                <tip><para>You can switch back to the document window to copy text without closing the <guilabel>Snippets Manager</guilabel> window.</para></tip>
-              </listitem>
-            </varlistentry>
-            <varlistentry><term>Tab Trigger</term>
-              <listitem>
-                <para>Enter the tab trigger for the snippet. This is the text that you type before pressing <keycap>Tab</keycap> to insert the snippet.</para>
-                <para>The tag must be either a single word comprising only letters, or any single character. The <guilabel>Tab trigger</guilabel> will highlight in red if an invalid tab trigger is entered.</para>
-              </listitem>
-            </varlistentry>
-            <varlistentry><term>Shortcut key</term>
-              <listitem>
-                <para>Type a shortcut key to use for inserting the snippet.</para>
-              </listitem>
-            </varlistentry>
-          </variablelist>
-
-        </listitem>
-      </orderedlist>
-  </sect3>
-  <sect3 id="pluma-snippets-plugin-edit">
-    <title>Editing and Removing Snippets</title>
-    <para>To edit a snippet, select it in the list and make changes to its text and activation properties.</para>
-    <para>To rename a snippet, click it again in the list.</para>
-    <para>To restore a built-in snippet that you have changed, press <guilabel>Revert</guilabel>.</para>
-    <para>To remove a snippet, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in snippets, only those you have created yourself.</para>
-  </sect3>
-
-  <sect3 id="pluma-snippets-plugin-syntax">
-    <title>Snippet Substitutions</title>
-    <para>In addition to inserting stored text, a snippet can include customizable text, or mark spaces where you can add text once the snippet is inserted in your document.</para>
-
-    <para></para>
-
-    <para>You can use the following placeholder codes in snippet text:</para>
-      <variablelist>
-        <varlistentry><term>Tab placeholders</term>
-          <listitem>
-            <para><literal>$<replaceable>n</replaceable></literal> defines a tab placeholder, where <literal>n</literal> is any number from 1 upwards. </para>
-            <para><literal>${<replaceable>n</replaceable>:<replaceable>default</replaceable>}</literal> defines a tab placeholder with a default value.</para>
-            <para>A tab placeholder marks a place in the snippet text where you can add extra text after the snippet is inserted.</para>
-            <para>To use tab placeholders, insert the snippet as normal. The cursor is placed at the first tab placeholder. Type text, and press <keycap>Tab</keycap> to advance to the next tab placeholder. The number in the placeholder code defines the order in which tab advances to each place in the text.</para>
-            <para>Press <keycombo><keycap>Shift</keycap><keycap>Tab</keycap></keycombo> to return to the previous tab placeholder. Pressing <keycap>Tab</keycap> when there are no more tab placeholders moves the cursor to the end of the snippet text, or to the end placeholder if it exists.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry><term>Mirror placeholders</term>
-          <listitem>
-            <para>A repeated tab placeholder will mirror the placeholder already defined. This allows you to type in text only once that you want to appear several times in the snippet.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry><term>End placeholder</term>
-          <listitem>
-            <para><literal>$0</literal> defines the end placeholder. This allows you to finish working with the snippet with the cursor at a point other than the end of the snippet text.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry><term>Environmental variables</term>
-          <listitem>
-            <para>Environmental variable such as <literal>$PATH</literal> and <literal>$HOME</literal> are substituted in snippet text. The following variables specific to <application>&app;</application> can also be used:</para>
-            <variablelist>
-              <varlistentry><term>$PLUMA_SELECTED_TEXT</term>
+        <section xml:id="pluma-plugins-overview">
+            <info>
+                <title>Working with Plugins</title>
+            </info>
+            <para>You can add extra features to <application>pluma</application> by enabling <firstterm>plugins</firstterm>. A plugin is a supplementary program that enhances the functionality of an application. Plugins add new items to the <application>pluma</application> menus for the new features they provide.
+            </para>
+            <para>Several plugins come built-in with <application>pluma</application>, and you can install more. The <link xlink:href="http://live.gnome.org/Pluma/Plugins">pluma website</link> lists third-party plugins.</para>
+            <para>To enable and disable plugins, or see which plugins are currently enabled, use the <link linkend="pluma-prefs-plugins">Plugins Preferences</link>.</para>
+            <para>The following plugins come built-in with <application>pluma</application>:</para>
+            <!-- Not yet documented:
+                    File browser
+            -->
+            <itemizedlist>
                 <listitem>
-                  <para>The currently selected text.</para>
+                    <para>
+                        <link linkend="pluma-change-case-plugin">
+                            <application>Change Case</application>
+                        </link> allows you to change the case of the selected text.</para>
                 </listitem>
-              </varlistentry>
-              <varlistentry><term>$PLUMA_FILENAME</term>
                 <listitem>
-                  <para>The full filename of the document, or an empty string if the document isn't saved yet.</para>
+                    <para>
+                        <application>
+                            <link linkend="pluma-document-statistics-plugin">Document Statistics</link>
+                        </application> shows the number of lines, words, and characters in the document. </para>
                 </listitem>
-              </varlistentry>
-              <varlistentry><term>$PLUMA_BASENAME</term>
                 <listitem>
-                  <para>The basename of the filename of the document, or an empty string if the document isn't saved yet.</para>
+                    <para>
+                        <application>
+                            <link linkend="pluma-external-tools-plugin">External Tools</link>
+                        </application> allows you to execute external commands from <application>pluma</application>.</para>
                 </listitem>
-              </varlistentry>
-              <varlistentry><term>$PLUMA_CURRENT_WORD</term>
                 <listitem>
-                  <para>The word at the cursor's location in the document. When this variable is used, the current word will be replaced by the snippet text.</para>
+                    <para>
+                        <application><!-- <link linkend="pluma-file-browser-plugin">File Browser</link>-->File Browser</application> allows you to browse your files and folders in the side pane.</para>
                 </listitem>
-              </varlistentry>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-indent-lines-plugin">Indent Lines</link>
+                        </application> adds or removes indentation from the selected lines.</para>
+                </listitem>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-insert-date-time-plugin">Insert Date/Time</link>
+                        </application> adds the current date and time into a document.</para>
+                </listitem>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-modelines-plugin">Modelines</link>
+                        </application> allows you to set editing preferences for individual documents, and supports <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>-style modelines.</para>
+                </listitem>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-python-console-plugin">Python Console</link>
+                        </application> allows you to run commands in the python programming language.</para>
+                </listitem>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-snippets-plugin">Snippets</link>
+                        </application> allows you to store frequently-used pieces of text and insert them quickly into a document.</para>
+                </listitem>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-sort-plugin">Sort</link>
+                        </application> arranges selected lines of text into alphabetical order.</para>
+                </listitem>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-spell-checker-plugin">Spell Checker</link>
+                        </application> corrects the spelling in the selected text, or marks errors automatically in the document.</para>
+                </listitem>
+                <listitem>
+                    <para>
+                        <application>
+                            <link linkend="pluma-tag-list-plugin">Tag List</link>
+                        </application> lets you insert commonly-used tags for HTML and other languages from a list in the side pane.</para>
+                </listitem>
+            </itemizedlist>
 
-            </variablelist>
+            <note>
+                <para>For more information on creating plugins, see the <link xlink:href="http://live.gnome.org/Pluma/Plugins"> <application>pluma</application> website</link>.</para>
+            </note>
+        </section>
 
-          </listitem>
-        </varlistentry>
-        <varlistentry><term>Shell placeholders</term>
-          <listitem>
-            <para><literal>$(<replaceable>cmd</replaceable>)</literal> is replaced by the result of executing <replaceable>cmd</replaceable> in a shell. </para>
-            <para><literal>$(<replaceable>n</replaceable>:<replaceable>cmd</replaceable>)</literal> allows you to give this placeholder a reference, where <replaceable>n</replaceable> is any number from 1 upwards. Use <literal>$<replaceable>n</replaceable></literal> to use the output from one shell placeholder as input in another.</para>
-          </listitem>
-        </varlistentry>
-        <varlistentry><term>Python placeholders</term>
-          <listitem>
-            <para><literal>$&lt;<replaceable>cmd</replaceable>&gt;</literal> is replaced by the result of evaluating <replaceable>cmd</replaceable> in the python interpreter.</para>
-            <para><literal>$&lt;<replaceable>a</replaceable>:<replaceable>cmd</replaceable>&gt;</literal> specifies another python placeholder as a dependency, where <replaceable>a</replaceable> gives its order in the snippet. This allows you to use python functions defined in another snippet. To specify several dependencies, separate the numbers with commas thus: <literal>$&lt;<replaceable>a</replaceable>,<replaceable>b</replaceable>:<replaceable>cmd</replaceable>&gt;</literal></para>
-            <para>To use a variable in all other python snippets, declare it as <literal>global</literal>.</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
-  </sect3>
+        <section xml:id="pluma-change-case-plugin">
+            <info>
+                <title>Change Case Plugin</title>
+            </info>
+            <para>The <application>Change Case</application> plugin changes the case of the selected text.</para>
+            <para>The following items are added to the <guimenu>Edit</guimenu> menu when the <application>Change Case</application> plugin is enabled:</para>
+            <informaltable frame="all">
+                <tgroup cols="3" colsep="1" rowsep="1">
+                    <colspec colname="COLSPEC0" colwidth="33*"/>
+                    <colspec colname="COLSPEC1" colwidth="33*"/>
+                    <colspec colname="COLSPEC2" colwidth="33*"/>
+                    <thead>
+                        <row valign="top">
+                            <entry colname="COLSPEC0">
+                                <para>Menu Item</para>
+                            </entry>
+                            <entry colname="COLSPEC1">
+                                <para>Action</para>
+                            </entry>
+                            <entry colname="COLSPEC2">
+                                <para>Example</para>
+                            </entry>
+                        </row>
+                    </thead>
+                    <tbody>
+                        <row valign="top">
+                            <entry>
+                                <para><menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>All Upper Case</guimenuitem> </menuchoice></para>
+                            </entry>
+                            <entry>
+                                <para>Change each character to uppercase. </para>
+                            </entry>
+                            <entry>
+                                <para><literal>This text</literal> becomes <literal>THIS TEXT</literal></para>
+                            </entry>
+                        </row>
+                        <row valign="top">
+                            <entry>
+                                <para><menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>All Lower Case</guimenuitem> </menuchoice></para>
+                            </entry>
+                            <entry>
+                                <para>Change each character to lowercase. </para>
+                            </entry>
+                            <entry>
+                                <para><literal>This Text</literal> becomes <literal>this text</literal></para>
+                            </entry>
+                        </row>
+                        <row valign="top">
+                            <entry>
+                                <para><menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>Invert Case</guimenuitem> </menuchoice></para>
+                            </entry>
+                            <entry>
+                                <para>Change each lowercase character to uppercase, and change each uppercase character to lowercase. </para>
+                            </entry>
+                            <entry>
+                                <para><literal>This Text</literal> becomes <literal>tHIS tEXT</literal></para>
+                            </entry>
+                        </row>
+                        <row valign="top">
+                            <entry>
+                                <para><menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>Title Case</guimenuitem> </menuchoice></para>
+                            </entry>
+                            <entry>
+                                <para>Change the first character of each word to uppercase. </para>
+                            </entry>
+                            <entry>
+                                <para><literal>this text</literal> becomes <literal>This Text</literal></para>
+                            </entry>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </informaltable>
 
-</sect2>
+        </section>
 
-<sect2 id="pluma-sort-plugin">
-<title>Sort Plugin</title>
-	<para>The <application>Sort</application> plugin arranges selected lines of text into alphabetical order.</para>
-		  <caution><para>You cannot undo the Sort operation, so you should save the file before performing the sort. To revert to the saved version of the file after the sort operation, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Revert</guimenuitem> </menuchoice>.
-				</para>
-		  </caution>
-              <para>To use the Sort plugin, perform the following steps:</para>
-		<orderedlist>
-		  <listitem>
-		    <para>Select the lines of text you want to sort.</para>
-		  </listitem>
-		  <listitem><para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Sort</guimenuitem> </menuchoice>. The <guilabel>Sort</guilabel> dialog opens.
-				</para>
-		  </listitem>
-		  <listitem><para>Choose the options you want for the sort:</para>
-		    <itemizedlist>
-    		  <listitem>
-    		    <para>To arrange the text in reverse order, select <guilabel>Reverse order</guilabel>.
-    				</para>
-    		  </listitem>
-    		  <listitem><para>To delete duplicate lines, select <guilabel>Remove duplicates</guilabel>.
-    				</para>
-    		  </listitem>
-    		  <listitem><para>To ignore case sensitivity, select <guilabel>Ignore case</guilabel>.
-    				</para>
-    		  </listitem>
-    		  <listitem><para>To have the sort ignore the characters at the start of the lines, set the first character that should be used for sorting in the <guilabel>Start at column</guilabel> spin box.
-    				</para>
-    		  </listitem>
-		    </itemizedlist>
-		  </listitem>
-		  <listitem><para>To perform the sort operation, click <guibutton>Sort</guibutton>.
-				</para>
-		  </listitem>
-		</orderedlist>
-</sect2>
+        <section xml:id="pluma-document-statistics-plugin">
+            <info>
+                <title>Document Statistics Plugin</title>
+            </info>
 
-<sect2 id="pluma-spell-checker-plugin">
-<title>Spell Checker Plugin</title>
-	<para>The <application>Spell Checker</application> plugin checks the spelling in the selected text. You can configure <application>&app;</application> to check the spelling automatically, or you can check the spelling manually, in the specified language. The language setting, and the autocheck spelling properties, apply per document. To use the Spell checker plugin, perform the following steps:</para>
-		<orderedlist>
-		  <listitem><para>Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Set Language</guimenuitem> </menuchoice> to display the <guilabel>Set language</guilabel> dialog. Select the appropriate language from the list. Click <guibutton>OK</guibutton> to close the <guilabel>Set language</guilabel> dialog.
-				</para>
-		  </listitem>
-		  <listitem><para>To check the spelling automatically, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice>. To unset the automatic spell check, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice> again. When automatic spell checking is set, an icon is displayed beside the <guimenuitem>Autocheck Spelling</guimenuitem> menu item. Automatic spell checking is unset by default, each time <application>&app;</application> starts.</para>
-                            <para>Unknown spellings are displayed in a different color, and underlined. Right-click on an unknown spelling, then select <guimenu>Spelling Suggestions</guimenu> from the popup menu:
-				</para>
-		    <itemizedlist>
-		      <listitem><para>To replace the unknown spelling with another spelling in the list, select the replacement spelling from the <guimenu>Spelling Suggestions</guimenu> popup menu.
-				</para>
-		      </listitem>
-		      <listitem><para>To add the unknown spelling to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Add</guimenuitem> </menuchoice>.
-				</para>
-		      </listitem>
-		      <listitem><para>To ignore all occurrences of the unknown spelling, so that they are no longer flagged as unknown but are not added to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Ignore All</guimenuitem> </menuchoice>. The unknown word is ignored in the current <application>&app;</application> session only.
-				</para>
-		      </listitem>
-		    </itemizedlist>
-		  </listitem>
-		  <listitem><para>To check the spelling manually, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Check Spelling</guimenuitem> </menuchoice>.
-				</para>
-				<para>If there are no spelling errors, an <guilabel>Information</guilabel> dialog displays a message stating that the document does not contain misspelled words. Click <guibutton>OK</guibutton> to close the <guilabel>Information</guilabel> dialog.
-				</para>
-				<para>If there are spelling errors, the <guilabel>Check Spelling</guilabel> dialog is displayed:
-				</para>
-		    <itemizedlist>
-		      <listitem><para>The <guilabel>Misspelled word</guilabel> is displayed at the top of the dialog.
-				</para>
-		      </listitem>
-		      <listitem><para>A suggested known spelling is displayed in the <guilabel>Change to</guilabel> text box. You can replace this with another known spelling by selecting a spelling from the <guilabel>Suggestions</guilabel> list, or you can enter text directly into the <guilabel>Change to</guilabel> text box.
-				</para>
-		      </listitem>
-		      <listitem><para>To check the spelling of the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Check Word</guibutton>. If this is a known word, the <guilabel>Suggestions</guilabel> list is replaced with the text <literal>(correct spelling)</literal>. If the word is not known, new entries appear in the <guilabel>Suggestions</guilabel> list.
-				</para>
-		      </listitem>
-		      <listitem><para>To ignore the current occurrence of the unknown word, click <guibutton>Ignore</guibutton>. To ignore all occurrences of the unknown word, click <guibutton>Ignore All</guibutton>. The unknown word is ignored in the current <application>&app;</application> session only.
-				</para>
-		      </listitem>
-		      <listitem><para>To change the current occurrence of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change</guibutton>. To change all occurrences of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change All</guibutton>.
-				</para>
-		      </listitem>
-		      <listitem><para>To add the unknown word to your personal dictionary, click <guibutton>Add word</guibutton>.
-				</para>
-		      </listitem>
-		      <listitem><para>To close the <guilabel>Check Spelling</guilabel> dialog, click <guibutton>Close</guibutton>.
-				</para>
-		      </listitem>
-		    </itemizedlist>
-		  </listitem>
-		</orderedlist>
-</sect2>
+            <para>The <application>Document Statistics</application> plugin counts the number of lines, words, characters with spaces, characters without spaces, and bytes in the current file. The plugin displays the results in a <guilabel>Document Statistics</guilabel> dialog. To use the Document Statistics plugin, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Document Statistics</guimenuitem> </menuchoice> to display the <guilabel>Document Statistics</guilabel> dialog. The <guilabel>Document Statistics</guilabel> dialog displays the following information about the file:</para>
+                    <itemizedlist>
+                        <listitem>
+                            <para>Number of lines in the current document.</para>
+                        </listitem>
+                        <listitem>
+                            <para>Number of words in the current document.</para>
+                        </listitem>
+                        <listitem>
+                            <para>Number of characters, including spaces, in the current document.</para>
+                        </listitem>
+                        <listitem>
+                            <para>Number of characters, not including spaces, in the current document.</para>
+                        </listitem>
+                        <listitem>
+                            <para>Number of bytes in the current document.</para>
+                        </listitem>
+                    </itemizedlist>
+                </listitem>
+                <listitem>
+                    <para>You can continue to update the <application>pluma</application> file while the <guilabel>Document Statistics</guilabel> dialog is open. To refresh the contents of the <guilabel>Document Statistics</guilabel> dialog, click <guibutton>Update</guibutton>.</para>
+                </listitem>
+            </orderedlist>
+        </section>
 
-<sect2 id="pluma-tag-list-plugin">
-<title>Tag List Plugin</title>
-	<para>The <application>Tag List</application> plugin allows you to insert common tags from a list in the side pane.</para>
-  <para>To use the Tag List plugin, perform the following steps:</para>
-		<orderedlist>
-		  <listitem><para>Choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice>.
-				</para>
-		  </listitem>
-		  <listitem>
-		    <para>By default, the side pane shows a tab containing a list of open documents. Click on the tab showing a + icon at the bottom of the side pane to show the tag list tab.</para>
-		  </listitem>
-		  <listitem><para>Select the appropriate tag category from the drop-down list. For example, <guilabel>HTML - Tags</guilabel>.
-				</para>
-		  </listitem>
-		  <listitem><para>Scroll through the tag list to find the required tag.
-				</para>
-		  </listitem>
-		  <listitem><para>To insert a tag at the cursor position in the current file, double-click on the tag in the tag list. You can also insert a tag as follows:</para>
-		    <itemizedlist>
-		      <listitem><para>To insert a tag in the current file and change the focus from the side pane to the display area, press <keycap>Return</keycap>.
-				</para>
-		      </listitem>
-		      <listitem><para>To insert a tag in the current file and maintain the focus on the <guilabel>Tag list plugin</guilabel> window, press <keycombo><keycap>Shift</keycap><keycap>Return</keycap></keycombo>.
-				</para>
-		      </listitem>
-		    </itemizedlist>
-		  </listitem>
-		</orderedlist>
-</sect2>
+        <section xml:id="pluma-external-tools-plugin">
+            <info>
+                <title>External Tools Plugin</title>
+            </info>
+            <para>The <application>External Tools</application> plugin allows you to execute external commands from <application>pluma</application>. You can pipe some content into a command and exploit its output (for example, <application>sed</application>), or launch a predefined command (for example, <application>make</application>).</para>
+            <para>Use the <guilabel>External Tools Manager</guilabel> to create and edit commands. To run an external command, choose it from the <guimenu>Tools</guimenu> menu.</para>
 
-</sect1>
+            <section xml:id="pluma-external-tools-plugin-builtin">
+                <info>
+                    <title>Built-in Commands</title>
+                </info>
+                <para>The following commands are provided with the <application>External Tools</application> plugin:</para>
+                <variablelist>
+                    <varlistentry>
+                        <term>Build</term>
+                        <listitem>
+                            <para>Runs <application>make</application> in the current document's directory.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Directory Listing</term>
+                        <listitem>
+                            <para>Lists the contents of the current document's directory in a new document.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Environment Variables</term>
+                        <listitem>
+                            <para>Displays the environment variables list in the bottom pane.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Grep</term>
+                        <listitem>
+                            <para>Searches for a term in all files in the current document directory, using pattern matching. Results are shown in the bottom pane.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Remove Trailing Spaces</term>
+                        <listitem>
+                            <para>Removes all spaces from the end of lines in the document.</para>
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
 
+            <section xml:id="pluma-external-tools-plugin-define">
+                <info>
+                    <title>Defining a Command</title>
+                </info>
+                <para>To add an external command, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>External Tools</guimenuitem> </menuchoice>.</para>
+                <para>In the <guilabel>External Tools Manager</guilabel> window, click <guibutton>New</guibutton>. You can specify the following details for the new command:</para>
+                <variablelist>
+                    <varlistentry>
+                        <term>Description</term>
+                        <listitem>
+                            <para>This description is shown in the statusbar when the menu command is chosen.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Accelerator</term>
+                        <listitem>
+                            <para>Enter a keyboard shortcut for the command.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Commands</term>
+                        <listitem>
+                            <para>The actual commands to be run. Several <application>pluma</application> environment variables can be used to pass content to these commands: see <xref linkend="pluma-external-tools-plugin-variables"/>.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Input</term>
+                        <listitem>
+                            <para>The content to give to the commands (as <systemitem>stdin</systemitem>): the entire text of the current document, the current selection, line, or word.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Output</term>
+                        <listitem>
+                            <para>What to do with the output of the commands: display in the bottom pane, put in a new document, or place in the current document, at the end, at the cursor position, or replacing the selection or the entire document.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Applicability</term>
+                        <listitem>
+                            <para>Determines which sort of documents can be affected by the command, for example whether saved or not, and local or remote.</para>
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
+
+            <section xml:id="pluma-external-tools-plugin-edit">
+                <info>
+                    <title>Editing and Removing Tools</title>
+                </info>
+                <para>To edit a tool, select it in the list and make changes to its properties.</para>
+                <para>To rename a tool, click it again in the list.</para>
+                <para>To restore a built-in tool that you have changed, press <guilabel>Revert</guilabel>.</para>
+                <para>To remove a tool, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in tools, only those you have created yourself.</para>
+            </section>
+
+            <section xml:id="pluma-external-tools-plugin-variables">
+                <info>
+                    <title>Variables</title>
+                </info>
+                <para>You can use the following variables in the <guilabel>Commands</guilabel> field of the command definition:</para>
+                <itemizedlist>
+                    <listitem>
+                        <para>PLUMA_CURRENT_DOCUMENT_URI</para>
+                    </listitem>
+                    <listitem>
+                        <para>PLUMA_CURRENT_DOCUMENT_NAME</para>
+                    </listitem>
+                    <listitem>
+                        <para>PLUMA_CURRENT_DOCUMENT_SCHEME</para>
+                    </listitem>
+                    <listitem>
+                        <para>PLUMA_CURRENT_DOCUMENT_PATH</para>
+                    </listitem>
+                    <listitem>
+                        <para>PLUMA_CURRENT_DOCUMENT_DIR</para>
+                    </listitem>
+                    <listitem>
+                        <para>PLUMA_DOCUMENTS_URI</para>
+                    </listitem>
+                    <listitem>
+                        <para>PLUMA_DOCUMENTS_PATH</para>
+                    </listitem>
+                </itemizedlist>
+            </section>
+        </section>
+
+        <section xml:id="pluma-file-browser-plugin">
+            <info>
+                <title>File Browser Plugin</title>
+            </info>
+            <para>The <application>File Browser</application> Plugin shows your files and folders in the side pane, allowing you to quickly open files.</para>
+            <para>To view the File Browser, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice> and then click on the tab showing the File Browser icon at the bottom of the side pane.</para>
+
+            <section xml:id="pluma-file-browser-plugin-browsing">
+                <info>
+                    <title>Browsing your Files</title>
+                </info>
+                <para>The File Browser tab initially shows your file manager bookmarks. To browse the contents of any item, double-click it.</para>
+                <para>To show a parent folder, choose from the drop-down list, or press the up arrow on the File Browser's toolbar.</para>
+                <para>To show the folder that contains the document you are currently working on, right-click in the file list and choose <guimenuitem>Set root to active document</guimenuitem>.</para>
+            </section>
+
+            <section xml:id="pluma-file-browser-plugin-open">
+                <info>
+                    <title>Opening a File</title>
+                </info>
+                <para>To open a file in <application>pluma</application>, double-click it in the file list.</para>
+            </section>
+
+            <section xml:id="pluma-file-browser-plugin-create">
+                <info>
+                    <title>Creating Files and Folders</title>
+                </info>
+                <para>To create a new, empty text file in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New File</guimenuitem>.</para>
+                <para>To create a new folder in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New Folder</guimenuitem>.</para>
+            </section>
+        </section>
+
+        <section xml:id="pluma-indent-lines-plugin">
+            <info>
+                <title>Indent Lines Plugin</title>
+            </info>
+            <para>The <application>Indent Lines</application> plugin adds or removes space from the beginning of lines of text.</para>
+            <para>To indent or unindent text, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Select the lines that you want to indent. To indent or unindent a single line, place the cursor anywhere on that line.</para>
+                </listitem>
+                <listitem>
+                    <itemizedlist>
+                        <listitem>
+                            <para>To indent the text, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Indent</guimenuitem> </menuchoice>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To remove the indentation, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Unindent</guimenuitem> </menuchoice>.</para>
+                        </listitem>
+                    </itemizedlist>
+                </listitem>
+            </orderedlist>
+            <para>The amount of space used, and whether tab character or space characters are used, depends on the <guilabel>Tab Stops</guilabel> settings in the Editor Preferences: see <xref linkend="pluma-prefs-editor"/>.</para>
+        </section>
+
+        <section xml:id="pluma-insert-date-time-plugin">
+            <info>
+                <title>Insert Date/Time Plugin</title>
+            </info>
+            <para>The <application>Insert Date/Time</application> plugin inserts the current date and time into a document. To use the Insert Date/Time plugin, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>. </para>
+                    <para>If you have not configured the Insert Date/Time plugin to automatically insert the date/time without prompting you for the format, <application>pluma</application> displays the <guilabel>Insert Date and Time</guilabel> dialog. Select the appropriate date/time format from the list. Click <guibutton>Insert</guibutton> to close the <guilabel>Insert Date and Time</guilabel> dialog. <application>pluma</application> inserts the date/time at the cursor position in the current file. </para>
+                    <para>If you have configured <application>pluma</application> to use one particular date/time format, the <guilabel>Insert Date and Time</guilabel> dialog is not displayed. The date/time is automatically entered at the cursor position in the current file. </para>
+                </listitem>
+            </orderedlist>
+
+            <section xml:id="pluma-date-time-configure">
+                <info>
+                    <title>Configuring the Insert Date/Time Plugin</title>
+                </info>
+                <para>To configure the Insert Date/Time plugin, perform the following steps:</para>
+                <orderedlist inheritnum="ignore" continuation="restarts">
+                    <listitem> 
+                        <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>.</para>
+                    </listitem>
+                    <listitem> 
+                        <para>Select the <guilabel>Plugins</guilabel> tab.</para>
+                    </listitem>
+                    <listitem> 
+                        <para>Select the <guilabel>Insert Date/Time</guilabel> plugin.</para>
+                    </listitem>
+                    <listitem> 
+                        <para>Click <guibutton>Configure Plugin</guibutton> to display the <guilabel>Configure insert date/time plugin</guilabel> dialog.</para>
+                    </listitem>
+                    <listitem> 
+                        <para>Select one of the options, as follows: </para>
+                        <itemizedlist>
+                            <listitem>
+                                <para>To specify the date/time format each time you insert the date/time, select the <guilabel>Prompt for a format</guilabel> option.</para>
+                            </listitem>
+                            <listitem>
+                                <para>To use the same <application>pluma</application>-provided date/time format each time you insert the date/time, select the <guilabel>Use the selected format</guilabel> option, then select the appropriate format from the list. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>.</para>
+                            </listitem>
+                            <listitem>
+                                <para>To use the same customized date/time format each time you insert the date/time, select the <guilabel>Use custom format</guilabel> option, then enter the appropriate format in the text box. Refer to the <link xlink:href="man:strftime">
+                                        <citerefentry>
+                                            <refentrytitle>strftime</refentrytitle>
+                                            <manvolnum>3</manvolnum>
+                                        </citerefentry>
+                                    </link> for more information on how to specify a custom format. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>.
+                                </para>
+                            </listitem>
+                        </itemizedlist>
+                    </listitem>
+                    <listitem> 
+                        <para>Click <guibutton>OK</guibutton> to close the <guilabel>Configure insert date/time plugin</guilabel> dialog.
+                        </para>
+                    </listitem>
+                    <listitem> 
+                        <para>To close the <guilabel>Preferences</guilabel> dialog, click <guibutton>Close</guibutton>.</para>
+                    </listitem>
+                </orderedlist>
+            </section>
+        </section>
+
+        <section xml:id="pluma-modelines-plugin">
+            <info>
+                <title>Modelines Plugin</title>
+            </info>
+            <para>The <application>Modelines</application> plugin allows you to set preferences for individual documents. A <firstterm>modeline</firstterm> is a line of text at the start or end of the document with settings that <application>pluma</application> recognizes.</para>
+            <para>Preferences set using modelines take precedence over the ones specified in the preference dialog.</para>
+            <para>You can set the following preferences with modelines:</para>
+            <itemizedlist>
+                <listitem>
+                    <para>Tab width</para>
+                </listitem>
+                <listitem>
+                    <para>Indent width</para>
+                </listitem>
+                <listitem>
+                    <para>Insert spaces instead of tabs</para>
+                </listitem>
+                <listitem>
+                    <para>Text Wrapping</para>
+                </listitem>
+                <listitem>
+                    <para>Right margin width</para>
+                </listitem>
+            </itemizedlist>
+            <para>The <application>Modelines</application> plugin supports a subset of the options used by other text editors <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>.</para>
+
+            <section xml:id="pluma-modelines-plugin-emacs">
+                <info>
+                    <title>Emacs Modelines</title>
+                </info>
+                <para>The first two lines of a document are scanned for <application>Emacs</application> modelines.</para>
+                <para>The <application>Emacs</application> options for tab-width, indent-offset, indent-tabs-mode and autowrap are supported. For more information, see the <link xlink:href="http://www.delorie.com/gnu/docs/emacs/emacs_486.html">GNU Emacs Manual</link>.</para>
+            </section>
+
+            <section xml:id="pluma-modelines-plugin-kate">
+                <info>
+                    <title>Kate Modelines</title>
+                </info>
+                <para>The first and last ten lines a document are scanned for <application>Kate</application> modelines.</para>
+                <para>The <application>Kate</application> options for tab-width, indent-width, space-indent, word-wrap and word-wrap-column are supported. For more information, see the <link xlink:href="http://www.kate-editor.org/article/katepart_modelines">Kate website</link>.</para>
+            </section>
+
+            <section xml:id="pluma-modelines-plugin-vim">
+                <info>
+                    <title>Vim Modelines</title>
+                </info>
+                <para>The first and last three lines a document are scanned for <application>Vim</application> modelines.</para>
+                <para>The <application>Vim</application> options for et, expandtab, ts, tabstop, sw, shiftwidth, wrap, and textwidth are supported. For more information, see the <link xlink:href="http://vimdoc.sourceforge.net/htmldoc/options.html#modeline">Vim website</link>.</para>
+            </section>
+        </section>
+
+        <section xml:id="pluma-python-console-plugin">
+            <info>
+                <title>Python Console Plugin</title>
+            </info>
+            <para>The <application>Python Console</application> Plugin allows you to run commands in the python programming language from <application>pluma</application>. Enabling the plugin adds a tab to the bottom pane. This shows recent output and a command prompt field.</para>
+            <caution>
+                <para>Commands entered into the python console are not checked before they are run. It is therefore possible to hang <application>pluma</application>, for example by entering an infinite loop.</para>
+            </caution>
+        </section>
+
+        <section xml:id="pluma-snippets-plugin">
+            <info>
+                <title>Snippets Plugin</title>
+            </info>
+            <para>The <application>Snippets</application> plugin allows you to store frequently-used pieces of text, called <firstterm>snippets</firstterm>, and insert them quickly into a document.</para>
+            <para>Snippets are specific to the language syntax of the current document. For example, when you are working with an HTML document, you can choose from a list of snippets that are useful for HTML. In addition, some snippets are global, and are available in all documents.</para>
+            <para>A number of built-in snippets are installed with <application>pluma</application>, which can be modified.</para>
+
+            <section xml:id="pluma-snippets-plugin-insert">
+                <info>
+                    <title>Inserting Snippets</title>
+                </info>
+                <para>To insert a snippet into a document, type its <firstterm>tab trigger</firstterm> and press <keycap>Tab</keycap>. A snippet's tab trigger is usually the first few letters of the snippet, or something else that is short and easy to remember.</para>
+                <para>Alternatively, press <keycombo> <keycap>Ctrl</keycap> <keycap>Space</keycap> </keycombo> to see a list of snippets you can insert.</para>
+            </section>
+
+            <section xml:id="pluma-snippets-plugin-add">
+                <info>
+                    <title>Adding Snippets</title>
+                </info>
+                <para>To create a new snippet, do the following:</para>
+                <orderedlist inheritnum="ignore" continuation="restarts">
+                    <listitem>
+                        <para>Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Manage Snippets</guimenuitem> </menuchoice>. The <guilabel>Snippets Manager</guilabel> window opens.</para>
+                    </listitem>
+                    <listitem>
+                        <para>The list of snippets is grouped by language. Select the language you want to add a snippet to, or a snippet in that language group. To add a snippet for all languages, choose Global at the top of the list. The syntax of the document you are currently working with is shown by default.</para>
+                    </listitem>
+                    <listitem>
+                        <para>Click <guibutton>New</guibutton>. A new snippet appears in the list.</para>
+                    </listitem>
+                    <listitem>
+                        <para>Enter the following information for the new snippet:</para>
+                        <variablelist>
+                            <varlistentry>
+                                <term>Name</term>
+                                <listitem>
+                                    <para>Enter a name for the snippet in the text field within the snippet list. The name of a snippet serves only as a reminder of its purpose. You can change name of a snippet you create by clicking on it in the list.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                <term>Snippet text</term>
+                                <listitem>
+                                    <para>Enter the text of the snippet in the <guilabel>Edit snippet</guilabel> text box. For special codes you can use, see <xref linkend="pluma-snippets-plugin-syntax"/>.</para>
+                                    <tip>
+                                        <para>You can switch back to the document window to copy text without closing the <guilabel>Snippets Manager</guilabel> window.</para>
+                                    </tip>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                <term>Tab Trigger</term>
+                                <listitem>
+                                    <para>Enter the tab trigger for the snippet. This is the text that you type before pressing <keycap>Tab</keycap> to insert the snippet.</para>
+                                    <para>The tag must be either a single word comprising only letters, or any single character. The <guilabel>Tab trigger</guilabel> will highlight in red if an invalid tab trigger is entered.</para>
+                                </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                <term>Shortcut key</term>
+                                <listitem>
+                                    <para>Type a shortcut key to use for inserting the snippet.</para>
+                                </listitem>
+                            </varlistentry>
+                        </variablelist>
+                    </listitem>
+                </orderedlist>
+            </section>
+
+            <section xml:id="pluma-snippets-plugin-edit">
+                <info>
+                    <title>Editing and Removing Snippets</title>
+                </info>
+                <para>To edit a snippet, select it in the list and make changes to its text and activation properties.</para>
+                <para>To rename a snippet, click it again in the list.</para>
+                <para>To restore a built-in snippet that you have changed, press <guilabel>Revert</guilabel>.</para>
+                <para>To remove a snippet, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in snippets, only those you have created yourself.</para>
+            </section>
+
+            <section xml:id="pluma-snippets-plugin-syntax">
+                <info>
+                    <title>Snippet Substitutions</title>
+                </info>
+                <para>In addition to inserting stored text, a snippet can include customizable text, or mark spaces where you can add text once the snippet is inserted in your document.</para>
+                <para>You can use the following placeholder codes in snippet text:</para>
+                <variablelist>
+                    <varlistentry>
+                        <term>Tab placeholders</term>
+                        <listitem>
+                            <para><literal>$<replaceable>n</replaceable></literal> defines a tab placeholder, where <literal>n</literal> is any number from 1 upwards. </para>
+                            <para><literal>${<replaceable>n</replaceable>:<replaceable>default</replaceable>}</literal> defines a tab placeholder with a default value.</para>
+                            <para>A tab placeholder marks a place in the snippet text where you can add extra text after the snippet is inserted.</para>
+                            <para>To use tab placeholders, insert the snippet as normal. The cursor is placed at the first tab placeholder. Type text, and press <keycap>Tab</keycap> to advance to the next tab placeholder. The number in the placeholder code defines the order in which tab advances to each place in the text.</para>
+                            <para>Press <keycombo> <keycap>Shift</keycap> <keycap>Tab</keycap> </keycombo> to return to the previous tab placeholder. Pressing <keycap>Tab</keycap> when there are no more tab placeholders moves the cursor to the end of the snippet text, or to the end placeholder if it exists.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Mirror placeholders</term>
+                        <listitem>
+                            <para>A repeated tab placeholder will mirror the placeholder already defined. This allows you to type in text only once that you want to appear several times in the snippet.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>End placeholder</term>
+                        <listitem>
+                            <para><literal>$0</literal> defines the end placeholder. This allows you to finish working with the snippet with the cursor at a point other than the end of the snippet text.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Environmental variables</term>
+                        <listitem>
+                            <para>Environmental variable such as <literal>$PATH</literal> and <literal>$HOME</literal> are substituted in snippet text. The following variables specific to <application>pluma</application> can also be used:</para>
+                            <variablelist>
+                                <varlistentry>
+                                    <term>$PLUMA_SELECTED_TEXT</term>
+                                    <listitem>
+                                        <para>The currently selected text.</para>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>$PLUMA_FILENAME</term>
+                                    <listitem>
+                                        <para>The full filename of the document, or an empty string if the document isn't saved yet.</para>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>$PLUMA_BASENAME</term>
+                                    <listitem>
+                                        <para>The basename of the filename of the document, or an empty string if the document isn't saved yet.</para>
+                                    </listitem>
+                                </varlistentry>
+                                <varlistentry>
+                                    <term>$PLUMA_CURRENT_WORD</term>
+                                    <listitem>
+                                        <para>The word at the cursor's location in the document. When this variable is used, the current word will be replaced by the snippet text.</para>
+                                    </listitem>
+                                </varlistentry>
+                            </variablelist>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Shell placeholders</term>
+                        <listitem>
+                            <para><literal>$(<replaceable>cmd</replaceable>)</literal> is replaced by the result of executing <replaceable>cmd</replaceable> in a shell. </para>
+                            <para><literal>$(<replaceable>n</replaceable>:<replaceable>cmd</replaceable>)</literal> allows you to give this placeholder a reference, where <replaceable>n</replaceable> is any number from 1 upwards. Use <literal>$<replaceable>n</replaceable></literal> to use the output from one shell placeholder as input in another.</para>
+                        </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term>Python placeholders</term>
+                        <listitem>
+                            <para><literal>$&lt;<replaceable>cmd</replaceable>&gt;</literal> is replaced by the result of evaluating <replaceable>cmd</replaceable> in the python interpreter.</para>
+                            <para><literal>$&lt;<replaceable>a</replaceable>:<replaceable>cmd</replaceable>&gt;</literal> specifies another python placeholder as a dependency, where <replaceable>a</replaceable> gives its order in the snippet. This allows you to use python functions defined in another snippet. To specify several dependencies, separate the numbers with commas thus: <literal>$&lt;<replaceable>a</replaceable>,<replaceable>b</replaceable>:<replaceable>cmd</replaceable>&gt;</literal></para>
+                            <para>To use a variable in all other python snippets, declare it as <literal>global</literal>.</para>
+                        </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
+        </section>
+
+        <section xml:id="pluma-sort-plugin">
+            <info>
+                <title>Sort Plugin</title>
+            </info>
+            <para>The <application>Sort</application> plugin arranges selected lines of text into alphabetical order.</para>
+            <caution>
+                <para>You cannot undo the Sort operation, so you should save the file before performing the sort. To revert to the saved version of the file after the sort operation, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Revert</guimenuitem> </menuchoice>.</para>
+            </caution>
+            <para>To use the Sort plugin, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Select the lines of text you want to sort.</para>
+                </listitem>
+                <listitem>
+                    <para>Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Sort</guimenuitem> </menuchoice>. The <guilabel>Sort</guilabel> dialog opens.</para>
+                </listitem>
+                <listitem>
+                    <para>Choose the options you want for the sort:</para>
+                    <itemizedlist>
+                        <listitem>
+                            <para>To arrange the text in reverse order, select <guilabel>Reverse order</guilabel>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To delete duplicate lines, select <guilabel>Remove duplicates</guilabel>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To ignore case sensitivity, select <guilabel>Ignore case</guilabel>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To have the sort ignore the characters at the start of the lines, set the first character that should be used for sorting in the <guilabel>Start at column</guilabel> spin box.</para>
+                        </listitem>
+                    </itemizedlist>
+                </listitem>
+                <listitem>
+                    <para>To perform the sort operation, click <guibutton>Sort</guibutton>.</para>
+                </listitem>
+            </orderedlist>
+        </section>
+
+        <section xml:id="pluma-spell-checker-plugin">
+            <info>
+                <title>Spell Checker Plugin</title>
+            </info>
+            <para>The <application>Spell Checker</application> plugin checks the spelling in the selected text. You can configure <application>pluma</application> to check the spelling automatically, or you can check the spelling manually, in the specified language. The language setting, and the autocheck spelling properties, apply per document. To use the Spell checker plugin, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Set Language</guimenuitem> </menuchoice> to display the <guilabel>Set language</guilabel> dialog. Select the appropriate language from the list. Click <guibutton>OK</guibutton> to close the <guilabel>Set language</guilabel> dialog.</para>
+                </listitem>
+                <listitem>
+                    <para>To check the spelling automatically, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice>. To unset the automatic spell check, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice> again. When automatic spell checking is set, an icon is displayed beside the <guimenuitem>Autocheck Spelling</guimenuitem> menu item. Automatic spell checking is unset by default, each time <application>pluma</application> starts.</para>
+                    <para>Unknown spellings are displayed in a different color, and underlined. Right-click on an unknown spelling, then select <guimenu>Spelling Suggestions</guimenu> from the popup menu:</para>
+                    <itemizedlist>
+                        <listitem>
+                            <para>To replace the unknown spelling with another spelling in the list, select the replacement spelling from the <guimenu>Spelling Suggestions</guimenu> popup menu.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To add the unknown spelling to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Add</guimenuitem> </menuchoice>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To ignore all occurrences of the unknown spelling, so that they are no longer flagged as unknown but are not added to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Ignore All</guimenuitem> </menuchoice>. The unknown word is ignored in the current <application>pluma</application> session only.</para>
+                        </listitem>
+                    </itemizedlist>
+                </listitem>
+                <listitem>
+                    <para>To check the spelling manually, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Check Spelling</guimenuitem> </menuchoice>.</para>
+                    <para>If there are no spelling errors, an <guilabel>Information</guilabel> dialog displays a message stating that the document does not contain misspelled words. Click <guibutton>OK</guibutton> to close the <guilabel>Information</guilabel> dialog.</para>
+                    <para>If there are spelling errors, the <guilabel>Check Spelling</guilabel> dialog is displayed:</para>
+                    <itemizedlist>
+                        <listitem>
+                            <para>The <guilabel>Misspelled word</guilabel> is displayed at the top of the dialog.</para>
+                        </listitem>
+                        <listitem>
+                            <para>A suggested known spelling is displayed in the <guilabel>Change to</guilabel> text box. You can replace this with another known spelling by selecting a spelling from the <guilabel>Suggestions</guilabel> list, or you can enter text directly into the <guilabel>Change to</guilabel> text box.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To check the spelling of the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Check Word</guibutton>. If this is a known word, the <guilabel>Suggestions</guilabel> list is replaced with the text <literal>(correct spelling)</literal>. If the word is not known, new entries appear in the <guilabel>Suggestions</guilabel> list.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To ignore the current occurrence of the unknown word, click <guibutton>Ignore</guibutton>. To ignore all occurrences of the unknown word, click <guibutton>Ignore All</guibutton>. The unknown word is ignored in the current <application>pluma</application> session only.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To change the current occurrence of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change</guibutton>. To change all occurrences of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change All</guibutton>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To add the unknown word to your personal dictionary, click <guibutton>Add word</guibutton>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To close the <guilabel>Check Spelling</guilabel> dialog, click <guibutton>Close</guibutton>.</para>
+                        </listitem>
+                    </itemizedlist>
+                </listitem>
+            </orderedlist>
+        </section>
+
+        <section xml:id="pluma-tag-list-plugin">
+            <info>
+                <title>Tag List Plugin</title>
+            </info>
+            <para>The <application>Tag List</application> plugin allows you to insert common tags from a list in the side pane.</para>
+            <para>To use the Tag List plugin, perform the following steps:</para>
+            <orderedlist inheritnum="ignore" continuation="restarts">
+                <listitem>
+                    <para>Choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice>.</para>
+                </listitem>
+                <listitem>
+                    <para>By default, the side pane shows a tab containing a list of open documents. Click on the tab showing a + icon at the bottom of the side pane to show the tag list tab.</para>
+                </listitem>
+                <listitem>
+                    <para>Select the appropriate tag category from the drop-down list. For example, <guilabel>HTML - Tags</guilabel>.</para>
+                </listitem>
+                <listitem>
+                    <para>Scroll through the tag list to find the required tag.</para>
+                </listitem>
+                <listitem>
+                    <para>To insert a tag at the cursor position in the current file, double-click on the tag in the tag list. You can also insert a tag as follows:</para>
+                    <itemizedlist>
+                        <listitem>
+                            <para>To insert a tag in the current file and change the focus from the side pane to the display area, press <keycap>Return</keycap>.</para>
+                        </listitem>
+                        <listitem>
+                            <para>To insert a tag in the current file and maintain the focus on the <guilabel>Tag list plugin</guilabel> window, press <keycombo> <keycap>Shift</keycap> <keycap>Return</keycap> </keycombo>.</para>
+                        </listitem>
+                    </itemizedlist>
+                </listitem>
+            </orderedlist>
+        </section>
+    </section>
 </article>

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -20,7 +20,7 @@
         <title>Pluma Manual</title>
 
         <copyright its:translate="no">
-            <year>2015</year>
+            <year>2019</year>
             <holder>MATE Documentation Project</holder> 
         </copyright>
         <copyright its:translate="no">

--- a/help/C/legal.xml
+++ b/help/C/legal.xml
@@ -1,12 +1,14 @@
-  <legalnotice id="legalnotice">
+<!-- Converted by db4-upgrade version 1.0 -->
+<legalnotice xmlns="http://docbook.org/ns/docbook"
+             xmlns:xlink="http://www.w3.org/1999/xlink"
+             version="5.0" xml:id="legalnotice" xml:lang="en">
 	<para>
 	  Permission is granted to copy, distribute and/or modify this
 	  document under the terms of the GNU Free Documentation
 	  License (GFDL), Version 1.1 or any later version published
 	  by the Free Software Foundation with no Invariant Sections,
 	  no Front-Cover Texts, and no Back-Cover Texts.  You can find
-	  a copy of the GFDL at this <ulink type="help"
-	  url="help:fdl">link</ulink> or in the file COPYING-DOCS
+	  a copy of the GFDL at this <link xlink:href="https://www.gnu.org/licenses/fdl-1.1.html">link</link> or in the file COPYING-DOCS
 	  distributed with this manual.
          </para>
          <para> This manual is part of a collection of MATE manuals
@@ -72,5 +74,8 @@
 		</listitem>
 	  </orderedlist>
 	</para>
+        <formalpara>
+            <title>Feedback</title>
+            <para>To report a bug or make a suggestion regarding the <application>pluma</application> application or this manual, follow the directions in the <link xlink:href="help:mate-user-guide/feedback">MATE Feedback Page</link>.</para>
+        </formalpara>
   </legalnotice>
-

--- a/help/pluma.pot
+++ b/help/pluma.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2019-02-04 20:02+0100\n"
+"POT-Creation-Date: 2019-02-07 00:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,289 +14,269 @@ msgctxt "_"
 msgid "translator-credits"
 msgstr ""
 
-#. (itstool) path: articleinfo/title
-#: C/index.docbook:27
+#. (itstool) path: info/title
+#: C/index.docbook:19
 msgid "Pluma Manual"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:28
+#. (itstool) path: info/copyright
+#: C/index.docbook:21
 msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:31
+#. (itstool) path: info/copyright
+#: C/index.docbook:25
 msgid "<year>2007</year> <holder>GNOME Documentation Project</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:34
+#. (itstool) path: info/copyright
+#: C/index.docbook:29
 msgid "<year>2002</year> <year>2003</year> <year>2004</year> <holder>Sun Microsystems</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:39
+#. (itstool) path: info/copyright
+#: C/index.docbook:35
 msgid "<year>2000</year> <holder>Eric Baudais</holder>"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
 #. (itstool) path: revdescription/para
-#: C/index.docbook:52
-#: C/index.docbook:225
+#: C/index.docbook:41
+#: C/index.docbook:206
 msgid "MATE Documentation Project"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
 #. (itstool) path: revdescription/para
-#: C/index.docbook:55
-#: C/index.docbook:137
-#: C/index.docbook:145
-#: C/index.docbook:153
-#: C/index.docbook:161
-#: C/index.docbook:169
-#: C/index.docbook:177
-#: C/index.docbook:185
-#: C/index.docbook:193
-#: C/index.docbook:201
-#: C/index.docbook:209
-#: C/index.docbook:217
+#: C/index.docbook:44
+#: C/index.docbook:118
+#: C/index.docbook:126
+#: C/index.docbook:134
+#: C/index.docbook:142
+#: C/index.docbook:150
+#: C/index.docbook:158
+#: C/index.docbook:166
+#: C/index.docbook:174
+#: C/index.docbook:182
+#: C/index.docbook:190
+#: C/index.docbook:198
 msgid "GNOME Documentation Project"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:61
-msgid "<firstname>MATE Documentation Project</firstname> <surname/> <affiliation> <orgname>MATE Desktop</orgname> </affiliation>"
+#: C/index.docbook:50
+msgid "<orgname>MATE Documentation Project</orgname> <affiliation> <orgname>MATE Desktop</orgname> </affiliation>"
+msgstr ""
+
+#. (itstool) path: authorgroup/author
+#: C/index.docbook:56
+msgid "<personname> <firstname>Joachim</firstname> <surname>Noreiko</surname> </personname>"
+msgstr ""
+
+#. (itstool) path: authorgroup/author
+#: C/index.docbook:62
+msgid "<orgname>GNOME Documentation Project</orgname> <affiliation> <orgname>GNOME</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
 #: C/index.docbook:68
-msgid "<firstname>Joachim</firstname> <surname>Noreiko</surname>"
+msgid "<personname> <firstname>Hal</firstname> <surname>Canary</surname> </personname> <contrib>Added the Shortcut Keys Table</contrib>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:72
-msgid "<firstname>GNOME Documentation Project</firstname> <surname/> <affiliation> <orgname>GNOME</orgname> </affiliation>"
+#: C/index.docbook:75
+msgid "<orgname>Sun Java Desktop System Documentation Team</orgname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation> <email>gdocteam@sun.com</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:79
-msgid "<firstname>Hal</firstname> <surname>Canary</surname> <contrib>Added the Shortcut Keys Table</contrib>"
+#: C/index.docbook:82
+msgid "<personname> <firstname>Eric</firstname> <surname>Baudais</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>baudais@okstate.edu</email>"
 msgstr ""
 
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:84
-msgid "<firstname>Sun Java Desktop System Documentation Team</firstname> <surname/> <affiliation> <orgname>Sun Microsystems</orgname> <address><email>gdocteam@sun.com</email></address> </affiliation>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
+#. (itstool) path: authorgroup/othercredit
 #: C/index.docbook:92
-msgid "<firstname>Eric</firstname> <surname>Baudais</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> <address> <email>baudais@okstate.edu</email> </address> </affiliation>"
+msgid "<personname> <firstname>Baris</firstname> <surname>Cicek</surname> </personname> <contrib>Provided information from earlier revisions of the pluma application.</contrib>"
 msgstr ""
 
 #. (itstool) path: authorgroup/othercredit
-#: C/index.docbook:100
-msgid "<firstname>Baris</firstname> <surname>Cicek provided information from earlier revisions of the pluma application.</surname> <contrib>Acknowledgments</contrib>"
-msgstr ""
-
-#. (itstool) path: authorgroup/othercredit
-#: C/index.docbook:105
-msgid "<firstname>Ajit</firstname> <surname>George provided information about plugins.</surname> <contrib>Acknowledgments</contrib>"
+#: C/index.docbook:99
+msgid "<personname> <firstname>George</firstname> <surname>Ajit</surname> </personname> <contrib>Provided information about plugins.</contrib>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:135
+#: C/index.docbook:117
 msgid "Eric Baudais <email>baudais@okstate.edu</email>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:131
-msgid "<revnumber>pluma V1.0</revnumber> <date>2000</date> <_:revdescription-1/>"
+#: C/index.docbook:113
+msgid "<revnumber>1.0</revnumber> <date>2000</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:144
-#: C/index.docbook:152
-#: C/index.docbook:160
-#: C/index.docbook:168
-#: C/index.docbook:176
-#: C/index.docbook:184
-#: C/index.docbook:192
-#: C/index.docbook:200
+#: C/index.docbook:125
+#: C/index.docbook:133
+#: C/index.docbook:141
+#: C/index.docbook:149
+#: C/index.docbook:157
+#: C/index.docbook:165
+#: C/index.docbook:173
+#: C/index.docbook:181
 msgid "Sun GNOME Documentation Team"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:140
-msgid "<revnumber>pluma Manual V2.0</revnumber> <date>March 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:121
+msgid "<revnumber>2.0</revnumber> <date>March 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:148
-msgid "<revnumber>pluma Manual V2.1</revnumber> <date>June 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:129
+msgid "<revnumber>2.1</revnumber> <date>June 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:156
-msgid "<revnumber>pluma Manual V2.2</revnumber> <date>August 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:137
+msgid "<revnumber>2.2</revnumber> <date>August 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:164
-msgid "<revnumber>pluma Manual V2.3</revnumber> <date>September 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:145
+msgid "<revnumber>2.3</revnumber> <date>September 2002</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:172
-msgid "<revnumber>pluma Manual V2.4</revnumber> <date>January 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:153
+msgid "<revnumber>2.4</revnumber> <date>January 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:180
-msgid "<revnumber>pluma Manual V2.5</revnumber> <date>March 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:161
+msgid "<revnumber>2.5</revnumber> <date>March 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:188
-msgid "<revnumber>pluma Manual V2.6</revnumber> <date>September 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:169
+msgid "<revnumber>2.6</revnumber> <date>September 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:196
-msgid "<revnumber>pluma Manual V2.7</revnumber> <date>March 2004</date> <_:revdescription-1/>"
+#: C/index.docbook:177
+msgid "<revnumber>2.7</revnumber> <date>March 2004</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:208
+#: C/index.docbook:189
 msgid "Sun Java Desktop System Documentation Team"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:204
-msgid "<revnumber>pluma Manual V2.8</revnumber> <date>July 2015</date> <_:revdescription-1/>"
+#: C/index.docbook:185
+msgid "<revnumber>2.8</revnumber> <date>July 2015</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:216
+#: C/index.docbook:197
 msgid "GNOME Documentation Team"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:212
-msgid "<revnumber>pluma Manual V2.9;</revnumber> <date>July 2006;</date> <_:revdescription-1/>"
+#: C/index.docbook:193
+msgid "<revnumber>2.9</revnumber> <date>July 2006</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:224
+#: C/index.docbook:205
 msgid "MATE Documentation Team"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:220
-msgid "<revnumber>pluma Manual V3.0</revnumber> <date>July 2015</date> <_:revdescription-1/>"
+#: C/index.docbook:201
+msgid "<revnumber>3.0</revnumber> <date>July 2015</date> <_:revdescription-1/>"
 msgstr ""
 
-#. (itstool) path: articleinfo/releaseinfo
-#: C/index.docbook:229
+#. (itstool) path: info/releaseinfo
+#: C/index.docbook:211
 msgid "This manual describes version 1.10 of pluma."
 msgstr ""
 
-#. (itstool) path: legalnotice/title
-#: C/index.docbook:232
-msgid "Feedback"
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/index.docbook:233
-msgid "MATE Feedback Page"
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:233
-msgid "To report a bug or make a suggestion regarding the <application>pluma</application> application or this manual, follow the directions in the <_:ulink-1/>."
-msgstr ""
-
-#. (itstool) path: abstract/para
-#: C/index.docbook:238
-msgid "pluma is a text editor for the MATE Desktop featuring basic yet robust capabilities such as printing, spell checking, find and replace, and syntax highlighting. More advanced features are available as plugins."
-msgstr ""
-
 #. (itstool) path: article/indexterm
-#: C/index.docbook:243
+#: C/index.docbook:215
 msgid "<primary>pluma</primary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:244
+#: C/index.docbook:218
 msgid "<primary>text editor</primary>"
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:249
+#. (itstool) path: info/title
+#: C/index.docbook:226
 msgid "Introduction"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:254
+#. (itstool) path: section/para
+#: C/index.docbook:230
 msgid "The <application>pluma</application> application enables you to create and edit text files."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:256
+#. (itstool) path: section/para
+#: C/index.docbook:231
 msgid "The aim of <application>pluma</application> is to be a simple and easy to use text editor. More powerful features can be enabled with different <firstterm>plugins</firstterm>, allowing a variety of tasks related to text-editing."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:260
+#. (itstool) path: info/title
+#: C/index.docbook:237
 msgid "Getting Started"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:264
+#. (itstool) path: info/title
+#: C/index.docbook:243
 msgid "Starting pluma"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:265
+#. (itstool) path: section/para
+#: C/index.docbook:245
 msgid "You can start <application>pluma</application> in the following ways:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:268
+#: C/index.docbook:248
 msgid "<guimenu>Applications</guimenu> menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:270
-msgid "Choose <menuchoice><guisubmenu>Accessories</guisubmenu><guimenuitem>Text Editor</guimenuitem></menuchoice>."
+#: C/index.docbook:251
+msgid "Choose <menuchoice> <guisubmenu>Accessories</guisubmenu> <guimenuitem>Text Editor</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:274
+#: C/index.docbook:255
 msgid "Command line"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:276
+#: C/index.docbook:257
 msgid "Execute the following command: <command>pluma</command>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:280
+#. (itstool) path: section/para
+#: C/index.docbook:261
 msgid "By default, when you open a text document in the file manager, pluma will start, and display the document."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:285
+#. (itstool) path: info/title
+#: C/index.docbook:266
 msgid "The pluma Window"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:286
+#. (itstool) path: section/para
+#: C/index.docbook:268
 msgid "When you start <application>pluma</application>, the following window is displayed:"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/index.docbook:289
+#. (itstool) path: info/title
+#: C/index.docbook:272
 msgid "pluma Window"
 msgstr ""
 
@@ -305,171 +285,160 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:293
+#: C/index.docbook:277
 msgctxt "_"
 msgid "external ref='figures/pluma_window.png' md5='48a265acf2b42650a4355f0baa1a498d'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/index.docbook:291
+#: C/index.docbook:275
 msgid "<imageobject> <imagedata fileref=\"figures/pluma_window.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows pluma main window.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:301
+#. (itstool) path: section/para
+#: C/index.docbook:286
 msgid "The <application>pluma</application> window contains the following elements:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:304
+#: C/index.docbook:289
 msgid "Menubar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:306
+#: C/index.docbook:291
 msgid "The menus on the menubar contain all the commands you need to work with files in <application>pluma</application>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:309
+#: C/index.docbook:295
 msgid "Toolbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:311
+#: C/index.docbook:297
 msgid "The toolbar contains a subset of the commands that you can access from the menubar."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:314
+#: C/index.docbook:301
 msgid "Display area"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:316
+#: C/index.docbook:303
 msgid "The display area contains the text of the file that you are editing."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:319
+#: C/index.docbook:307
 msgid "Statusbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:321
+#: C/index.docbook:309
 msgid "The statusbar displays information about current <application>pluma</application> activity and contextual information about the menu items. The statusbar also displays the following information:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:324
+#: C/index.docbook:312
 msgid "Cursor position: the line number and column number where the cursor is located."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:327
+#: C/index.docbook:315
 msgid "Edit mode: If the editor is in insert mode, the statusbar contains the text <guilabel>INS</guilabel>. If the editor is in overwrite mode, the statusbar contains the text <guilabel>OVR</guilabel>. Press the <keycap>Insert</keycap> key to change edit mode."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:332
+#: C/index.docbook:321
 msgid "Side Pane"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:334
+#: C/index.docbook:323
 msgid "The side pane displays a list of open documents, and other information depending on which plugins are enabled."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:335
-msgid "By default, the side pane is not shown. To show it, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Side Pane</guimenuitem></menuchoice>."
+#: C/index.docbook:324
+msgid "By default, the side pane is not shown. To show it, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:338
+#: C/index.docbook:328
 msgid "Bottom Pane"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:340
+#: C/index.docbook:330
 msgid "The bottom pane is used by programming tools such as the <application>Python Console</application> plugin to display output."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:341
-msgid "By default, the bottom pane is not shown. To show it, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Bottom Pane</guimenuitem></menuchoice>."
+#: C/index.docbook:331
+msgid "By default, the bottom pane is not shown. To show it, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Bottom Pane</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:345
+#. (itstool) path: section/para
+#: C/index.docbook:335
 msgid "When you right-click in the <application>pluma</application> window, the application displays a popup menu. The popup menu contains the most common text editing commands."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/index.docbook:347
-msgid "User Guide"
+#. (itstool) path: section/para
+#: C/index.docbook:336
+msgid "Like other MATE applications, actions in <application>pluma</application> can be performed in several ways: with the menu, with the toolbar, or with shortcut keys. Shortcuts keys common to all applications are listed in the <link xlink:href=\"help:mate-user-guide/shortcuts-apps\">User Guide</link>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:347
-msgid "Like other MATE applications, actions in <application>pluma</application> can be performed in several ways: with the menu, with the toolbar, or with shortcut keys. Shortcuts keys common to all applications are listed in the <_:ulink-1/>."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:352
+#. (itstool) path: info/title
+#: C/index.docbook:342
 msgid "Running pluma from a Command Line"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:353
+#. (itstool) path: section/para
+#: C/index.docbook:344
 msgid "You can run <application>pluma</application> from a command line and open a single file or multiple files. To open multiple files from a command line, type the following command, then press <keycap>Return</keycap>:"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:354
+#. (itstool) path: section/para
+#: C/index.docbook:345
 msgid "<command>pluma <replaceable>file1.txt file2.txt file3.txt</replaceable></command>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:355
+#. (itstool) path: section/para
+#: C/index.docbook:348
 msgid "Alternatively, you can specify a URI instead of a filename."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/index.docbook:356
-msgid "<citerefentry><refentrytitle>pluma</refentrytitle><manvolnum>1</manvolnum></citerefentry>"
+#. (itstool) path: section/para
+#: C/index.docbook:349
+msgid "Refer to the <link xlink:href=\"man:pluma\"> <citerefentry> <refentrytitle>pluma</refentrytitle> <manvolnum>1</manvolnum> </citerefentry> </link> man page for more information on how to run <application>pluma</application> from a command line."
 msgstr ""
 
-#. (itstool) path: sect2/para
+#. (itstool) path: info/title
 #: C/index.docbook:356
-msgid "Refer to the <_:ulink-1/> man page for more information on how to run <application>pluma</application> from a command line."
-msgstr ""
-
-#. (itstool) path: sect1/title
-#: C/index.docbook:361
 msgid "Working with Files"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:365
+#. (itstool) path: info/title
+#: C/index.docbook:362
 msgid "Creating a New Document"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:366
-msgid "To create a new document, choose <menuchoice><guimenu>File</guimenu><guimenuitem>New</guimenuitem></menuchoice>. The application displays a new blank document in the <application>pluma</application> window."
+#. (itstool) path: section/para
+#: C/index.docbook:364
+msgid "To create a new document, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>New</guimenuitem> </menuchoice>. The application displays a new blank document in the <application>pluma</application> window."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#. (itstool) path: sect3/title
-#: C/index.docbook:371
-#: C/index.docbook:1599
+#. (itstool) path: info/title
+#: C/index.docbook:370
+#: C/index.docbook:2103
 msgid "Opening a File"
 msgstr ""
 
-#. (itstool) path: sect2/para
+#. (itstool) path: section/para
 #: C/index.docbook:372
-msgid "To open a file, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Open</guimenuitem></menuchoice> to display the <guilabel>Open File</guilabel> dialog. Select the file that you want to open, then click <guibutton>Open</guibutton>. The file is displayed in the <application>pluma</application> window."
+msgid "To open a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Open</guimenuitem> </menuchoice> to display the <guilabel>Open File</guilabel> dialog. Select the file that you want to open, then click <guibutton>Open</guibutton>. The file is displayed in the <application>pluma</application> window."
 msgstr ""
 
 #. (itstool) path: imageobject/imagedata
@@ -477,2895 +446,2865 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:374
+#: C/index.docbook:375
 msgctxt "_"
 msgid "external ref='figures/pluma_recent_files_menu_icon.png' md5='62b4bede31db64226f7e7f9b18f5eb74'"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:374
-msgid "The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice><guimenu>File</guimenu></menuchoice> menu. You can also click on the <inlinemediaobject><imageobject><imagedata fileref=\"figures/pluma_recent_files_menu_icon.png\" format=\"PNG\"/></imageobject><textobject><phrase>Shows Recent Files menu icon.</phrase></textobject></inlinemediaobject> icon on the toolbar to display the list of recent files."
+#. (itstool) path: section/para
+#: C/index.docbook:373
+msgid "The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice> <guimenu>File</guimenu> </menuchoice> menu. You can also click on the <inlinemediaobject> <imageobject> <imagedata fileref=\"figures/pluma_recent_files_menu_icon.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows Recent Files menu icon.</phrase> </textobject> </inlinemediaobject> icon on the toolbar to display the list of recent files."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:376
+#: C/index.docbook:382
 msgid "You can open multiple files in <application>pluma</application>. The application adds a tab for each open file to the window. For more on this see <xref linkend=\"pluma-tabs\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:382
+#. (itstool) path: info/title
+#: C/index.docbook:389
 msgid "Saving a File"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:383
+#. (itstool) path: section/para
+#: C/index.docbook:391
 msgid "You can save files in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:385
-msgid "To save changes to an existing file, choose <menuchoice><guimenu>File</guimenu><guimenuitem>Save</guimenuitem></menuchoice>."
+#: C/index.docbook:394
+msgid "To save changes to an existing file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Save</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:387
+#: C/index.docbook:397
 msgid "To save a new file or to save an existing file under a new filename, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Save As</guimenuitem> </menuchoice>. Enter a name for the file in the <guilabel>Save As</guilabel> dialog, then click <guibutton>Save</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:389
+#: C/index.docbook:400
 msgid "To save all the files that are currently open in <application>pluma</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Save All</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:392
+#. (itstool) path: section/para
+#: C/index.docbook:403
 msgid "To close all the files that are currently open in <application>pluma</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Close All</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:397
+#. (itstool) path: info/title
+#: C/index.docbook:409
 msgid "Working With Tabs"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:399
+#. (itstool) path: section/para
+#: C/index.docbook:411
 msgid "When more than one file is open, <application>pluma</application> shows a <firstterm>tab</firstterm> for each document above the display area. To switch to another document, click on its tab."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:400
+#. (itstool) path: section/para
+#: C/index.docbook:412
 msgid "To move a document to another <application> pluma</application> window, drag the tab corresponding to the file to the window you want to move it to."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:401
+#. (itstool) path: section/para
+#: C/index.docbook:413
 msgid "To move a document to a new <application> pluma</application> window, either drag its tab to the desktop, or choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Move to New Window</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:407
+#. (itstool) path: info/title
+#: C/index.docbook:420
 msgid "Working with Text"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:411
+#. (itstool) path: info/title
+#: C/index.docbook:426
 msgid "Editing Text"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:412
+#. (itstool) path: section/para
+#: C/index.docbook:428
 msgid "You can edit the text of a file in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:414
+#: C/index.docbook:431
 msgid "Type new text from the keyboard. The blinking <firstterm>insertion cursor</firstterm> marks the point where new text appears. To change this, use the arrow keys on the keyboard or click with the mouse."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:416
+#: C/index.docbook:434
 msgid "To copy the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Copy</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:418
+#: C/index.docbook:437
 msgid "To delete the selected text from the file and move the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Cut</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:420
+#: C/index.docbook:440
 msgid "To permanently delete the selected text from the file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Delete</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:422
+#: C/index.docbook:443
 msgid "To insert the contents of the clipboard at the cursor position, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Paste</guimenuitem> </menuchoice>. You must cut or copy text before you can paste text into the file, either from pluma or another application."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:424
+#: C/index.docbook:446
 msgid "To select all the text in a file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Select All</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:430
+#. (itstool) path: info/title
+#: C/index.docbook:454
 msgid "Undoing and Redoing Changes"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:431
+#. (itstool) path: section/para
+#: C/index.docbook:456
 msgid "To undo a change you have made, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Undo</guimenuitem> </menuchoice>. To reverse this action, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Redo</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:436
+#. (itstool) path: info/title
+#: C/index.docbook:462
 msgid "Finding and Replacing"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:438
+#. (itstool) path: section/para
+#: C/index.docbook:464
 msgid "In <application>pluma</application>, there are two ways of searching for text. You can use the <guilabel>Find</guilabel> dialog to search for a specific piece of text, or <guilabel>Incremental Search</guilabel> to highlight matching text as you type it."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:443
+#. (itstool) path: info/title
+#: C/index.docbook:469
 msgid "Finding Text"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:444
+#. (itstool) path: section/para
+#: C/index.docbook:472
 msgid "To search a file for a string of text, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:446
+#: C/index.docbook:475
 msgid "Choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find</guimenuitem> </menuchoice> to display the <guilabel>Find</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:448
+#: C/index.docbook:481
 msgid "Type the string that you want to find in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend=\"pluma-find-escapes\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:450
+#: C/index.docbook:484
 msgid "Click <guibutton>Find</guibutton> to search the file for the first occurrence of the string after your current cursor position. If <application>pluma</application> finds the string, the application selects first occurrence of the string. Other occurrences of the string are highlighted."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:452
+#: C/index.docbook:487
 msgid "To find the next occurrence of the string, click <guibutton>Find</guibutton> or choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Next</guimenuitem> </menuchoice>. To find the previous occurrence of the text, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Previous</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:455
+#. (itstool) path: section/para
+#: C/index.docbook:496
 msgid "After you have closed the <guilabel>Find</guilabel> dialog, you can still move the selection to other occurrences of the text by choosing <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Next</guimenuitem> </menuchoice> and <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Previous</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:456
+#. (itstool) path: section/para
+#: C/index.docbook:503
 msgid "To remove the highlighting from the text, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Clear Highlight</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:460
+#. (itstool) path: info/title
+#: C/index.docbook:511
 msgid "Incremental Search"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:462
+#. (itstool) path: section/para
+#: C/index.docbook:515
 msgid "Incremental search highlights matching text in the document as you type it letter by letter. (This is similar to the search feature in several web browsers.)"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:463
+#. (itstool) path: section/para
+#: C/index.docbook:516
 msgid "To start an incremental search, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Incremental Search</guimenuitem> </menuchoice>. The search box appears at the top of the display area."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:464
+#. (itstool) path: section/para
+#: C/index.docbook:520
 msgid "Begin typing, and text that matches will be highlighted in the document. The first instance after the cursor position is also selected."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:465
-msgid "To advance the selection to the next match while keeping the incremental search box open, press <keycombo><keycap>Ctrl</keycap><keycap>G</keycap></keycombo>. Press <keycombo><keycap>Ctrl</keycap><keycap>Shift</keycap><keycap>G</keycap></keycombo> to go back to the previous match."
+#. (itstool) path: section/para
+#: C/index.docbook:521
+msgid "To advance the selection to the next match while keeping the incremental search box open, press <keycombo> <keycap>Ctrl</keycap> <keycap>G</keycap> </keycombo>. Press <keycombo> <keycap>Ctrl</keycap> <keycap>Shift</keycap> <keycap>G</keycap> </keycombo> to go back to the previous match."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/index.docbook:466
+#: C/index.docbook:530
 msgid "You can also use the up and down arrow keys or the mouse wheel to move the selection between matches."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:471
+#. (itstool) path: info/title
+#: C/index.docbook:537
 msgid "Replacing Text"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:473
+#. (itstool) path: section/para
+#: C/index.docbook:539
 msgid "To search a file for a string, and replace the string with an alternative string, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:475
+#: C/index.docbook:542
 msgid "Choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Replace</guimenuitem> </menuchoice> to display the <guilabel>Replace</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:477
+#: C/index.docbook:548
 msgid "Type the string that you want to find, in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend=\"pluma-find-escapes\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:478
+#: C/index.docbook:551
 msgid "Type the string that you want to use to replace the string that you find, in the <guilabel>Replace with</guilabel> field."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:482
+#. (itstool) path: section/para
+#: C/index.docbook:555
 msgid "To examine each occurrence of the string before replacing it, click <guibutton>Find</guibutton>. If <application>pluma</application> finds the string, the application selects the string. Click <guibutton>Replace</guibutton> to replace the selected occurrence of the string. To find the next occurrence of the string, click <guibutton>Find</guibutton> again."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:483
+#. (itstool) path: section/para
+#: C/index.docbook:556
 msgid "To replace all occurrences of the string throughout the document, click <guibutton>Replace All</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:488
+#. (itstool) path: info/title
+#: C/index.docbook:562
 msgid "Find and Replace Options"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:489
+#. (itstool) path: section/para
+#: C/index.docbook:565
 msgid "The <guilabel>Find</guilabel> dialog and the <guilabel>Replace</guilabel> dialog both have the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:491
+#: C/index.docbook:568
 msgid "Select the <guilabel>Match case</guilabel> option to only find occurrences of the string that match the case of the text that you type. For example, with <guilabel>Match case</guilabel> selected, \"TEXT\" will not match \"text\"."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:493
+#: C/index.docbook:571
 msgid "Select the <guilabel>Match entire word only</guilabel> option to only find occurrences of the string that match the entire words of the text that you type. For example, with <guilabel>Match entire word only</guilabel> selected, \"text\" will not match \"texture\"."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:495
+#: C/index.docbook:574
 msgid "Select the <guilabel>Search backwards</guilabel> option to search backwards towards the beginning of the document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:497
+#: C/index.docbook:577
 msgid "Select the <guilabel>Wrap around</guilabel> option to search to one end of the document and then continue the search from the other end of the file."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:504
+#. (itstool) path: info/title
+#: C/index.docbook:585
 msgid "Special Characters"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:505
+#. (itstool) path: section/para
+#: C/index.docbook:588
 msgid "You can include the following escape sequences in the text to find or replace to represent special characters:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:508
+#: C/index.docbook:591
 msgid "<literal>\\n</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:510
+#: C/index.docbook:595
 msgid "Specifies a new line."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:514
+#: C/index.docbook:599
 msgid "<literal>\\t</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:516
+#: C/index.docbook:603
 msgid "Specifies a tab character."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:520
+#: C/index.docbook:607
 msgid "<literal>\\r</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:522
+#: C/index.docbook:611
 msgid "Specifies a carriage return."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:526
+#: C/index.docbook:615
 msgid "<literal>\\\\</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:528
+#: C/index.docbook:619
 msgid "The backslash character itself must be escaped if it is being searched for. For example, if you are looking for the \"<literal>\\n</literal>\" literal, you will have to type \"\\\\n\" in the <guilabel>Search for</guilabel> field. Or if you are looking for a sequence of backslashes, you will have to double the number of searched backslashes."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:540
+#. (itstool) path: info/title
+#: C/index.docbook:632
 msgid "Positioning the Cursor on a Specific Line"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:542
+#. (itstool) path: section/para
+#: C/index.docbook:634
 msgid "To position the cursor on a specific line in the current file, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Go to Line</guimenuitem> </menuchoice>. The line number box appears at the top of the display area."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:543
+#. (itstool) path: section/para
+#: C/index.docbook:635
 msgid "Begin typing the number of the line that you want to move the cursor to and the document will scroll to the specified line."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:544
+#. (itstool) path: section/para
+#: C/index.docbook:636
 msgid "To dismiss the box and move the cursor to the specified line, press <keycap>Return</keycap>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:550
+#. (itstool) path: info/title
+#: C/index.docbook:642
 msgid "Printing"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:554
+#. (itstool) path: info/title
+#: C/index.docbook:648
 msgid "Setting the Page Options"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:556
+#. (itstool) path: section/para
+#: C/index.docbook:651
 msgid "To set the page options, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Page Setup</guimenuitem> </menuchoice> to display the <guilabel>Page Setup</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:558
+#. (itstool) path: section/para
+#: C/index.docbook:653
 msgid "The <guilabel>Page Setup</guilabel> dialog enables you to specify the following print options:"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:561
+#. (itstool) path: info/title
+#: C/index.docbook:657
 msgid "General Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:563
+#: C/index.docbook:661
 msgid "<guilabel>Print syntax highlighting</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:565
+#: C/index.docbook:665
 msgid "Select this option to print syntax highlighting. For more information about syntax highlighting, see <xref linkend=\"pluma-set-highlightmode\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:568
+#: C/index.docbook:669
 msgid "<guilabel>Print page headers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:570
+#: C/index.docbook:673
 msgid "Select this option to include a header on each page that you print. You cannot configure the header."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:573
-#: C/index.docbook:1185
+#: C/index.docbook:677
+#: C/index.docbook:1555
 msgid "<guilabel>Line Numbers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:576
+#: C/index.docbook:681
 msgid "Select the <guilabel>Print line numbers</guilabel> option to include line numbers when you print a file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:577
+#: C/index.docbook:682
 msgid "Use the <guilabel>Number every ... lines </guilabel> spin box to specify how often to print the line numbers, for example every 5 lines, every 10 lines, and so on."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:580
-#: C/index.docbook:1178
+#: C/index.docbook:686
+#: C/index.docbook:1546
 msgid "<guilabel>Text Wrapping</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:582
+#: C/index.docbook:690
 msgid "Select the <guilabel>Enable text wrapping</guilabel> option to wrap text onto the next line, at a character level, when you print a file. The application counts wrapped lines as one line for line numbering purposes."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:584
+#: C/index.docbook:691
 msgid "Select the <guilabel>Do not split words over two lines</guilabel> option to wrap text onto the next line, at a word level, when you print a file."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:592
+#. (itstool) path: info/title
+#: C/index.docbook:699
 msgid "Fonts"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:594
+#: C/index.docbook:703
 msgid "<guilabel>Body</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:596
+#: C/index.docbook:707
 msgid "Click on this button to select the font used to print the body text of a file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:599
+#: C/index.docbook:711
 msgid "<guilabel>Line numbers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:602
+#: C/index.docbook:715
 msgid "Click on this button to select the font used to print line numbers."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:605
+#: C/index.docbook:719
 msgid "<guilabel>Headers and footers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:607
+#: C/index.docbook:723
 msgid "Click on this button to select the font to use to print the headers and footers in a file."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:611
+#. (itstool) path: section/para
+#: C/index.docbook:727
 msgid "To reset the fonts to the default fonts for printing a file from <application>pluma</application>, click <guibutton>Restore Default Fonts</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:618
+#. (itstool) path: info/title
+#: C/index.docbook:734
 msgid "Printing a Document"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:619
+#. (itstool) path: section/para
+#: C/index.docbook:736
 msgid "You can use <application>pluma</application> to perform the following print operations:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:621
+#: C/index.docbook:739
 msgid "Print a document to a printer."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:623
+#: C/index.docbook:742
 msgid "Print the output of the print command to a file."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:626
+#. (itstool) path: section/para
+#: C/index.docbook:745
 msgid "If you print to a file, <application>pluma</application> sends the output of the file to a pre-press format file. The most common pre-press formats are PostScript and Portable Document Format (PDF)."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:628
+#. (itstool) path: section/para
+#: C/index.docbook:746
 msgid "To preview the pages that you want to print, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print Preview</guimenuitem> </menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:630
+#. (itstool) path: section/para
+#: C/index.docbook:747
 msgid "To print the current file to a printer or a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print</guimenuitem> </menuchoice> to display the <guilabel>Print</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:632
+#. (itstool) path: section/para
+#: C/index.docbook:748
 msgid "The <guilabel>Print</guilabel> dialog enables you to specify the following print options:"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:635
+#. (itstool) path: info/title
+#: C/index.docbook:752
 msgid "Job Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:637
+#: C/index.docbook:756
 msgid "<guilabel>Print range</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:639
+#: C/index.docbook:760
 msgid "Select one of the following options to determine how many pages to print:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:642
+#: C/index.docbook:763
 msgid "<guilabel>All</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:643
+#: C/index.docbook:766
 msgid "Select this option to print all the pages in the file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:646
+#: C/index.docbook:769
 msgid "<guilabel>Lines</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:647
+#: C/index.docbook:772
 msgid "Select this option to print the specified lines only. Use the <guilabel>From</guilabel> and <guilabel>To</guilabel> spin boxes to specify the line range."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:650
+#: C/index.docbook:775
 msgid "<guilabel>Selection</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:651
+#: C/index.docbook:778
 msgid "Select this option to print the selected text only. This option is only available if you select text."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:657
+#: C/index.docbook:784
 msgid "<guilabel>Copies</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:659
+#: C/index.docbook:788
 msgid "Use the <guilabel>Number of copies</guilabel> spin box to specify the number of copies of the file that you want to print."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:660
+#: C/index.docbook:789
 msgid "If you print multiple copies of the file, select the <guilabel>Collate</guilabel> option to collate the printed copies."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:667
+#. (itstool) path: info/title
+#: C/index.docbook:797
 msgid "Printer Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:669
+#: C/index.docbook:802
 msgid "<guilabel>Printer</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:671
+#: C/index.docbook:806
 msgid "Use this drop-down list to select the printer to which you want to print the file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:674
+#: C/index.docbook:810
 msgid "<guilabel>Settings</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:676
+#: C/index.docbook:814
 msgid "Use this drop-down list to select the printer settings."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:678
+#: C/index.docbook:815
 msgid "To configure the printer, click <guibutton>Configure</guibutton>. For example, you can enable or disable duplex printing, or schedule delayed printing, if this functionality is supported by the printer."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:682
+#: C/index.docbook:819
 msgid "<guilabel>Location</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:684
+#: C/index.docbook:823
 msgid "Use this drop-down list to select one of the following print destinations:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:689
+#: C/index.docbook:826
 msgid "<guilabel>CUPS</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:691
+#: C/index.docbook:830
 msgid "Print the file to a CUPS printer."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:695
+#: C/index.docbook:832
 msgid "If the selected printer is a CUPS printer, <guilabel>CUPS</guilabel> is the only entry in this drop-down list."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:702
+#: C/index.docbook:837
 msgid "<guilabel>lpr</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:704
+#: C/index.docbook:841
 msgid "Print the file to a printer."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:710
+#: C/index.docbook:845
 msgid "<guilabel>File</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:712
+#: C/index.docbook:849
 msgid "Print the file to a PostScript file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:715
+#: C/index.docbook:850
 msgid "Click <guibutton>Save As</guibutton> to display a dialog where you specify the name and location of the PostScript file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:721
+#: C/index.docbook:854
 msgid "<guilabel>Custom</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:723
+#: C/index.docbook:858
 msgid "Use the specified command to print the file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:726
+#: C/index.docbook:859
 msgid "Type the name of the command in the text box. Include all command-line arguments."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:734
+#: C/index.docbook:866
 msgid "<guilabel>State</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:736
-#: C/index.docbook:742
-#: C/index.docbook:748
+#: C/index.docbook:870
+#: C/index.docbook:878
+#: C/index.docbook:886
 msgid "This functionality is not supported in this version of pluma."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:740
+#: C/index.docbook:874
 msgid "<guilabel>Type</guilabel>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:746
+#: C/index.docbook:882
 msgid "<guilabel>Comment</guilabel>"
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:756
+#. (itstool) path: info/title
+#: C/index.docbook:894
 msgid "Paper Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:758
+#: C/index.docbook:899
 msgid "<guilabel>Paper size</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:760
+#: C/index.docbook:903
 msgid "Use this drop-down list to select the size of the paper to which you want to print the file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:763
+#: C/index.docbook:907
 msgid "<guilabel>Width</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:765
+#: C/index.docbook:911
 msgid "Use this spin box to specify the width of the paper. Use the adjacent drop-down list to change the measurement unit."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:768
+#: C/index.docbook:915
 msgid "<guilabel>Height</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:770
+#: C/index.docbook:919
 msgid "Use this spin box to specify the height of the paper."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:773
+#: C/index.docbook:923
 msgid "<guilabel>Feed orientation</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:775
+#: C/index.docbook:927
 msgid "Use this drop-down list to select the orientation of the paper in the printer."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:778
+#: C/index.docbook:931
 msgid "<guilabel>Page orientation</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:780
+#: C/index.docbook:935
 msgid "Use this drop-down list to select the page orientation."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:783
+#: C/index.docbook:939
 msgid "<guilabel>Layout</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:785
+#: C/index.docbook:943
 msgid "Use this drop-down list to select the page layout. A preview of each layout that you select is displayed in the <guilabel>Preview</guilabel> area."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:788
+#: C/index.docbook:947
 msgid "<guilabel>Paper tray</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:790
+#: C/index.docbook:951
 msgid "Use this drop-down list to select the paper tray."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:801
+#. (itstool) path: info/title
+#: C/index.docbook:961
 msgid "Programming Features"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:803
+#. (itstool) path: section/para
+#: C/index.docbook:963
 msgid "Several of <application>pluma</application>'s features for programming are provided with plugins. For example, the Tag List plugin provides a list of commonly-used tags for different markup languages: see <xref linkend=\"pluma-tag-list-plugin\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:807
+#. (itstool) path: info/title
+#: C/index.docbook:968
 msgid "Syntax Highlighting"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:808
+#. (itstool) path: section/para
+#: C/index.docbook:971
 msgid "Syntax highlighting makes source code easier to read by showing different parts of the text in different colors."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:810
+#. (itstool) path: section/para
+#: C/index.docbook:972
 msgid "<application>pluma</application> chooses an appropriate syntax highlighting mode based on a document's type. To override the syntax highlighting mode, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Highlight Mode</guimenuitem> </menuchoice>, then choose one of the following menu items:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:813
+#: C/index.docbook:975
 msgid "<guimenuitem>Normal</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:815
+#: C/index.docbook:979
 msgid "Do not display any syntax highlighting."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:819
+#: C/index.docbook:983
 msgid "<guisubmenu>Sources</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:821
+#: C/index.docbook:987
 msgid "Display syntax highlighting to edit source code. Use the <guisubmenu>Sources</guisubmenu> submenu to select the source code type."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:825
+#: C/index.docbook:991
 msgid "<guisubmenu>Markup</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:827
+#: C/index.docbook:995
 msgid "Display syntax highlighting to edit markup code. Use the <guisubmenu>Markup</guisubmenu> submenu to select the markup code type."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:831
+#: C/index.docbook:999
 msgid "<guisubmenu>Scripts</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:833
+#: C/index.docbook:1003
 msgid "Display syntax highlighting to edit script code. Use the <guisubmenu>Scripts</guisubmenu> submenu to select the script code type."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:837
+#: C/index.docbook:1007
 msgid "<guisubmenu>Others</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:839
+#: C/index.docbook:1011
 msgid "Display syntax highlighting to edit other types of code. Use the <guisubmenu>Others</guisubmenu> submenu to select the code type."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:847
+#. (itstool) path: info/title
+#: C/index.docbook:1020
 msgid "Piping the Output of a Command to a File"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:848
+#. (itstool) path: section/para
+#: C/index.docbook:1022
 msgid "You can use <application>pluma</application> to pipe the output of a command to a text file. For example, to pipe the output of an <command>ls</command> command to a text file, type <command>ls | pluma</command>, then press <keycap>Return</keycap>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:849
+#. (itstool) path: section/para
+#: C/index.docbook:1023
 msgid "The output of the <command>ls</command> command is displayed in a new text file in the <application>pluma</application> window."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:850
+#. (itstool) path: section/para
+#: C/index.docbook:1024
 msgid "Alternatively, you can use the <application>External tools</application> plugin to pipe command output to the current file."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:856
+#. (itstool) path: info/title
+#: C/index.docbook:1031
 msgid "Shortcut Keys"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:857
+#. (itstool) path: section/para
+#: C/index.docbook:1033
 msgid "Use shortcut keys to perform common tasks more quickly than with the mouse and menus. The following tables list all of <application>pluma</application>'s shortcut keys."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/index.docbook:858
-msgid "Desktop User Guide"
+#. (itstool) path: section/para
+#: C/index.docbook:1034
+msgid "For more on shortcut keys, see the <link xlink:href=\"help:mate-user-guide/keyboard-skills\">Desktop User Guide</link>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:858
-msgid "For more on shortcut keys, see the <_:ulink-1/>."
-msgstr ""
-
-#. (itstool) path: sect1/bridgehead
-#: C/index.docbook:861
+#. (itstool) path: section/bridgehead
+#: C/index.docbook:1037
 msgid "Tabs"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:862
+#. (itstool) path: section/para
+#: C/index.docbook:1038
 msgid "Shortcuts for tabs:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:870
-#: C/index.docbook:914
-#: C/index.docbook:970
-#: C/index.docbook:1026
-#: C/index.docbook:1054
-#: C/index.docbook:1101
-#: C/index.docbook:1144
+#: C/index.docbook:1046
+#: C/index.docbook:1116
+#: C/index.docbook:1210
+#: C/index.docbook:1304
+#: C/index.docbook:1342
+#: C/index.docbook:1420
+#: C/index.docbook:1490
 msgid "Shortcut Key"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:872
-#: C/index.docbook:916
-#: C/index.docbook:972
-#: C/index.docbook:1028
-#: C/index.docbook:1056
-#: C/index.docbook:1103
-#: C/index.docbook:1146
+#: C/index.docbook:1049
+#: C/index.docbook:1119
+#: C/index.docbook:1213
+#: C/index.docbook:1307
+#: C/index.docbook:1345
+#: C/index.docbook:1423
+#: C/index.docbook:1493
 msgid "Command"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:877
+#: C/index.docbook:1056
 msgid "Ctrl + Alt + PageUp"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:878
+#: C/index.docbook:1059
 msgid "Switches to the next tab to the left."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:881
+#: C/index.docbook:1064
 msgid "Ctrl + Alt + PageDown"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:882
+#: C/index.docbook:1067
 msgid "Switches to the next tab to the right."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:885
-#: C/index.docbook:949
+#: C/index.docbook:1072
+#: C/index.docbook:1182
 msgid "Ctrl + W"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:886
+#: C/index.docbook:1075
 msgid "Close tab."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:889
+#: C/index.docbook:1080
 msgid "Ctrl + Shift + L"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:890
+#: C/index.docbook:1083
 msgid "Save all tabs."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:893
+#: C/index.docbook:1088
 msgid "Ctrl + Shift + W"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:894
+#: C/index.docbook:1091
 msgid "Close all tabs."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:897
+#: C/index.docbook:1096
 msgid "Alt + n"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:898
+#: C/index.docbook:1099
 msgid "Jump to nth tab."
 msgstr ""
 
-#. (itstool) path: sect1/bridgehead
-#: C/index.docbook:905
+#. (itstool) path: section/bridgehead
+#: C/index.docbook:1107
 msgid "Files"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:906
+#. (itstool) path: section/para
+#: C/index.docbook:1108
 msgid "Shortcuts for working with files:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:921
+#: C/index.docbook:1126
 msgid "Ctrl + N"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:922
+#: C/index.docbook:1129
 msgid "Create a new document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:925
+#: C/index.docbook:1134
 msgid "Ctrl + O"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:926
+#: C/index.docbook:1137
 msgid "Open a document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:929
+#: C/index.docbook:1142
 msgid "Ctrl + L"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:930
+#: C/index.docbook:1145
 msgid "Open a location."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:933
+#: C/index.docbook:1150
 msgid "Ctrl + S"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:934
+#: C/index.docbook:1153
 msgid "Save the current document to disk."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:937
+#: C/index.docbook:1158
 msgid "Ctrl + Shift + S"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:938
+#: C/index.docbook:1161
 msgid "Save the current document with a new filename."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:941
+#: C/index.docbook:1166
 msgid "Ctrl + P"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:942
+#: C/index.docbook:1169
 msgid "Print the current document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:945
+#: C/index.docbook:1174
 msgid "Ctrl + Shift + P"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:946
+#: C/index.docbook:1177
 msgid "Print preview."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:950
+#: C/index.docbook:1185
 msgid "Close the current document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:953
+#: C/index.docbook:1190
 msgid "Ctrl + Q"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:954
+#: C/index.docbook:1193
 msgid "Quit Pluma."
 msgstr ""
 
-#. (itstool) path: sect1/bridgehead
-#: C/index.docbook:961
+#. (itstool) path: section/bridgehead
+#: C/index.docbook:1201
 msgid "Edit"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:962
+#. (itstool) path: section/para
+#: C/index.docbook:1202
 msgid "Shortcuts for editing documents:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:977
+#: C/index.docbook:1220
 msgid "Ctrl + Z"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:978
+#: C/index.docbook:1223
 msgid "Undo the last action."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:981
+#: C/index.docbook:1228
 msgid "Ctrl + Shift + Z"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:982
+#: C/index.docbook:1231
 msgid "Redo the last undone action ."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:985
+#: C/index.docbook:1236
 msgid "Ctrl + X"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:986
+#: C/index.docbook:1239
 msgid "Cut the selected text or region and place it on the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:989
+#: C/index.docbook:1244
 msgid "Ctrl + C"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:990
+#: C/index.docbook:1247
 msgid "Copy the selected text or region onto the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:993
+#: C/index.docbook:1252
 msgid "Ctrl + V"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:994
+#: C/index.docbook:1255
 msgid "Paste the contents of the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:997
+#: C/index.docbook:1260
 msgid "Ctrl + A"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:998
+#: C/index.docbook:1263
 msgid "Select all."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1001
+#: C/index.docbook:1268
 msgid "Ctrl + D"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1002
+#: C/index.docbook:1271
 msgid "Delete current line."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1005
+#: C/index.docbook:1276
 msgid "Alt + Up"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1006
+#: C/index.docbook:1279
 msgid "Move the selected line up one line."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1009
+#: C/index.docbook:1284
 msgid "Alt + Down"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1010
+#: C/index.docbook:1287
 msgid "Move the selected line down one line."
 msgstr ""
 
-#. (itstool) path: sect1/bridgehead
-#: C/index.docbook:1017
+#. (itstool) path: section/bridgehead
+#: C/index.docbook:1295
 msgid "Panes"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1018
+#. (itstool) path: section/para
+#: C/index.docbook:1296
 msgid "Shortcuts for showing and hiding panes:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1033
+#: C/index.docbook:1314
 msgid "F9"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1034
+#: C/index.docbook:1317
 msgid "Show/hide the side pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1037
+#: C/index.docbook:1322
 msgid "Ctrl + F9"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1038
+#: C/index.docbook:1325
 msgid "Show/hide the bottom pane."
 msgstr ""
 
-#. (itstool) path: sect1/bridgehead
-#: C/index.docbook:1045
+#. (itstool) path: section/bridgehead
+#: C/index.docbook:1333
 msgid "Search"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1046
+#. (itstool) path: section/para
+#: C/index.docbook:1334
 msgid "Shortcuts for searching:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1061
+#: C/index.docbook:1352
 msgid "Ctrl + F"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1062
+#: C/index.docbook:1355
 msgid "Find a string."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1065
+#: C/index.docbook:1360
 msgid "Ctrl + G"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1066
+#: C/index.docbook:1363
 msgid "Find the next instance of the string."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1069
+#: C/index.docbook:1368
 msgid "Ctrl + Shift + G"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1070
+#: C/index.docbook:1371
 msgid "Find the previous instance of the string."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1073
+#: C/index.docbook:1376
 msgid "Ctrl + K"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1074
+#: C/index.docbook:1379
 msgid "Interactive search."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1077
+#: C/index.docbook:1384
 msgid "Ctrl + H"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1078
+#: C/index.docbook:1387
 msgid "Search and replace."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1081
+#: C/index.docbook:1392
 msgid "Ctrl + Shift + K"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1082
+#: C/index.docbook:1395
 msgid "Clear highlight."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1085
+#: C/index.docbook:1400
 msgid "Ctrl + I"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1086
+#: C/index.docbook:1403
 msgid "Goto line."
 msgstr ""
 
-#. (itstool) path: sect1/bridgehead
-#: C/index.docbook:1092
+#. (itstool) path: section/bridgehead
+#: C/index.docbook:1411
 msgid "Tools"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1093
+#. (itstool) path: section/para
+#: C/index.docbook:1412
 msgid "Shortcuts for tools:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1108
+#: C/index.docbook:1430
 msgid "Shift + F7"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1109
+#: C/index.docbook:1433
 msgid "Check spelling (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1112
+#: C/index.docbook:1438
 msgid "Alt + F12"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1113
+#: C/index.docbook:1441
 msgid "Remove trailing spaces (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1116
+#: C/index.docbook:1446
 msgid "Ctrl + T"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1117
+#: C/index.docbook:1449
 msgid "Indent (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1120
+#: C/index.docbook:1454
 msgid "Ctrl + Shift + T"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1121
+#: C/index.docbook:1457
 msgid "Remove Indent (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1124
+#: C/index.docbook:1462
 msgid "F8"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1125
+#: C/index.docbook:1465
 msgid "Run \"make\" in current directory (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1128
+#: C/index.docbook:1470
 msgid "Ctrl + Shift + D"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1129
+#: C/index.docbook:1473
 msgid "Directory listing (with plugin)."
 msgstr ""
 
-#. (itstool) path: sect1/bridgehead
-#: C/index.docbook:1135
+#. (itstool) path: section/bridgehead
+#: C/index.docbook:1481
 msgid "Help"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1136
+#. (itstool) path: section/para
+#: C/index.docbook:1482
 msgid "Shortcuts for help:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1151
+#: C/index.docbook:1500
 msgid "F1"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1152
+#: C/index.docbook:1503
 msgid "Open <application>pluma</application>'s user manual."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1164
+#. (itstool) path: info/title
+#: C/index.docbook:1514
 msgid "Preferences"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1166
+#. (itstool) path: section/para
+#: C/index.docbook:1516
 msgid "To configure <application>pluma</application>, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>. The <guilabel>Preferences</guilabel> dialog contains the following categories:"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1175
+#. (itstool) path: info/title
+#: C/index.docbook:1542
 msgid "View Preferences"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1180
+#: C/index.docbook:1550
 msgid "Select the <guilabel>Enable text wrapping</guilabel> option to have long lines of text flow into paragraphs instead of running off the edge of the text window. This avoids having to scroll horizontally"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1181
+#: C/index.docbook:1551
 msgid "Select the <guilabel>Do not split words over two lines</guilabel> option to have the text wrapping option preserve whole words when flowing text to the next line. This makes text easier to read."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1187
+#: C/index.docbook:1559
 msgid "Select the <guilabel>Display line numbers</guilabel> option to display line numbers on the left side of the <application>pluma</application> window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1191
+#: C/index.docbook:1563
 msgid "<guilabel>Current Line</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1193
+#: C/index.docbook:1567
 msgid "Select the <guilabel>Highlight current line</guilabel> option to highlight the line where the cursor is placed."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1197
+#: C/index.docbook:1571
 msgid "<guilabel>Right Margin</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1199
+#: C/index.docbook:1575
 msgid "Select the <guilabel>Display right margin</guilabel> option to display a vertical line that indicates the right margin."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1200
+#: C/index.docbook:1576
 msgid "Use the <guilabel>Right margin at column</guilabel> spin box to specify the location of the vertical line."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1204
+#: C/index.docbook:1580
 msgid "<guilabel>Bracket Matching</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1206
+#: C/index.docbook:1584
 msgid "Select the <guilabel>Highlight matching bracket</guilabel> option to highlight the corresponding bracket when the cursor is positioned on a bracket character."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1214
+#. (itstool) path: info/title
+#: C/index.docbook:1592
 msgid "Editor Preferences"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1217
+#: C/index.docbook:1596
 msgid "<guilabel>Tabs</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1219
+#: C/index.docbook:1600
 msgid "Use the <guilabel>Tab width</guilabel> spin box to specify the width of the space that <application> pluma</application> inserts when you press the <keycap>Tab</keycap> key."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1220
+#: C/index.docbook:1601
 msgid "Select the <guilabel>Insert spaces instead of tabs</guilabel> option to specify that <application> pluma</application> inserts spaces instead of a tab character when you press the <keycap>Tab</keycap> key."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1224
+#: C/index.docbook:1605
 msgid "<guilabel>Auto Indentation</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1226
+#: C/index.docbook:1609
 msgid "Select the <guilabel>Enable auto indentation</guilabel> option to specify that the next line starts at the indentation level of the current line."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1230
+#: C/index.docbook:1613
 msgid "<guilabel>File Saving</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1232
+#: C/index.docbook:1617
 msgid "Select the <guilabel>Create a backup copy of files before saving</guilabel> option to create a backup copy of a file each time you save the file. The backup copy of the file contains a ~ at the end of the filename."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1233
+#: C/index.docbook:1618
 msgid "Select the <guilabel>Autosave files every ... minutes</guilabel> option to automatically save the current file at regular intervals. Use the spin box to specify how often you want to save the file."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1240
+#. (itstool) path: info/title
+#: C/index.docbook:1626
 msgid "Font &amp; Colors Preferences"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1243
+#: C/index.docbook:1631
 msgid "<guilabel>Font</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1245
+#: C/index.docbook:1635
 msgid "Select the <guilabel>Use default theme font</guilabel> option to use the default system font for the text in the <application>pluma</application> text window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1246
+#: C/index.docbook:1636
 msgid "The <guilabel>Editor font</guilabel> field displays the font that <application>pluma</application> uses to display text. Click on the button to specify the font type, style, and size to use for text."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1250
+#: C/index.docbook:1640
 msgid "<guilabel>Color Scheme</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1252
+#: C/index.docbook:1644
 msgid "You can choose a color scheme from the list of color schemes. By default, the following color schemes are installed:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1255
+#: C/index.docbook:1647
 msgid "<guilabel>Classic</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1257
+#: C/index.docbook:1651
 msgid "Classic color scheme based on the gvim color scheme."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1261
+#: C/index.docbook:1655
 msgid "<guilabel>Cobalt</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1263
+#: C/index.docbook:1659
 msgid "Blue based color scheme."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1267
+#: C/index.docbook:1663
 msgid "<guilabel>Kate</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1269
+#: C/index.docbook:1667
 msgid "Color scheme used in the Kate text editor."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1273
+#: C/index.docbook:1671
 msgid "<guilabel>Oblivion</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1275
+#: C/index.docbook:1675
 msgid "Dark color scheme using the Tango color palette."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1279
+#: C/index.docbook:1679
 msgid "<guilabel>Tango</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1281
+#: C/index.docbook:1683
 msgid "Color scheme using the Tango color scheme."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1285
+#: C/index.docbook:1687
 msgid "You can add a new color scheme by clicking on <guilabel>Add...</guilabel>, and selecting a color scheme file"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1286
+#: C/index.docbook:1688
 msgid "You can remove the selected color scheme by clicking on <guilabel>Remove</guilabel>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1293
+#. (itstool) path: info/title
+#: C/index.docbook:1696
 msgid "Plugins Preferences"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1294
+#. (itstool) path: section/para
+#: C/index.docbook:1698
 msgid "Plugins add extra features to <application>pluma</application>. For more information on plugins and how to use the built-in plugins, see <xref linkend=\"pluma-plugins-overview\"/>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:1298
+#. (itstool) path: info/title
+#: C/index.docbook:1703
 msgid "Enabling a Plugin"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1299
+#. (itstool) path: section/para
+#: C/index.docbook:1705
 msgid "To enable a <application>pluma</application> plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1302
-#: C/index.docbook:1323
-#: C/index.docbook:1645
+#: C/index.docbook:1708
+#: C/index.docbook:1732
+#: C/index.docbook:2161
 msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1305
-#: C/index.docbook:1326
-#: C/index.docbook:1648
+#: C/index.docbook:1711
+#: C/index.docbook:1735
+#: C/index.docbook:2164
 msgid "Select the <guilabel>Plugins</guilabel> tab."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1308
+#: C/index.docbook:1714
 msgid "Select the check box next to the name of the plugin that you want to enable."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1311
-#: C/index.docbook:1332
+#: C/index.docbook:1717
+#: C/index.docbook:1741
 msgid "Click <guibutton>Close</guibutton> to close the <guilabel>Preferences</guilabel> dialog."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:1318
+#. (itstool) path: info/title
+#: C/index.docbook:1725
 msgid "Disabling a Plugin"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1319
+#. (itstool) path: section/para
+#: C/index.docbook:1728
 msgid "A plugin remains enabled when you quit <application>pluma</application>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1320
+#. (itstool) path: section/para
+#: C/index.docbook:1729
 msgid "To disable a <application>pluma</application> plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1329
+#: C/index.docbook:1738
 msgid "Deselect the check box next to the name of the plugin that you want to disable."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1341
+#. (itstool) path: info/title
+#: C/index.docbook:1751
 msgid "Plugins"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1343
+#. (itstool) path: info/title
+#: C/index.docbook:1756
 msgid "Working with Plugins"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1344
+#. (itstool) path: section/para
+#: C/index.docbook:1758
 msgid "You can add extra features to <application>pluma</application> by enabling <firstterm>plugins</firstterm>. A plugin is a supplementary program that enhances the functionality of an application. Plugins add new items to the <application>pluma</application> menus for the new features they provide."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/index.docbook:1346
-msgid "pluma website"
+#. (itstool) path: section/para
+#: C/index.docbook:1760
+msgid "Several plugins come built-in with <application>pluma</application>, and you can install more. The <link xlink:href=\"http://live.gnome.org/Pluma/Plugins\">pluma website</link> lists third-party plugins."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1346
-msgid "Several plugins come built-in with <application>pluma</application>, and you can install more. The <_:ulink-1/> lists third-party plugins."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1347
+#. (itstool) path: section/para
+#: C/index.docbook:1761
 msgid "To enable and disable plugins, or see which plugins are currently enabled, use the <link linkend=\"pluma-prefs-plugins\">Plugins Preferences</link>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1348
+#. (itstool) path: section/para
+#: C/index.docbook:1762
 msgid "The following plugins come built-in with <application>pluma</application>:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1354
-msgid "<link linkend=\"pluma-change-case-plugin\"><application>Change Case</application></link> allows you to change the case of the selected text."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1357
-msgid "<application><link linkend=\"pluma-document-statistics-plugin\">Document Statistics</link></application> shows the number of lines, words, and characters in the document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1360
-msgid "<application><link linkend=\"pluma-external-tools-plugin\">External Tools</link></application> allows you to execute external commands from <application>pluma</application>."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1363
-msgid "<application>File Browser</application> allows you to browse your files and folders in the side pane."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1366
-msgid "<application><link linkend=\"pluma-indent-lines-plugin\">Indent Lines</link></application> adds or removes indentation from the selected lines."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1369
-msgid "<application><link linkend=\"pluma-insert-date-time-plugin\">Insert Date/Time</link></application> adds the current date and time into a document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1372
-msgid "<application><link linkend=\"pluma-modelines-plugin\">Modelines</link></application> allows you to set editing preferences for individual documents, and supports <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>-style modelines."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1375
-msgid "<application><link linkend=\"pluma-python-console-plugin\">Python Console</link></application> allows you to run commands in the python programming language."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1378
-msgid "<application><link linkend=\"pluma-snippets-plugin\">Snippets</link></application> allows you to store frequently-used pieces of text and insert them quickly into a document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1381
-msgid "<application><link linkend=\"pluma-sort-plugin\">Sort</link></application> arranges selected lines of text into alphabetical order."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1384
-msgid "<application><link linkend=\"pluma-spell-checker-plugin\">Spell Checker</link></application> corrects the spelling in the selected text, or marks errors automatically in the document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1387
-msgid "<application><link linkend=\"pluma-tag-list-plugin\">Tag List</link></application> lets you insert commonly-used tags for HTML and other languages from a list in the side pane."
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/index.docbook:1391
-msgid "<application>pluma</application> website"
-msgstr ""
-
-#. (itstool) path: note/para
-#: C/index.docbook:1391
-msgid "For more information on creating plugins, see the <_:ulink-1/>."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1395
-msgid "Change Case Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1396
-msgid "The <application>Change Case</application> plugin changes the case of the selected text."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1397
-msgid "The following items are added to the <guimenu>Edit</guimenu> menu when the <application>Change Case</application> plugin is enabled:"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1407
-msgid "Menu Item"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1409
-msgid "Action"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1411
-msgid "Example"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1416
-msgid "<menuchoice><guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu><guimenuitem>All Upper Case</guimenuitem></menuchoice>"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1418
-msgid "Change each character to uppercase."
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1419
-msgid "<literal>This text</literal> becomes <literal>THIS TEXT</literal>"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1422
-msgid "<menuchoice><guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu><guimenuitem>All Lower Case</guimenuitem></menuchoice>"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1424
-msgid "Change each character to lowercase."
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1425
-msgid "<literal>This Text</literal> becomes <literal>this text</literal>"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1428
-msgid "<menuchoice><guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu><guimenuitem>Invert Case</guimenuitem></menuchoice>"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1430
-msgid "Change each lowercase character to uppercase, and change each uppercase character to lowercase."
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1431
-msgid "<literal>This Text</literal> becomes <literal>tHIS tEXT</literal>"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1434
-msgid "<menuchoice><guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu><guimenuitem>Title Case</guimenuitem></menuchoice>"
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1436
-msgid "Change the first character of each word to uppercase."
-msgstr ""
-
-#. (itstool) path: entry/para
-#: C/index.docbook:1437
-msgid "<literal>this text</literal> becomes <literal>This Text</literal>"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1446
-msgid "Document Statistics Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1447
-msgid "The <application>Document Statistics</application> plugin counts the number of lines, words, characters with spaces, characters without spaces, and bytes in the current file. The plugin displays the results in a <guilabel>Document Statistics</guilabel> dialog. To use the Document Statistics plugin, perform the following steps:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1449
-msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Document Statistics</guimenuitem> </menuchoice> to display the <guilabel>Document Statistics</guilabel> dialog. The <guilabel>Document Statistics</guilabel> dialog displays the following information about the file:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1452
-msgid "Number of lines in the current document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1455
-msgid "Number of words in the current document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1458
-msgid "Number of characters, including spaces, in the current document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1461
-msgid "Number of characters, not including spaces, in the current document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1464
-msgid "Number of bytes in the current document."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1469
-msgid "You can continue to update the <application>pluma</application> file while the <guilabel>Document Statistics</guilabel> dialog is open. To refresh the contents of the <guilabel>Document Statistics</guilabel> dialog, click <guibutton>Update</guibutton>."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1476
-msgid "External Tools Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1477
-msgid "The <application>External Tools</application> plugin allows you to execute external commands from <application>pluma</application>. You can pipe some content into a command and exploit its output (for example, <application>sed</application>), or launch a predefined command (for example, <application>make</application>)."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1478
-msgid "Use the <guilabel>External Tools Manager</guilabel> to create and edit commands. To run an external command, choose it from the <guimenu>Tools</guimenu> menu."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1481
-msgid "Built-in Commands"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1482
-msgid "The following commands are provided with the <application>External Tools</application> plugin:"
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1484
-msgid "Build"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1486
-msgid "Runs <application>make</application> in the current document's directory."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1489
-msgid "Directory Listing"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1491
-msgid "Lists the contents of the current document's directory in a new document."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1494
-msgid "Environment Variables"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1496
-msgid "Displays the environment variables list in the bottom pane."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1499
-msgid "Grep"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1501
-msgid "Searches for a term in all files in the current document directory, using pattern matching. Results are shown in the bottom pane."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1504
-msgid "Remove Trailing Spaces"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1506
-msgid "Removes all spaces from the end of lines in the document."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1513
-msgid "Defining a Command"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1514
-msgid "To add an external command, choose <menuchoice><guimenu>Tools</guimenu><guimenuitem>External Tools</guimenuitem></menuchoice>."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1515
-msgid "In the <guilabel>External Tools Manager</guilabel> window, click <guibutton>New</guibutton>. You can specify the following details for the new command:"
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1517
-msgid "Description"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1519
-msgid "This description is shown in the statusbar when the menu command is chosen."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1522
-msgid "Accelerator"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1524
-msgid "Enter a keyboard shortcut for the command."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1527
-msgid "Commands"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1529
-msgid "The actual commands to be run. Several <application>pluma</application> environment variables can be used to pass content to these commands: see <xref linkend=\"pluma-external-tools-plugin-variables\"/>."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1532
-msgid "Input"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1534
-msgid "The content to give to the commands (as <systemitem>stdin</systemitem>): the entire text of the current document, the current selection, line, or word."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1537
-msgid "Output"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1539
-msgid "What to do with the output of the commands: display in the bottom pane, put in a new document, or place in the current document, at the end, at the cursor position, or replacing the selection or the entire document."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1542
-msgid "Applicability"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1544
-msgid "Determines which sort of documents can be affected by the command, for example whether saved or not, and local or remote."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1552
-msgid "Editing and Removing Tools"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1553
-msgid "To edit a tool, select it in the list and make changes to its properties."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1554
-msgid "To rename a tool, click it again in the list."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1555
-msgid "To restore a built-in tool that you have changed, press <guilabel>Revert</guilabel>."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1556
-msgid "To remove a tool, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in tools, only those you have created yourself."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1560
-msgid "Variables"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1561
-msgid "You can use the following variables in the <guilabel>Commands</guilabel> field of the command definition:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1564
-msgid "PLUMA_CURRENT_DOCUMENT_URI"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1567
-msgid "PLUMA_CURRENT_DOCUMENT_NAME"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1570
-msgid "PLUMA_CURRENT_DOCUMENT_SCHEME"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1573
-msgid "PLUMA_CURRENT_DOCUMENT_PATH"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1576
-msgid "PLUMA_CURRENT_DOCUMENT_DIR"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1579
-msgid "PLUMA_DOCUMENTS_URI"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1582
-msgid "PLUMA_DOCUMENTS_PATH"
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1589
-msgid "File Browser Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1590
-msgid "The <application>File Browser</application> Plugin shows your files and folders in the side pane, allowing you to quickly open files."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1591
-msgid "To view the File Browser, choose <menuchoice><guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice> and then click on the tab showing the File Browser icon at the bottom of the side pane."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1593
-msgid "Browsing your Files"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1594
-msgid "The File Browser tab initially shows your file manager bookmarks. To browse the contents of any item, double-click it."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1595
-msgid "To show a parent folder, choose from the drop-down list, or press the up arrow on the File Browser's toolbar."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1596
-msgid "To show the folder that contains the document you are currently working on, right-click in the file list and choose <guimenuitem>Set root to active document</guimenuitem>."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1600
-msgid "To open a file in <application>pluma</application>, double-click it in the file list."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1603
-msgid "Creating Files and Folders"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1604
-msgid "To create a new, empty text file in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New File</guimenuitem>."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1605
-msgid "To create a new folder in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New Folder</guimenuitem>."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1610
-msgid "Indent Lines Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1611
-msgid "The <application>Indent Lines</application> plugin adds or removes space from the beginning of lines of text."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1612
-msgid "To indent or unindent text, perform the following steps:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1614
-msgid "Select the lines that you want to indent. To indent or unindent a single line, place the cursor anywhere on that line."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1619
-msgid "To indent the text, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Indent</guimenuitem> </menuchoice>."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1622
-msgid "To remove the indentation, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Unindent</guimenuitem> </menuchoice>."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1627
-msgid "The amount of space used, and whether tab character or space characters are used, depends on the <guilabel>Tab Stops</guilabel> settings in the Editor Preferences: see <xref linkend=\"pluma-prefs-editor\"/>."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1632
-msgid "Insert Date/Time Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1633
-msgid "The <application>Insert Date/Time</application> plugin inserts the current date and time into a document. To use the Insert Date/Time plugin, perform the following steps:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1635
-msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1636
-msgid "If you have not configured the Insert Date/Time plugin to automatically insert the date/time without prompting you for the format, <application>pluma</application> displays the <guilabel>Insert Date and Time</guilabel> dialog. Select the appropriate date/time format from the list. Click <guibutton>Insert</guibutton> to close the <guilabel>Insert Date and Time</guilabel> dialog. <application>pluma</application> inserts the date/time at the cursor position in the current file."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1637
-msgid "If you have configured <application>pluma</application> to use one particular date/time format, the <guilabel>Insert Date and Time</guilabel> dialog is not displayed. The date/time is automatically entered at the cursor position in the current file."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1642
-msgid "Configuring the Insert Date/Time Plugin"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1643
-msgid "To configure the Insert Date/Time plugin, perform the following steps:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1651
-msgid "Select the <guilabel>Insert Date/Time</guilabel> plugin."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1654
-msgid "Click <guibutton>Configure Plugin</guibutton> to display the <guilabel>Configure insert date/time plugin</guilabel> dialog."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1657
-msgid "Select one of the options, as follows:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1659
-msgid "To specify the date/time format each time you insert the date/time, select the <guilabel>Prompt for a format</guilabel> option."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1662
-msgid "To use the same <application>pluma</application>-provided date/time format each time you insert the date/time, select the <guilabel>Use the selected format</guilabel> option, then select the appropriate format from the list. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/index.docbook:1665
-msgid "<citerefentry><refentrytitle>strftime</refentrytitle><manvolnum>3</manvolnum></citerefentry>"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1665
-msgid "To use the same customized date/time format each time you insert the date/time, select the <guilabel>Use custom format</guilabel> option, then enter the appropriate format in the text box. Refer to the <_:ulink-1/> for more information on how to specify a custom format. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1670
-msgid "Click <guibutton>OK</guibutton> to close the <guilabel>Configure insert date/time plugin</guilabel> dialog."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1673
-msgid "To close the <guilabel>Preferences</guilabel> dialog, click <guibutton>Close</guibutton>."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1680
-msgid "Modelines Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1681
-msgid "The <application>Modelines</application> plugin allows you to set preferences for individual documents. A <firstterm>modeline</firstterm> is a line of text at the start or end of the document with settings that <application>pluma</application> recognizes."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1682
-msgid "Preferences set using modelines take precedence over the ones specified in the preference dialog."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1683
-msgid "You can set the following preferences with modelines:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1686
-msgid "Tab width"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1689
-msgid "Indent width"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1692
-msgid "Insert spaces instead of tabs"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1695
-msgid "Text Wrapping"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1698
-msgid "Right margin width"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1702
-msgid "The <application>Modelines</application> plugin supports a subset of the options used by other text editors <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1705
-msgid "Emacs Modelines"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1706
-msgid "The first two lines of a document are scanned for <application>Emacs</application> modelines."
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/index.docbook:1707
-msgid "GNU Emacs Manual"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1707
-msgid "The <application>Emacs</application> options for tab-width, indent-offset, indent-tabs-mode and autowrap are supported. For more information, see the <_:ulink-1/>."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1710
-msgid "Kate Modelines"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1711
-msgid "The first and last ten lines a document are scanned for <application>Kate</application> modelines."
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/index.docbook:1712
-msgid "Kate website"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1712
-msgid "The <application>Kate</application> options for tab-width, indent-width, space-indent, word-wrap and word-wrap-column are supported. For more information, see the <_:ulink-1/>."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1715
-msgid "Vim Modelines"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1716
-msgid "The first and last three lines a document are scanned for <application>Vim</application> modelines."
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/index.docbook:1717
-msgid "Vim website"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1717
-msgid "The <application>Vim</application> options for et, expandtab, ts, tabstop, sw, shiftwidth, wrap, and textwidth are supported. For more information, see the <_:ulink-1/>."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1722
-msgid "Python Console Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1723
-msgid "The <application>Python Console</application> Plugin allows you to run commands in the python programming language from <application>pluma</application>. Enabling the plugin adds a tab to the bottom pane. This shows recent output and a command prompt field."
-msgstr ""
-
-#. (itstool) path: caution/para
-#: C/index.docbook:1724
-msgid "Commands entered into the python console are not checked before they are run. It is therefore possible to hang <application>pluma</application>, for example by entering an infinite loop."
-msgstr ""
-
-#. (itstool) path: sect2/title
-#: C/index.docbook:1728
-msgid "Snippets Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1729
-msgid "The <application>Snippets</application> plugin allows you to store frequently-used pieces of text, called <firstterm>snippets</firstterm>, and insert them quickly into a document."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1730
-msgid "Snippets are specific to the language syntax of the current document. For example, when you are working with an HTML document, you can choose from a list of snippets that are useful for HTML. In addition, some snippets are global, and are available in all documents."
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1731
-msgid "A number of built-in snippets are installed with <application>pluma</application>, which can be modified."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1734
-msgid "Inserting Snippets"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1735
-msgid "To insert a snippet into a document, type its <firstterm>tab trigger</firstterm> and press <keycap>Tab</keycap>. A snippet's tab trigger is usually the first few letters of the snippet, or something else that is short and easy to remember."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1736
-msgid "Alternatively, press <keycombo><keycap>Ctrl</keycap><keycap>Space</keycap></keycombo> to see a list of snippets you can insert."
-msgstr ""
-
-#. (itstool) path: sect3/title
-#: C/index.docbook:1740
-msgid "Adding Snippets"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1741
-msgid "To create a new snippet, do the following:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1744
-msgid "Choose <menuchoice><guimenu>Tools</guimenu><guimenuitem>Manage Snippets</guimenuitem></menuchoice>. The <guilabel>Snippets Manager</guilabel> window opens."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1747
-msgid "The list of snippets is grouped by language. Select the language you want to add a snippet to, or a snippet in that language group. To add a snippet for all languages, choose Global at the top of the list. The syntax of the document you are currently working with is shown by default."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1750
-msgid "Click <guibutton>New</guibutton>. A new snippet appears in the list."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1753
-msgid "Enter the following information for the new snippet:"
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1755
-msgid "Name"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1757
-msgid "Enter a name for the snippet in the text field within the snippet list. The name of a snippet serves only as a reminder of its purpose. You can change name of a snippet you create by clicking on it in the list."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1760
-msgid "Snippet text"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1762
-msgid "Enter the text of the snippet in the <guilabel>Edit snippet</guilabel> text box. For special codes you can use, see <xref linkend=\"pluma-snippets-plugin-syntax\"/>."
-msgstr ""
-
-#. (itstool) path: tip/para
-#: C/index.docbook:1763
-msgid "You can switch back to the document window to copy text without closing the <guilabel>Snippets Manager</guilabel> window."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1766
-msgid "Tab Trigger"
-msgstr ""
-
-#. (itstool) path: listitem/para
 #: C/index.docbook:1768
-msgid "Enter the tab trigger for the snippet. This is the text that you type before pressing <keycap>Tab</keycap> to insert the snippet."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1769
-msgid "The tag must be either a single word comprising only letters, or any single character. The <guilabel>Tab trigger</guilabel> will highlight in red if an invalid tab trigger is entered."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1772
-msgid "Shortcut key"
+msgid "<link linkend=\"pluma-change-case-plugin\"> <application>Change Case</application> </link> allows you to change the case of the selected text."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1774
-msgid "Type a shortcut key to use for inserting the snippet."
+msgid "<application> <link linkend=\"pluma-document-statistics-plugin\">Document Statistics</link> </application> shows the number of lines, words, and characters in the document."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:1783
-msgid "Editing and Removing Snippets"
+#. (itstool) path: listitem/para
+#: C/index.docbook:1780
+msgid "<application> <link linkend=\"pluma-external-tools-plugin\">External Tools</link> </application> allows you to execute external commands from <application>pluma</application>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1784
-msgid "To edit a snippet, select it in the list and make changes to its text and activation properties."
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1785
-msgid "To rename a snippet, click it again in the list."
-msgstr ""
-
-#. (itstool) path: sect3/para
+#. (itstool) path: listitem/para
 #: C/index.docbook:1786
-msgid "To restore a built-in snippet that you have changed, press <guilabel>Revert</guilabel>."
+msgid "<application>File Browser</application> allows you to browse your files and folders in the side pane."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1787
-msgid "To remove a snippet, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in snippets, only those you have created yourself."
+#. (itstool) path: listitem/para
+#: C/index.docbook:1790
+msgid "<application> <link linkend=\"pluma-indent-lines-plugin\">Indent Lines</link> </application> adds or removes indentation from the selected lines."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:1791
-msgid "Snippet Substitutions"
-msgstr ""
-
-#. (itstool) path: sect3/para
-#: C/index.docbook:1792
-msgid "In addition to inserting stored text, a snippet can include customizable text, or mark spaces where you can add text once the snippet is inserted in your document."
-msgstr ""
-
-#. (itstool) path: sect3/para
+#. (itstool) path: listitem/para
 #: C/index.docbook:1796
-msgid "You can use the following placeholder codes in snippet text:"
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1798
-msgid "Tab placeholders"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1800
-msgid "<literal>$<replaceable>n</replaceable></literal> defines a tab placeholder, where <literal>n</literal> is any number from 1 upwards."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1801
-msgid "<literal>${<replaceable>n</replaceable>:<replaceable>default</replaceable>}</literal> defines a tab placeholder with a default value."
+msgid "<application> <link linkend=\"pluma-insert-date-time-plugin\">Insert Date/Time</link> </application> adds the current date and time into a document."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1802
-msgid "A tab placeholder marks a place in the snippet text where you can add extra text after the snippet is inserted."
+msgid "<application> <link linkend=\"pluma-modelines-plugin\">Modelines</link> </application> allows you to set editing preferences for individual documents, and supports <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>-style modelines."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1803
-msgid "To use tab placeholders, insert the snippet as normal. The cursor is placed at the first tab placeholder. Type text, and press <keycap>Tab</keycap> to advance to the next tab placeholder. The number in the placeholder code defines the order in which tab advances to each place in the text."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1804
-msgid "Press <keycombo><keycap>Shift</keycap><keycap>Tab</keycap></keycombo> to return to the previous tab placeholder. Pressing <keycap>Tab</keycap> when there are no more tab placeholders moves the cursor to the end of the snippet text, or to the end placeholder if it exists."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1807
-msgid "Mirror placeholders"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1809
-msgid "A repeated tab placeholder will mirror the placeholder already defined. This allows you to type in text only once that you want to appear several times in the snippet."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1812
-msgid "End placeholder"
+#: C/index.docbook:1808
+msgid "<application> <link linkend=\"pluma-python-console-plugin\">Python Console</link> </application> allows you to run commands in the python programming language."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1814
-msgid "<literal>$0</literal> defines the end placeholder. This allows you to finish working with the snippet with the cursor at a point other than the end of the snippet text."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1817
-msgid "Environmental variables"
+msgid "<application> <link linkend=\"pluma-snippets-plugin\">Snippets</link> </application> allows you to store frequently-used pieces of text and insert them quickly into a document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1819
-msgid "Environmental variable such as <literal>$PATH</literal> and <literal>$HOME</literal> are substituted in snippet text. The following variables specific to <application>pluma</application> can also be used:"
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1821
-msgid "$PLUMA_SELECTED_TEXT"
+#: C/index.docbook:1820
+msgid "<application> <link linkend=\"pluma-sort-plugin\">Sort</link> </application> arranges selected lines of text into alphabetical order."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1823
-msgid "The currently selected text."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
 #: C/index.docbook:1826
-msgid "$PLUMA_FILENAME"
+msgid "<application> <link linkend=\"pluma-spell-checker-plugin\">Spell Checker</link> </application> corrects the spelling in the selected text, or marks errors automatically in the document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1828
-msgid "The full filename of the document, or an empty string if the document isn't saved yet."
+#: C/index.docbook:1832
+msgid "<application> <link linkend=\"pluma-tag-list-plugin\">Tag List</link> </application> lets you insert commonly-used tags for HTML and other languages from a list in the side pane."
 msgstr ""
 
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1831
-msgid "$PLUMA_BASENAME"
+#. (itstool) path: note/para
+#: C/index.docbook:1840
+msgid "For more information on creating plugins, see the <link xlink:href=\"http://live.gnome.org/Pluma/Plugins\"> <application>pluma</application> website</link>."
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1833
-msgid "The basename of the filename of the document, or an empty string if the document isn't saved yet."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1836
-msgid "$PLUMA_CURRENT_WORD"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1838
-msgid "The word at the cursor's location in the document. When this variable is used, the current word will be replaced by the snippet text."
-msgstr ""
-
-#. (itstool) path: varlistentry/term
+#. (itstool) path: info/title
 #: C/index.docbook:1846
-msgid "Shell placeholders"
+msgid "Change Case Plugin"
 msgstr ""
 
-#. (itstool) path: listitem/para
+#. (itstool) path: section/para
 #: C/index.docbook:1848
-msgid "<literal>$(<replaceable>cmd</replaceable>)</literal> is replaced by the result of executing <replaceable>cmd</replaceable> in a shell."
+msgid "The <application>Change Case</application> plugin changes the case of the selected text."
 msgstr ""
 
-#. (itstool) path: listitem/para
+#. (itstool) path: section/para
 #: C/index.docbook:1849
-msgid "<literal>$(<replaceable>n</replaceable>:<replaceable>cmd</replaceable>)</literal> allows you to give this placeholder a reference, where <replaceable>n</replaceable> is any number from 1 upwards. Use <literal>$<replaceable>n</replaceable></literal> to use the output from one shell placeholder as input in another."
+msgid "The following items are added to the <guimenu>Edit</guimenu> menu when the <application>Change Case</application> plugin is enabled:"
 msgstr ""
 
-#. (itstool) path: varlistentry/term
-#: C/index.docbook:1852
-msgid "Python placeholders"
+#. (itstool) path: entry/para
+#: C/index.docbook:1858
+msgid "Menu Item"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1854
-msgid "<literal>$&lt;<replaceable>cmd</replaceable>&gt;</literal> is replaced by the result of evaluating <replaceable>cmd</replaceable> in the python interpreter."
+#. (itstool) path: entry/para
+#: C/index.docbook:1861
+msgid "Action"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1855
-msgid "<literal>$&lt;<replaceable>a</replaceable>:<replaceable>cmd</replaceable>&gt;</literal> specifies another python placeholder as a dependency, where <replaceable>a</replaceable> gives its order in the snippet. This allows you to use python functions defined in another snippet. To specify several dependencies, separate the numbers with commas thus: <literal>$&lt;<replaceable>a</replaceable>,<replaceable>b</replaceable>:<replaceable>cmd</replaceable>&gt;</literal>"
+#. (itstool) path: entry/para
+#: C/index.docbook:1864
+msgid "Example"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1856
-msgid "To use a variable in all other python snippets, declare it as <literal>global</literal>."
+#. (itstool) path: entry/para
+#: C/index.docbook:1871
+msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>All Upper Case</guimenuitem> </menuchoice>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1865
-msgid "Sort Plugin"
+#. (itstool) path: entry/para
+#: C/index.docbook:1874
+msgid "Change each character to uppercase."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1866
-msgid "The <application>Sort</application> plugin arranges selected lines of text into alphabetical order."
+#. (itstool) path: entry/para
+#: C/index.docbook:1877
+msgid "<literal>This text</literal> becomes <literal>THIS TEXT</literal>"
 msgstr ""
 
-#. (itstool) path: caution/para
-#: C/index.docbook:1867
-msgid "You cannot undo the Sort operation, so you should save the file before performing the sort. To revert to the saved version of the file after the sort operation, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Revert</guimenuitem> </menuchoice>."
+#. (itstool) path: entry/para
+#: C/index.docbook:1882
+msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>All Lower Case</guimenuitem> </menuchoice>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1870
-msgid "To use the Sort plugin, perform the following steps:"
+#. (itstool) path: entry/para
+#: C/index.docbook:1885
+msgid "Change each character to lowercase."
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1873
-msgid "Select the lines of text you want to sort."
+#. (itstool) path: entry/para
+#: C/index.docbook:1888
+msgid "<literal>This Text</literal> becomes <literal>this text</literal>"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1875
-msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Sort</guimenuitem> </menuchoice>. The <guilabel>Sort</guilabel> dialog opens."
+#. (itstool) path: entry/para
+#: C/index.docbook:1893
+msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>Invert Case</guimenuitem> </menuchoice>"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1878
-msgid "Choose the options you want for the sort:"
+#. (itstool) path: entry/para
+#: C/index.docbook:1896
+msgid "Change each lowercase character to uppercase, and change each uppercase character to lowercase."
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1881
-msgid "To arrange the text in reverse order, select <guilabel>Reverse order</guilabel>."
+#. (itstool) path: entry/para
+#: C/index.docbook:1899
+msgid "<literal>This Text</literal> becomes <literal>tHIS tEXT</literal>"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1884
-msgid "To delete duplicate lines, select <guilabel>Remove duplicates</guilabel>."
+#. (itstool) path: entry/para
+#: C/index.docbook:1904
+msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>Title Case</guimenuitem> </menuchoice>"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1887
-msgid "To ignore case sensitivity, select <guilabel>Ignore case</guilabel>."
+#. (itstool) path: entry/para
+#: C/index.docbook:1907
+msgid "Change the first character of each word to uppercase."
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1890
-msgid "To have the sort ignore the characters at the start of the lines, set the first character that should be used for sorting in the <guilabel>Start at column</guilabel> spin box."
+#. (itstool) path: entry/para
+#: C/index.docbook:1910
+msgid "<literal>this text</literal> becomes <literal>This Text</literal>"
 msgstr ""
 
-#. (itstool) path: listitem/para
-#: C/index.docbook:1895
-msgid "To perform the sort operation, click <guibutton>Sort</guibutton>."
+#. (itstool) path: info/title
+#: C/index.docbook:1921
+msgid "Document Statistics Plugin"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1902
-msgid "Spell Checker Plugin"
-msgstr ""
-
-#. (itstool) path: sect2/para
-#: C/index.docbook:1903
-msgid "The <application>Spell Checker</application> plugin checks the spelling in the selected text. You can configure <application>pluma</application> to check the spelling automatically, or you can check the spelling manually, in the specified language. The language setting, and the autocheck spelling properties, apply per document. To use the Spell checker plugin, perform the following steps:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1905
-msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Set Language</guimenuitem> </menuchoice> to display the <guilabel>Set language</guilabel> dialog. Select the appropriate language from the list. Click <guibutton>OK</guibutton> to close the <guilabel>Set language</guilabel> dialog."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1908
-msgid "To check the spelling automatically, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice>. To unset the automatic spell check, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice> again. When automatic spell checking is set, an icon is displayed beside the <guimenuitem>Autocheck Spelling</guimenuitem> menu item. Automatic spell checking is unset by default, each time <application>pluma</application> starts."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1909
-msgid "Unknown spellings are displayed in a different color, and underlined. Right-click on an unknown spelling, then select <guimenu>Spelling Suggestions</guimenu> from the popup menu:"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1912
-msgid "To replace the unknown spelling with another spelling in the list, select the replacement spelling from the <guimenu>Spelling Suggestions</guimenu> popup menu."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1915
-msgid "To add the unknown spelling to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Add</guimenuitem> </menuchoice>."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1918
-msgid "To ignore all occurrences of the unknown spelling, so that they are no longer flagged as unknown but are not added to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Ignore All</guimenuitem> </menuchoice>. The unknown word is ignored in the current <application>pluma</application> session only."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1923
-msgid "To check the spelling manually, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Check Spelling</guimenuitem> </menuchoice>."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:1925
-msgid "If there are no spelling errors, an <guilabel>Information</guilabel> dialog displays a message stating that the document does not contain misspelled words. Click <guibutton>OK</guibutton> to close the <guilabel>Information</guilabel> dialog."
+#. (itstool) path: section/para
+#: C/index.docbook:1924
+msgid "The <application>Document Statistics</application> plugin counts the number of lines, words, characters with spaces, characters without spaces, and bytes in the current file. The plugin displays the results in a <guilabel>Document Statistics</guilabel> dialog. To use the Document Statistics plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1927
-msgid "If there are spelling errors, the <guilabel>Check Spelling</guilabel> dialog is displayed:"
+msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Document Statistics</guimenuitem> </menuchoice> to display the <guilabel>Document Statistics</guilabel> dialog. The <guilabel>Document Statistics</guilabel> dialog displays the following information about the file:"
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1930
-msgid "The <guilabel>Misspelled word</guilabel> is displayed at the top of the dialog."
+msgid "Number of lines in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1933
-msgid "A suggested known spelling is displayed in the <guilabel>Change to</guilabel> text box. You can replace this with another known spelling by selecting a spelling from the <guilabel>Suggestions</guilabel> list, or you can enter text directly into the <guilabel>Change to</guilabel> text box."
+msgid "Number of words in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1936
-msgid "To check the spelling of the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Check Word</guibutton>. If this is a known word, the <guilabel>Suggestions</guilabel> list is replaced with the text <literal>(correct spelling)</literal>. If the word is not known, new entries appear in the <guilabel>Suggestions</guilabel> list."
+msgid "Number of characters, including spaces, in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1939
-msgid "To ignore the current occurrence of the unknown word, click <guibutton>Ignore</guibutton>. To ignore all occurrences of the unknown word, click <guibutton>Ignore All</guibutton>. The unknown word is ignored in the current <application>pluma</application> session only."
+msgid "Number of characters, not including spaces, in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
 #: C/index.docbook:1942
+msgid "Number of bytes in the current document."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:1947
+msgid "You can continue to update the <application>pluma</application> file while the <guilabel>Document Statistics</guilabel> dialog is open. To refresh the contents of the <guilabel>Document Statistics</guilabel> dialog, click <guibutton>Update</guibutton>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:1954
+msgid "External Tools Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:1956
+msgid "The <application>External Tools</application> plugin allows you to execute external commands from <application>pluma</application>. You can pipe some content into a command and exploit its output (for example, <application>sed</application>), or launch a predefined command (for example, <application>make</application>)."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:1957
+msgid "Use the <guilabel>External Tools Manager</guilabel> to create and edit commands. To run an external command, choose it from the <guimenu>Tools</guimenu> menu."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:1961
+msgid "Built-in Commands"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:1963
+msgid "The following commands are provided with the <application>External Tools</application> plugin:"
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:1966
+msgid "Build"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:1968
+msgid "Runs <application>make</application> in the current document's directory."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:1972
+msgid "Directory Listing"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:1974
+msgid "Lists the contents of the current document's directory in a new document."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:1978
+msgid "Environment Variables"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:1980
+msgid "Displays the environment variables list in the bottom pane."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:1984
+msgid "Grep"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:1986
+msgid "Searches for a term in all files in the current document directory, using pattern matching. Results are shown in the bottom pane."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:1990
+msgid "Remove Trailing Spaces"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:1992
+msgid "Removes all spaces from the end of lines in the document."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2000
+msgid "Defining a Command"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2002
+msgid "To add an external command, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>External Tools</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2003
+msgid "In the <guilabel>External Tools Manager</guilabel> window, click <guibutton>New</guibutton>. You can specify the following details for the new command:"
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2006
+msgid "Description"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2008
+msgid "This description is shown in the statusbar when the menu command is chosen."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2012
+msgid "Accelerator"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2014
+msgid "Enter a keyboard shortcut for the command."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2018
+msgid "Commands"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2020
+msgid "The actual commands to be run. Several <application>pluma</application> environment variables can be used to pass content to these commands: see <xref linkend=\"pluma-external-tools-plugin-variables\"/>."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2024
+msgid "Input"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2026
+msgid "The content to give to the commands (as <systemitem>stdin</systemitem>): the entire text of the current document, the current selection, line, or word."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2030
+msgid "Output"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2032
+msgid "What to do with the output of the commands: display in the bottom pane, put in a new document, or place in the current document, at the end, at the cursor position, or replacing the selection or the entire document."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2036
+msgid "Applicability"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2038
+msgid "Determines which sort of documents can be affected by the command, for example whether saved or not, and local or remote."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2046
+msgid "Editing and Removing Tools"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2048
+msgid "To edit a tool, select it in the list and make changes to its properties."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2049
+msgid "To rename a tool, click it again in the list."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2050
+msgid "To restore a built-in tool that you have changed, press <guilabel>Revert</guilabel>."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2051
+msgid "To remove a tool, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in tools, only those you have created yourself."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2056
+msgid "Variables"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2058
+msgid "You can use the following variables in the <guilabel>Commands</guilabel> field of the command definition:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2061
+msgid "PLUMA_CURRENT_DOCUMENT_URI"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2064
+msgid "PLUMA_CURRENT_DOCUMENT_NAME"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2067
+msgid "PLUMA_CURRENT_DOCUMENT_SCHEME"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2070
+msgid "PLUMA_CURRENT_DOCUMENT_PATH"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2073
+msgid "PLUMA_CURRENT_DOCUMENT_DIR"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2076
+msgid "PLUMA_DOCUMENTS_URI"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2079
+msgid "PLUMA_DOCUMENTS_PATH"
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2087
+msgid "File Browser Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2089
+msgid "The <application>File Browser</application> Plugin shows your files and folders in the side pane, allowing you to quickly open files."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2090
+msgid "To view the File Browser, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice> and then click on the tab showing the File Browser icon at the bottom of the side pane."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2094
+msgid "Browsing your Files"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2096
+msgid "The File Browser tab initially shows your file manager bookmarks. To browse the contents of any item, double-click it."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2097
+msgid "To show a parent folder, choose from the drop-down list, or press the up arrow on the File Browser's toolbar."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2098
+msgid "To show the folder that contains the document you are currently working on, right-click in the file list and choose <guimenuitem>Set root to active document</guimenuitem>."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2105
+msgid "To open a file in <application>pluma</application>, double-click it in the file list."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2110
+msgid "Creating Files and Folders"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2112
+msgid "To create a new, empty text file in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New File</guimenuitem>."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2113
+msgid "To create a new folder in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New Folder</guimenuitem>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2119
+msgid "Indent Lines Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2121
+msgid "The <application>Indent Lines</application> plugin adds or removes space from the beginning of lines of text."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2122
+msgid "To indent or unindent text, perform the following steps:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2125
+msgid "Select the lines that you want to indent. To indent or unindent a single line, place the cursor anywhere on that line."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2130
+msgid "To indent the text, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Indent</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2133
+msgid "To remove the indentation, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Unindent</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2138
+msgid "The amount of space used, and whether tab character or space characters are used, depends on the <guilabel>Tab Stops</guilabel> settings in the Editor Preferences: see <xref linkend=\"pluma-prefs-editor\"/>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2143
+msgid "Insert Date/Time Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2145
+msgid "The <application>Insert Date/Time</application> plugin inserts the current date and time into a document. To use the Insert Date/Time plugin, perform the following steps:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2148
+msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2149
+msgid "If you have not configured the Insert Date/Time plugin to automatically insert the date/time without prompting you for the format, <application>pluma</application> displays the <guilabel>Insert Date and Time</guilabel> dialog. Select the appropriate date/time format from the list. Click <guibutton>Insert</guibutton> to close the <guilabel>Insert Date and Time</guilabel> dialog. <application>pluma</application> inserts the date/time at the cursor position in the current file."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2150
+msgid "If you have configured <application>pluma</application> to use one particular date/time format, the <guilabel>Insert Date and Time</guilabel> dialog is not displayed. The date/time is automatically entered at the cursor position in the current file."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2156
+msgid "Configuring the Insert Date/Time Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2158
+msgid "To configure the Insert Date/Time plugin, perform the following steps:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2167
+msgid "Select the <guilabel>Insert Date/Time</guilabel> plugin."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2170
+msgid "Click <guibutton>Configure Plugin</guibutton> to display the <guilabel>Configure insert date/time plugin</guilabel> dialog."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2173
+msgid "Select one of the options, as follows:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2176
+msgid "To specify the date/time format each time you insert the date/time, select the <guilabel>Prompt for a format</guilabel> option."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2179
+msgid "To use the same <application>pluma</application>-provided date/time format each time you insert the date/time, select the <guilabel>Use the selected format</guilabel> option, then select the appropriate format from the list. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2182
+msgid "To use the same customized date/time format each time you insert the date/time, select the <guilabel>Use custom format</guilabel> option, then enter the appropriate format in the text box. Refer to the <link xlink:href=\"man:strftime\"> <citerefentry> <refentrytitle>strftime</refentrytitle> <manvolnum>3</manvolnum> </citerefentry> </link> for more information on how to specify a custom format. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2193
+msgid "Click <guibutton>OK</guibutton> to close the <guilabel>Configure insert date/time plugin</guilabel> dialog."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2197
+msgid "To close the <guilabel>Preferences</guilabel> dialog, click <guibutton>Close</guibutton>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2205
+msgid "Modelines Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2207
+msgid "The <application>Modelines</application> plugin allows you to set preferences for individual documents. A <firstterm>modeline</firstterm> is a line of text at the start or end of the document with settings that <application>pluma</application> recognizes."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2208
+msgid "Preferences set using modelines take precedence over the ones specified in the preference dialog."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2209
+msgid "You can set the following preferences with modelines:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2212
+msgid "Tab width"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2215
+msgid "Indent width"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2218
+msgid "Insert spaces instead of tabs"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2221
+msgid "Text Wrapping"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2224
+msgid "Right margin width"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2227
+msgid "The <application>Modelines</application> plugin supports a subset of the options used by other text editors <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2231
+msgid "Emacs Modelines"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2233
+msgid "The first two lines of a document are scanned for <application>Emacs</application> modelines."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2234
+msgid "The <application>Emacs</application> options for tab-width, indent-offset, indent-tabs-mode and autowrap are supported. For more information, see the <link xlink:href=\"http://www.delorie.com/gnu/docs/emacs/emacs_486.html\">GNU Emacs Manual</link>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2239
+msgid "Kate Modelines"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2241
+msgid "The first and last ten lines a document are scanned for <application>Kate</application> modelines."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2242
+msgid "The <application>Kate</application> options for tab-width, indent-width, space-indent, word-wrap and word-wrap-column are supported. For more information, see the <link xlink:href=\"http://www.kate-editor.org/article/katepart_modelines\">Kate website</link>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2247
+msgid "Vim Modelines"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2249
+msgid "The first and last three lines a document are scanned for <application>Vim</application> modelines."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2250
+msgid "The <application>Vim</application> options for et, expandtab, ts, tabstop, sw, shiftwidth, wrap, and textwidth are supported. For more information, see the <link xlink:href=\"http://vimdoc.sourceforge.net/htmldoc/options.html#modeline\">Vim website</link>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2256
+msgid "Python Console Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2258
+msgid "The <application>Python Console</application> Plugin allows you to run commands in the python programming language from <application>pluma</application>. Enabling the plugin adds a tab to the bottom pane. This shows recent output and a command prompt field."
+msgstr ""
+
+#. (itstool) path: caution/para
+#: C/index.docbook:2260
+msgid "Commands entered into the python console are not checked before they are run. It is therefore possible to hang <application>pluma</application>, for example by entering an infinite loop."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2266
+msgid "Snippets Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2268
+msgid "The <application>Snippets</application> plugin allows you to store frequently-used pieces of text, called <firstterm>snippets</firstterm>, and insert them quickly into a document."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2269
+msgid "Snippets are specific to the language syntax of the current document. For example, when you are working with an HTML document, you can choose from a list of snippets that are useful for HTML. In addition, some snippets are global, and are available in all documents."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2270
+msgid "A number of built-in snippets are installed with <application>pluma</application>, which can be modified."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2274
+msgid "Inserting Snippets"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2276
+msgid "To insert a snippet into a document, type its <firstterm>tab trigger</firstterm> and press <keycap>Tab</keycap>. A snippet's tab trigger is usually the first few letters of the snippet, or something else that is short and easy to remember."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2277
+msgid "Alternatively, press <keycombo> <keycap>Ctrl</keycap> <keycap>Space</keycap> </keycombo> to see a list of snippets you can insert."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2282
+msgid "Adding Snippets"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2284
+msgid "To create a new snippet, do the following:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2287
+msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Manage Snippets</guimenuitem> </menuchoice>. The <guilabel>Snippets Manager</guilabel> window opens."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2290
+msgid "The list of snippets is grouped by language. Select the language you want to add a snippet to, or a snippet in that language group. To add a snippet for all languages, choose Global at the top of the list. The syntax of the document you are currently working with is shown by default."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2293
+msgid "Click <guibutton>New</guibutton>. A new snippet appears in the list."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2296
+msgid "Enter the following information for the new snippet:"
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2299
+msgid "Name"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2301
+msgid "Enter a name for the snippet in the text field within the snippet list. The name of a snippet serves only as a reminder of its purpose. You can change name of a snippet you create by clicking on it in the list."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2305
+msgid "Snippet text"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2307
+msgid "Enter the text of the snippet in the <guilabel>Edit snippet</guilabel> text box. For special codes you can use, see <xref linkend=\"pluma-snippets-plugin-syntax\"/>."
+msgstr ""
+
+#. (itstool) path: tip/para
+#: C/index.docbook:2309
+msgid "You can switch back to the document window to copy text without closing the <guilabel>Snippets Manager</guilabel> window."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2314
+msgid "Tab Trigger"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2316
+msgid "Enter the tab trigger for the snippet. This is the text that you type before pressing <keycap>Tab</keycap> to insert the snippet."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2317
+msgid "The tag must be either a single word comprising only letters, or any single character. The <guilabel>Tab trigger</guilabel> will highlight in red if an invalid tab trigger is entered."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2321
+msgid "Shortcut key"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2323
+msgid "Type a shortcut key to use for inserting the snippet."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2333
+msgid "Editing and Removing Snippets"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2335
+msgid "To edit a snippet, select it in the list and make changes to its text and activation properties."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2336
+msgid "To rename a snippet, click it again in the list."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2337
+msgid "To restore a built-in snippet that you have changed, press <guilabel>Revert</guilabel>."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2338
+msgid "To remove a snippet, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in snippets, only those you have created yourself."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2343
+msgid "Snippet Substitutions"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2345
+msgid "In addition to inserting stored text, a snippet can include customizable text, or mark spaces where you can add text once the snippet is inserted in your document."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2346
+msgid "You can use the following placeholder codes in snippet text:"
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2349
+msgid "Tab placeholders"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2351
+msgid "<literal>$<replaceable>n</replaceable></literal> defines a tab placeholder, where <literal>n</literal> is any number from 1 upwards."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2352
+msgid "<literal>${<replaceable>n</replaceable>:<replaceable>default</replaceable>}</literal> defines a tab placeholder with a default value."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2353
+msgid "A tab placeholder marks a place in the snippet text where you can add extra text after the snippet is inserted."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2354
+msgid "To use tab placeholders, insert the snippet as normal. The cursor is placed at the first tab placeholder. Type text, and press <keycap>Tab</keycap> to advance to the next tab placeholder. The number in the placeholder code defines the order in which tab advances to each place in the text."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2355
+msgid "Press <keycombo> <keycap>Shift</keycap> <keycap>Tab</keycap> </keycombo> to return to the previous tab placeholder. Pressing <keycap>Tab</keycap> when there are no more tab placeholders moves the cursor to the end of the snippet text, or to the end placeholder if it exists."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2359
+msgid "Mirror placeholders"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2361
+msgid "A repeated tab placeholder will mirror the placeholder already defined. This allows you to type in text only once that you want to appear several times in the snippet."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2365
+msgid "End placeholder"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2367
+msgid "<literal>$0</literal> defines the end placeholder. This allows you to finish working with the snippet with the cursor at a point other than the end of the snippet text."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2371
+msgid "Environmental variables"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2373
+msgid "Environmental variable such as <literal>$PATH</literal> and <literal>$HOME</literal> are substituted in snippet text. The following variables specific to <application>pluma</application> can also be used:"
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2376
+msgid "$PLUMA_SELECTED_TEXT"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2378
+msgid "The currently selected text."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2382
+msgid "$PLUMA_FILENAME"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2384
+msgid "The full filename of the document, or an empty string if the document isn't saved yet."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2388
+msgid "$PLUMA_BASENAME"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2390
+msgid "The basename of the filename of the document, or an empty string if the document isn't saved yet."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2394
+msgid "$PLUMA_CURRENT_WORD"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2396
+msgid "The word at the cursor's location in the document. When this variable is used, the current word will be replaced by the snippet text."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2403
+msgid "Shell placeholders"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2405
+msgid "<literal>$(<replaceable>cmd</replaceable>)</literal> is replaced by the result of executing <replaceable>cmd</replaceable> in a shell."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2406
+msgid "<literal>$(<replaceable>n</replaceable>:<replaceable>cmd</replaceable>)</literal> allows you to give this placeholder a reference, where <replaceable>n</replaceable> is any number from 1 upwards. Use <literal>$<replaceable>n</replaceable></literal> to use the output from one shell placeholder as input in another."
+msgstr ""
+
+#. (itstool) path: varlistentry/term
+#: C/index.docbook:2410
+msgid "Python placeholders"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2412
+msgid "<literal>$&lt;<replaceable>cmd</replaceable>&gt;</literal> is replaced by the result of evaluating <replaceable>cmd</replaceable> in the python interpreter."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2413
+msgid "<literal>$&lt;<replaceable>a</replaceable>:<replaceable>cmd</replaceable>&gt;</literal> specifies another python placeholder as a dependency, where <replaceable>a</replaceable> gives its order in the snippet. This allows you to use python functions defined in another snippet. To specify several dependencies, separate the numbers with commas thus: <literal>$&lt;<replaceable>a</replaceable>,<replaceable>b</replaceable>:<replaceable>cmd</replaceable>&gt;</literal>"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2414
+msgid "To use a variable in all other python snippets, declare it as <literal>global</literal>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2423
+msgid "Sort Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2425
+msgid "The <application>Sort</application> plugin arranges selected lines of text into alphabetical order."
+msgstr ""
+
+#. (itstool) path: caution/para
+#: C/index.docbook:2427
+msgid "You cannot undo the Sort operation, so you should save the file before performing the sort. To revert to the saved version of the file after the sort operation, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Revert</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2429
+msgid "To use the Sort plugin, perform the following steps:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2432
+msgid "Select the lines of text you want to sort."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2435
+msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Sort</guimenuitem> </menuchoice>. The <guilabel>Sort</guilabel> dialog opens."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2438
+msgid "Choose the options you want for the sort:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2441
+msgid "To arrange the text in reverse order, select <guilabel>Reverse order</guilabel>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2444
+msgid "To delete duplicate lines, select <guilabel>Remove duplicates</guilabel>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2447
+msgid "To ignore case sensitivity, select <guilabel>Ignore case</guilabel>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2450
+msgid "To have the sort ignore the characters at the start of the lines, set the first character that should be used for sorting in the <guilabel>Start at column</guilabel> spin box."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2455
+msgid "To perform the sort operation, click <guibutton>Sort</guibutton>."
+msgstr ""
+
+#. (itstool) path: info/title
+#: C/index.docbook:2462
+msgid "Spell Checker Plugin"
+msgstr ""
+
+#. (itstool) path: section/para
+#: C/index.docbook:2464
+msgid "The <application>Spell Checker</application> plugin checks the spelling in the selected text. You can configure <application>pluma</application> to check the spelling automatically, or you can check the spelling manually, in the specified language. The language setting, and the autocheck spelling properties, apply per document. To use the Spell checker plugin, perform the following steps:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2467
+msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Set Language</guimenuitem> </menuchoice> to display the <guilabel>Set language</guilabel> dialog. Select the appropriate language from the list. Click <guibutton>OK</guibutton> to close the <guilabel>Set language</guilabel> dialog."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2470
+msgid "To check the spelling automatically, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice>. To unset the automatic spell check, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice> again. When automatic spell checking is set, an icon is displayed beside the <guimenuitem>Autocheck Spelling</guimenuitem> menu item. Automatic spell checking is unset by default, each time <application>pluma</application> starts."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2471
+msgid "Unknown spellings are displayed in a different color, and underlined. Right-click on an unknown spelling, then select <guimenu>Spelling Suggestions</guimenu> from the popup menu:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2474
+msgid "To replace the unknown spelling with another spelling in the list, select the replacement spelling from the <guimenu>Spelling Suggestions</guimenu> popup menu."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2477
+msgid "To add the unknown spelling to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Add</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2480
+msgid "To ignore all occurrences of the unknown spelling, so that they are no longer flagged as unknown but are not added to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Ignore All</guimenuitem> </menuchoice>. The unknown word is ignored in the current <application>pluma</application> session only."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2485
+msgid "To check the spelling manually, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Check Spelling</guimenuitem> </menuchoice>."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2486
+msgid "If there are no spelling errors, an <guilabel>Information</guilabel> dialog displays a message stating that the document does not contain misspelled words. Click <guibutton>OK</guibutton> to close the <guilabel>Information</guilabel> dialog."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2487
+msgid "If there are spelling errors, the <guilabel>Check Spelling</guilabel> dialog is displayed:"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2490
+msgid "The <guilabel>Misspelled word</guilabel> is displayed at the top of the dialog."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2493
+msgid "A suggested known spelling is displayed in the <guilabel>Change to</guilabel> text box. You can replace this with another known spelling by selecting a spelling from the <guilabel>Suggestions</guilabel> list, or you can enter text directly into the <guilabel>Change to</guilabel> text box."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2496
+msgid "To check the spelling of the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Check Word</guibutton>. If this is a known word, the <guilabel>Suggestions</guilabel> list is replaced with the text <literal>(correct spelling)</literal>. If the word is not known, new entries appear in the <guilabel>Suggestions</guilabel> list."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2499
+msgid "To ignore the current occurrence of the unknown word, click <guibutton>Ignore</guibutton>. To ignore all occurrences of the unknown word, click <guibutton>Ignore All</guibutton>. The unknown word is ignored in the current <application>pluma</application> session only."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/index.docbook:2502
 msgid "To change the current occurrence of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change</guibutton>. To change all occurrences of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change All</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1945
+#: C/index.docbook:2505
 msgid "To add the unknown word to your personal dictionary, click <guibutton>Add word</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1948
+#: C/index.docbook:2508
 msgid "To close the <guilabel>Check Spelling</guilabel> dialog, click <guibutton>Close</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1957
+#. (itstool) path: info/title
+#: C/index.docbook:2517
 msgid "Tag List Plugin"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1958
+#. (itstool) path: section/para
+#: C/index.docbook:2519
 msgid "The <application>Tag List</application> plugin allows you to insert common tags from a list in the side pane."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1959
+#. (itstool) path: section/para
+#: C/index.docbook:2520
 msgid "To use the Tag List plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1961
+#: C/index.docbook:2523
 msgid "Choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1965
+#: C/index.docbook:2526
 msgid "By default, the side pane shows a tab containing a list of open documents. Click on the tab showing a + icon at the bottom of the side pane to show the tag list tab."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1967
+#: C/index.docbook:2529
 msgid "Select the appropriate tag category from the drop-down list. For example, <guilabel>HTML - Tags</guilabel>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1970
+#: C/index.docbook:2532
 msgid "Scroll through the tag list to find the required tag."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1973
+#: C/index.docbook:2535
 msgid "To insert a tag at the cursor position in the current file, double-click on the tag in the tag list. You can also insert a tag as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1975
+#: C/index.docbook:2538
 msgid "To insert a tag in the current file and change the focus from the side pane to the display area, press <keycap>Return</keycap>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1978
-msgid "To insert a tag in the current file and maintain the focus on the <guilabel>Tag list plugin</guilabel> window, press <keycombo><keycap>Shift</keycap><keycap>Return</keycap></keycombo>."
-msgstr ""
-
-#. (itstool) path: para/ulink
-#: C/legal.xml:9
-msgid "link"
+#: C/index.docbook:2541
+msgid "To insert a tag in the current file and maintain the focus on the <guilabel>Tag list plugin</guilabel> window, press <keycombo> <keycap>Shift</keycap> <keycap>Return</keycap> </keycombo>."
 msgstr ""
 
 #. (itstool) path: legalnotice/para
-#: C/legal.xml:2
-msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <_:ulink-1/> or in the file COPYING-DOCS distributed with this manual."
+#: C/legal.xml:5
+msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <link xlink:href=\"https://www.gnu.org/licenses/fdl-1.1.html\">link</link> or in the file COPYING-DOCS distributed with this manual."
 msgstr ""
 
 #. (itstool) path: legalnotice/para
-#: C/legal.xml:12
+#: C/legal.xml:14
 msgid "This manual is part of a collection of MATE manuals distributed under the GFDL. If you want to distribute this manual separately from the collection, you can do so by adding a copy of the license to the manual, as described in section 6 of the license."
 msgstr ""
 
 #. (itstool) path: legalnotice/para
-#: C/legal.xml:19
+#: C/legal.xml:21
 msgid "Many of the names used by companies to distinguish their products and services are claimed as trademarks. Where those names appear in any MATE documentation, and the members of the MATE Documentation Project are made aware of those trademarks, then the names are in capital letters or initial capital letters."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/legal.xml:35
+#: C/legal.xml:37
 msgid "DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS FREE OF DEFECTS MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY, ACCURACY, AND PERFORMANCE OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS WITH YOU. SHOULD ANY DOCUMENT OR MODIFIED VERSION PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL WRITER, AUTHOR OR ANY CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER; AND"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/legal.xml:55
+#: C/legal.xml:57
 msgid "UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE AUTHOR, INITIAL WRITER, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER DAMAGES OR LOSSES ARISING OUT OF OR RELATING TO USE OF THE DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES."
 msgstr ""
 
 #. (itstool) path: legalnotice/para
-#: C/legal.xml:28
+#: C/legal.xml:30
 msgid "DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT ARE PROVIDED UNDER THE TERMS OF THE GNU FREE DOCUMENTATION LICENSE WITH THE FURTHER UNDERSTANDING THAT: <_:orderedlist-1/>"
+msgstr ""
+
+#. (itstool) path: formalpara/title
+#: C/legal.xml:78
+msgid "Feedback"
+msgstr ""
+
+#. (itstool) path: formalpara/para
+#: C/legal.xml:79
+msgid "To report a bug or make a suggestion regarding the <application>pluma</application> application or this manual, follow the directions in the <link xlink:href=\"help:mate-user-guide/feedback\">MATE Feedback Page</link>."
 msgstr ""
 

--- a/help/pluma.pot
+++ b/help/pluma.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2019-02-07 00:30+0100\n"
+"POT-Creation-Date: 2019-02-09 18:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,41 +15,83 @@ msgid "translator-credits"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:19
+#: C/index.docbook:20
 msgid "Pluma Manual"
 msgstr ""
 
-#. (itstool) path: info/copyright
-#: C/index.docbook:21
-msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
-msgstr ""
-
-#. (itstool) path: info/copyright
-#: C/index.docbook:25
-msgid "<year>2007</year> <holder>GNOME Documentation Project</holder>"
-msgstr ""
-
-#. (itstool) path: info/copyright
-#: C/index.docbook:29
-msgid "<year>2002</year> <year>2003</year> <year>2004</year> <holder>Sun Microsystems</holder>"
-msgstr ""
-
-#. (itstool) path: info/copyright
-#: C/index.docbook:35
-msgid "<year>2000</year> <holder>Eric Baudais</holder>"
-msgstr ""
-
 #. (itstool) path: publisher/publishername
+#. (itstool) path: author/orgname
 #. (itstool) path: revdescription/para
-#: C/index.docbook:41
-#: C/index.docbook:206
+#: C/index.docbook:42
+#: C/index.docbook:52
+#: C/index.docbook:207
 msgid "MATE Documentation Project"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
+#. (itstool) path: author/orgname
+#. (itstool) path: affiliation/orgname
 #. (itstool) path: revdescription/para
-#: C/index.docbook:44
-#: C/index.docbook:118
+#: C/index.docbook:45
+#: C/index.docbook:64
+#: C/index.docbook:89
+#: C/index.docbook:119
+#: C/index.docbook:127
+#: C/index.docbook:135
+#: C/index.docbook:143
+#: C/index.docbook:151
+#: C/index.docbook:159
+#: C/index.docbook:167
+#: C/index.docbook:175
+#: C/index.docbook:183
+#: C/index.docbook:191
+#: C/index.docbook:199
+msgid "GNOME Documentation Project"
+msgstr ""
+
+#. (itstool) path: affiliation/orgname
+#: C/index.docbook:54
+msgid "MATE Desktop"
+msgstr ""
+
+#. (itstool) path: affiliation/orgname
+#: C/index.docbook:66
+msgid "GNOME"
+msgstr ""
+
+#. (itstool) path: author/contrib
+#: C/index.docbook:74
+msgid "Added the Shortcut Keys Table"
+msgstr ""
+
+#. (itstool) path: author/orgname
+#. (itstool) path: revdescription/para
+#: C/index.docbook:77
+#: C/index.docbook:190
+msgid "Sun Java Desktop System Documentation Team"
+msgstr ""
+
+#. (itstool) path: affiliation/orgname
+#: C/index.docbook:79
+msgid "Sun Microsystems"
+msgstr ""
+
+#. (itstool) path: othercredit/contrib
+#: C/index.docbook:98
+msgid "Provided information from earlier revisions of the pluma application."
+msgstr ""
+
+#. (itstool) path: othercredit/contrib
+#: C/index.docbook:105
+msgid "Provided information about plugins."
+msgstr ""
+
+#. (itstool) path: revision/date
+#: C/index.docbook:124
+msgid "March 2002"
+msgstr ""
+
+#. (itstool) path: revdescription/para
 #: C/index.docbook:126
 #: C/index.docbook:134
 #: C/index.docbook:142
@@ -58,3213 +100,3120 @@ msgstr ""
 #: C/index.docbook:166
 #: C/index.docbook:174
 #: C/index.docbook:182
-#: C/index.docbook:190
-#: C/index.docbook:198
-msgid "GNOME Documentation Project"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:50
-msgid "<orgname>MATE Documentation Project</orgname> <affiliation> <orgname>MATE Desktop</orgname> </affiliation>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:56
-msgid "<personname> <firstname>Joachim</firstname> <surname>Noreiko</surname> </personname>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:62
-msgid "<orgname>GNOME Documentation Project</orgname> <affiliation> <orgname>GNOME</orgname> </affiliation>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:68
-msgid "<personname> <firstname>Hal</firstname> <surname>Canary</surname> </personname> <contrib>Added the Shortcut Keys Table</contrib>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:75
-msgid "<orgname>Sun Java Desktop System Documentation Team</orgname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation> <email>gdocteam@sun.com</email>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:82
-msgid "<personname> <firstname>Eric</firstname> <surname>Baudais</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>baudais@okstate.edu</email>"
-msgstr ""
-
-#. (itstool) path: authorgroup/othercredit
-#: C/index.docbook:92
-msgid "<personname> <firstname>Baris</firstname> <surname>Cicek</surname> </personname> <contrib>Provided information from earlier revisions of the pluma application.</contrib>"
-msgstr ""
-
-#. (itstool) path: authorgroup/othercredit
-#: C/index.docbook:99
-msgid "<personname> <firstname>George</firstname> <surname>Ajit</surname> </personname> <contrib>Provided information about plugins.</contrib>"
-msgstr ""
-
-#. (itstool) path: revdescription/para
-#: C/index.docbook:117
-msgid "Eric Baudais <email>baudais@okstate.edu</email>"
-msgstr ""
-
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:113
-msgid "<revnumber>1.0</revnumber> <date>2000</date> <_:revdescription-1/>"
-msgstr ""
-
-#. (itstool) path: revdescription/para
-#: C/index.docbook:125
-#: C/index.docbook:133
-#: C/index.docbook:141
-#: C/index.docbook:149
-#: C/index.docbook:157
-#: C/index.docbook:165
-#: C/index.docbook:173
-#: C/index.docbook:181
 msgid "Sun GNOME Documentation Team"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:121
-msgid "<revnumber>2.0</revnumber> <date>March 2002</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:132
+msgid "June 2002"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:129
-msgid "<revnumber>2.1</revnumber> <date>June 2002</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:140
+msgid "August 2002"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:137
-msgid "<revnumber>2.2</revnumber> <date>August 2002</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:148
+msgid "September 2002"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:145
-msgid "<revnumber>2.3</revnumber> <date>September 2002</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:156
+msgid "January 2003"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:153
-msgid "<revnumber>2.4</revnumber> <date>January 2003</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:164
+msgid "March 2003"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:161
-msgid "<revnumber>2.5</revnumber> <date>March 2003</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:172
+msgid "September 2003"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:169
-msgid "<revnumber>2.6</revnumber> <date>September 2003</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:180
+msgid "March 2004"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:177
-msgid "<revnumber>2.7</revnumber> <date>March 2004</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:188
+#: C/index.docbook:204
+msgid "July 2015"
 msgstr ""
 
-#. (itstool) path: revdescription/para
-#: C/index.docbook:189
-msgid "Sun Java Desktop System Documentation Team"
-msgstr ""
-
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:185
-msgid "<revnumber>2.8</revnumber> <date>July 2015</date> <_:revdescription-1/>"
+#. (itstool) path: revision/date
+#: C/index.docbook:196
+msgid "July 2006"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:197
+#: C/index.docbook:198
 msgid "GNOME Documentation Team"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:193
-msgid "<revnumber>2.9</revnumber> <date>July 2006</date> <_:revdescription-1/>"
-msgstr ""
-
 #. (itstool) path: revdescription/para
-#: C/index.docbook:205
+#: C/index.docbook:206
 msgid "MATE Documentation Team"
 msgstr ""
 
-#. (itstool) path: revhistory/revision
-#: C/index.docbook:201
-msgid "<revnumber>3.0</revnumber> <date>July 2015</date> <_:revdescription-1/>"
-msgstr ""
-
 #. (itstool) path: info/releaseinfo
-#: C/index.docbook:211
+#: C/index.docbook:212
 msgid "This manual describes version 1.10 of pluma."
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:215
+#: C/index.docbook:216
 msgid "<primary>pluma</primary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:218
+#: C/index.docbook:219
 msgid "<primary>text editor</primary>"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:226
+#: C/index.docbook:227
 msgid "Introduction"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:230
+#: C/index.docbook:231
 msgid "The <application>pluma</application> application enables you to create and edit text files."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:231
+#: C/index.docbook:232
 msgid "The aim of <application>pluma</application> is to be a simple and easy to use text editor. More powerful features can be enabled with different <firstterm>plugins</firstterm>, allowing a variety of tasks related to text-editing."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:237
+#: C/index.docbook:238
 msgid "Getting Started"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:243
+#: C/index.docbook:244
 msgid "Starting pluma"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:245
+#: C/index.docbook:246
 msgid "You can start <application>pluma</application> in the following ways:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:248
+#: C/index.docbook:249
 msgid "<guimenu>Applications</guimenu> menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:251
+#: C/index.docbook:252
 msgid "Choose <menuchoice> <guisubmenu>Accessories</guisubmenu> <guimenuitem>Text Editor</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:255
+#: C/index.docbook:256
 msgid "Command line"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:257
+#: C/index.docbook:258
 msgid "Execute the following command: <command>pluma</command>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:261
+#: C/index.docbook:262
 msgid "By default, when you open a text document in the file manager, pluma will start, and display the document."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:266
+#: C/index.docbook:267
 msgid "The pluma Window"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:268
+#: C/index.docbook:269
 msgid "When you start <application>pluma</application>, the following window is displayed:"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:272
+#: C/index.docbook:273
 msgid "pluma Window"
 msgstr ""
 
-#. (itstool) path: imageobject/imagedata
-#. This is a reference to an external file such as an image or video. When
-#. the file changes, the md5 hash will change to let you know you need to
-#. update your localized copy. The msgstr is not used at all. Set it to
-#. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:277
-msgctxt "_"
-msgid "external ref='figures/pluma_window.png' md5='48a265acf2b42650a4355f0baa1a498d'"
-msgstr ""
-
-#. (itstool) path: screenshot/mediaobject
-#: C/index.docbook:275
-msgid "<imageobject> <imagedata fileref=\"figures/pluma_window.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows pluma main window.</phrase> </textobject>"
+#. (itstool) path: textobject/phrase
+#: C/index.docbook:281
+msgid "Shows pluma main window."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:286
+#: C/index.docbook:287
 msgid "The <application>pluma</application> window contains the following elements:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:289
+#: C/index.docbook:290
 msgid "Menubar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:291
+#: C/index.docbook:292
 msgid "The menus on the menubar contain all the commands you need to work with files in <application>pluma</application>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:295
+#: C/index.docbook:296
 msgid "Toolbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:297
+#: C/index.docbook:298
 msgid "The toolbar contains a subset of the commands that you can access from the menubar."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:301
+#: C/index.docbook:302
 msgid "Display area"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:303
+#: C/index.docbook:304
 msgid "The display area contains the text of the file that you are editing."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:307
+#: C/index.docbook:308
 msgid "Statusbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:309
+#: C/index.docbook:310
 msgid "The statusbar displays information about current <application>pluma</application> activity and contextual information about the menu items. The statusbar also displays the following information:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:312
+#: C/index.docbook:313
 msgid "Cursor position: the line number and column number where the cursor is located."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:315
+#: C/index.docbook:316
 msgid "Edit mode: If the editor is in insert mode, the statusbar contains the text <guilabel>INS</guilabel>. If the editor is in overwrite mode, the statusbar contains the text <guilabel>OVR</guilabel>. Press the <keycap>Insert</keycap> key to change edit mode."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:321
+#: C/index.docbook:322
 msgid "Side Pane"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:323
+#: C/index.docbook:324
 msgid "The side pane displays a list of open documents, and other information depending on which plugins are enabled."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:324
+#: C/index.docbook:325
 msgid "By default, the side pane is not shown. To show it, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:328
+#: C/index.docbook:329
 msgid "Bottom Pane"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:330
+#: C/index.docbook:331
 msgid "The bottom pane is used by programming tools such as the <application>Python Console</application> plugin to display output."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:331
+#: C/index.docbook:332
 msgid "By default, the bottom pane is not shown. To show it, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Bottom Pane</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:335
+#: C/index.docbook:336
 msgid "When you right-click in the <application>pluma</application> window, the application displays a popup menu. The popup menu contains the most common text editing commands."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:336
+#: C/index.docbook:337
 msgid "Like other MATE applications, actions in <application>pluma</application> can be performed in several ways: with the menu, with the toolbar, or with shortcut keys. Shortcuts keys common to all applications are listed in the <link xlink:href=\"help:mate-user-guide/shortcuts-apps\">User Guide</link>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:342
+#: C/index.docbook:343
 msgid "Running pluma from a Command Line"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:344
+#: C/index.docbook:345
 msgid "You can run <application>pluma</application> from a command line and open a single file or multiple files. To open multiple files from a command line, type the following command, then press <keycap>Return</keycap>:"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:345
+#: C/index.docbook:346
 msgid "<command>pluma <replaceable>file1.txt file2.txt file3.txt</replaceable></command>"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:348
+#: C/index.docbook:349
 msgid "Alternatively, you can specify a URI instead of a filename."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:349
+#: C/index.docbook:350
 msgid "Refer to the <link xlink:href=\"man:pluma\"> <citerefentry> <refentrytitle>pluma</refentrytitle> <manvolnum>1</manvolnum> </citerefentry> </link> man page for more information on how to run <application>pluma</application> from a command line."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:356
+#: C/index.docbook:357
 msgid "Working with Files"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:362
+#: C/index.docbook:363
 msgid "Creating a New Document"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:364
+#: C/index.docbook:365
 msgid "To create a new document, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>New</guimenuitem> </menuchoice>. The application displays a new blank document in the <application>pluma</application> window."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:370
-#: C/index.docbook:2103
+#: C/index.docbook:371
+#: C/index.docbook:2104
 msgid "Opening a File"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:372
+#: C/index.docbook:373
 msgid "To open a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Open</guimenuitem> </menuchoice> to display the <guilabel>Open File</guilabel> dialog. Select the file that you want to open, then click <guibutton>Open</guibutton>. The file is displayed in the <application>pluma</application> window."
 msgstr ""
 
-#. (itstool) path: imageobject/imagedata
-#. This is a reference to an external file such as an image or video. When
-#. the file changes, the md5 hash will change to let you know you need to
-#. update your localized copy. The msgstr is not used at all. Set it to
-#. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:375
-msgctxt "_"
-msgid "external ref='figures/pluma_recent_files_menu_icon.png' md5='62b4bede31db64226f7e7f9b18f5eb74'"
+#. (itstool) path: textobject/phrase
+#: C/index.docbook:379
+msgid "Shows Recent Files menu icon."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:373
-msgid "The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice> <guimenu>File</guimenu> </menuchoice> menu. You can also click on the <inlinemediaobject> <imageobject> <imagedata fileref=\"figures/pluma_recent_files_menu_icon.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows Recent Files menu icon.</phrase> </textobject> </inlinemediaobject> icon on the toolbar to display the list of recent files."
+#: C/index.docbook:374
+msgid "The application records the paths and filenames of the five most recent files that you edited and displays the files as menu items on the <menuchoice> <guimenu>File</guimenu> </menuchoice> menu. You can also click on the <_:inlinemediaobject-1/> icon on the toolbar to display the list of recent files."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:382
+#: C/index.docbook:383
 msgid "You can open multiple files in <application>pluma</application>. The application adds a tab for each open file to the window. For more on this see <xref linkend=\"pluma-tabs\"/>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:389
+#: C/index.docbook:390
 msgid "Saving a File"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:391
+#: C/index.docbook:392
 msgid "You can save files in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:394
+#: C/index.docbook:395
 msgid "To save changes to an existing file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Save</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:397
+#: C/index.docbook:398
 msgid "To save a new file or to save an existing file under a new filename, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Save As</guimenuitem> </menuchoice>. Enter a name for the file in the <guilabel>Save As</guilabel> dialog, then click <guibutton>Save</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:400
+#: C/index.docbook:401
 msgid "To save all the files that are currently open in <application>pluma</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Save All</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:403
+#: C/index.docbook:404
 msgid "To close all the files that are currently open in <application>pluma</application>, choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Close All</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:409
+#: C/index.docbook:410
 msgid "Working With Tabs"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:411
+#: C/index.docbook:412
 msgid "When more than one file is open, <application>pluma</application> shows a <firstterm>tab</firstterm> for each document above the display area. To switch to another document, click on its tab."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:412
+#: C/index.docbook:413
 msgid "To move a document to another <application> pluma</application> window, drag the tab corresponding to the file to the window you want to move it to."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:413
+#: C/index.docbook:414
 msgid "To move a document to a new <application> pluma</application> window, either drag its tab to the desktop, or choose <menuchoice> <guimenu>Documents</guimenu> <guimenuitem>Move to New Window</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:420
+#: C/index.docbook:421
 msgid "Working with Text"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:426
+#: C/index.docbook:427
 msgid "Editing Text"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:428
+#: C/index.docbook:429
 msgid "You can edit the text of a file in the following ways:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:431
+#: C/index.docbook:432
 msgid "Type new text from the keyboard. The blinking <firstterm>insertion cursor</firstterm> marks the point where new text appears. To change this, use the arrow keys on the keyboard or click with the mouse."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:434
+#: C/index.docbook:435
 msgid "To copy the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Copy</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:437
+#: C/index.docbook:438
 msgid "To delete the selected text from the file and move the selected text to the clipboard, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Cut</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:440
+#: C/index.docbook:441
 msgid "To permanently delete the selected text from the file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Delete</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:443
+#: C/index.docbook:444
 msgid "To insert the contents of the clipboard at the cursor position, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Paste</guimenuitem> </menuchoice>. You must cut or copy text before you can paste text into the file, either from pluma or another application."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:446
+#: C/index.docbook:447
 msgid "To select all the text in a file, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Select All</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:454
+#: C/index.docbook:455
 msgid "Undoing and Redoing Changes"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:456
+#: C/index.docbook:457
 msgid "To undo a change you have made, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Undo</guimenuitem> </menuchoice>. To reverse this action, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Redo</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:462
+#: C/index.docbook:463
 msgid "Finding and Replacing"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:464
+#: C/index.docbook:465
 msgid "In <application>pluma</application>, there are two ways of searching for text. You can use the <guilabel>Find</guilabel> dialog to search for a specific piece of text, or <guilabel>Incremental Search</guilabel> to highlight matching text as you type it."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:469
+#: C/index.docbook:470
 msgid "Finding Text"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:472
+#: C/index.docbook:473
 msgid "To search a file for a string of text, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:475
+#: C/index.docbook:476
 msgid "Choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find</guimenuitem> </menuchoice> to display the <guilabel>Find</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:481
+#: C/index.docbook:482
 msgid "Type the string that you want to find in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend=\"pluma-find-escapes\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:484
+#: C/index.docbook:485
 msgid "Click <guibutton>Find</guibutton> to search the file for the first occurrence of the string after your current cursor position. If <application>pluma</application> finds the string, the application selects first occurrence of the string. Other occurrences of the string are highlighted."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:487
+#: C/index.docbook:488
 msgid "To find the next occurrence of the string, click <guibutton>Find</guibutton> or choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Next</guimenuitem> </menuchoice>. To find the previous occurrence of the text, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Previous</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:496
+#: C/index.docbook:497
 msgid "After you have closed the <guilabel>Find</guilabel> dialog, you can still move the selection to other occurrences of the text by choosing <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Next</guimenuitem> </menuchoice> and <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Find Previous</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:503
+#: C/index.docbook:504
 msgid "To remove the highlighting from the text, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Clear Highlight</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:511
+#: C/index.docbook:512
 msgid "Incremental Search"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:515
+#: C/index.docbook:516
 msgid "Incremental search highlights matching text in the document as you type it letter by letter. (This is similar to the search feature in several web browsers.)"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:516
+#: C/index.docbook:517
 msgid "To start an incremental search, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Incremental Search</guimenuitem> </menuchoice>. The search box appears at the top of the display area."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:520
+#: C/index.docbook:521
 msgid "Begin typing, and text that matches will be highlighted in the document. The first instance after the cursor position is also selected."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:521
+#: C/index.docbook:522
 msgid "To advance the selection to the next match while keeping the incremental search box open, press <keycombo> <keycap>Ctrl</keycap> <keycap>G</keycap> </keycombo>. Press <keycombo> <keycap>Ctrl</keycap> <keycap>Shift</keycap> <keycap>G</keycap> </keycombo> to go back to the previous match."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/index.docbook:530
+#: C/index.docbook:531
 msgid "You can also use the up and down arrow keys or the mouse wheel to move the selection between matches."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:537
+#: C/index.docbook:538
 msgid "Replacing Text"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:539
+#: C/index.docbook:540
 msgid "To search a file for a string, and replace the string with an alternative string, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:542
+#: C/index.docbook:543
 msgid "Choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Replace</guimenuitem> </menuchoice> to display the <guilabel>Replace</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:548
+#: C/index.docbook:549
 msgid "Type the string that you want to find, in the <guilabel>Search for</guilabel> field. You can include special characters such as a new line or tab: see <xref linkend=\"pluma-find-escapes\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:551
+#: C/index.docbook:552
 msgid "Type the string that you want to use to replace the string that you find, in the <guilabel>Replace with</guilabel> field."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:555
+#: C/index.docbook:556
 msgid "To examine each occurrence of the string before replacing it, click <guibutton>Find</guibutton>. If <application>pluma</application> finds the string, the application selects the string. Click <guibutton>Replace</guibutton> to replace the selected occurrence of the string. To find the next occurrence of the string, click <guibutton>Find</guibutton> again."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:556
+#: C/index.docbook:557
 msgid "To replace all occurrences of the string throughout the document, click <guibutton>Replace All</guibutton>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:562
+#: C/index.docbook:563
 msgid "Find and Replace Options"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:565
+#: C/index.docbook:566
 msgid "The <guilabel>Find</guilabel> dialog and the <guilabel>Replace</guilabel> dialog both have the following options:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:568
+#: C/index.docbook:569
 msgid "Select the <guilabel>Match case</guilabel> option to only find occurrences of the string that match the case of the text that you type. For example, with <guilabel>Match case</guilabel> selected, \"TEXT\" will not match \"text\"."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:571
+#: C/index.docbook:572
 msgid "Select the <guilabel>Match entire word only</guilabel> option to only find occurrences of the string that match the entire words of the text that you type. For example, with <guilabel>Match entire word only</guilabel> selected, \"text\" will not match \"texture\"."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:574
+#: C/index.docbook:575
 msgid "Select the <guilabel>Search backwards</guilabel> option to search backwards towards the beginning of the document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:577
+#: C/index.docbook:578
 msgid "Select the <guilabel>Wrap around</guilabel> option to search to one end of the document and then continue the search from the other end of the file."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:585
+#: C/index.docbook:586
 msgid "Special Characters"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:588
+#: C/index.docbook:589
 msgid "You can include the following escape sequences in the text to find or replace to represent special characters:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:591
+#: C/index.docbook:592
 msgid "<literal>\\n</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:595
+#: C/index.docbook:596
 msgid "Specifies a new line."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:599
+#: C/index.docbook:600
 msgid "<literal>\\t</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:603
+#: C/index.docbook:604
 msgid "Specifies a tab character."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:607
+#: C/index.docbook:608
 msgid "<literal>\\r</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:611
+#: C/index.docbook:612
 msgid "Specifies a carriage return."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:615
+#: C/index.docbook:616
 msgid "<literal>\\\\</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:619
+#: C/index.docbook:620
 msgid "The backslash character itself must be escaped if it is being searched for. For example, if you are looking for the \"<literal>\\n</literal>\" literal, you will have to type \"\\\\n\" in the <guilabel>Search for</guilabel> field. Or if you are looking for a sequence of backslashes, you will have to double the number of searched backslashes."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:632
+#: C/index.docbook:633
 msgid "Positioning the Cursor on a Specific Line"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:634
+#: C/index.docbook:635
 msgid "To position the cursor on a specific line in the current file, choose <menuchoice> <guimenu>Search</guimenu> <guimenuitem>Go to Line</guimenuitem> </menuchoice>. The line number box appears at the top of the display area."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:635
+#: C/index.docbook:636
 msgid "Begin typing the number of the line that you want to move the cursor to and the document will scroll to the specified line."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:636
+#: C/index.docbook:637
 msgid "To dismiss the box and move the cursor to the specified line, press <keycap>Return</keycap>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:642
+#: C/index.docbook:643
 msgid "Printing"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:648
+#: C/index.docbook:649
 msgid "Setting the Page Options"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:651
+#: C/index.docbook:652
 msgid "To set the page options, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Page Setup</guimenuitem> </menuchoice> to display the <guilabel>Page Setup</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:653
+#: C/index.docbook:654
 msgid "The <guilabel>Page Setup</guilabel> dialog enables you to specify the following print options:"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:657
+#: C/index.docbook:658
 msgid "General Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:661
+#: C/index.docbook:662
 msgid "<guilabel>Print syntax highlighting</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:665
+#: C/index.docbook:666
 msgid "Select this option to print syntax highlighting. For more information about syntax highlighting, see <xref linkend=\"pluma-set-highlightmode\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:669
+#: C/index.docbook:670
 msgid "<guilabel>Print page headers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:673
+#: C/index.docbook:674
 msgid "Select this option to include a header on each page that you print. You cannot configure the header."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:677
-#: C/index.docbook:1555
+#: C/index.docbook:678
+#: C/index.docbook:1556
 msgid "<guilabel>Line Numbers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:681
+#: C/index.docbook:682
 msgid "Select the <guilabel>Print line numbers</guilabel> option to include line numbers when you print a file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:682
+#: C/index.docbook:683
 msgid "Use the <guilabel>Number every ... lines </guilabel> spin box to specify how often to print the line numbers, for example every 5 lines, every 10 lines, and so on."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:686
-#: C/index.docbook:1546
+#: C/index.docbook:687
+#: C/index.docbook:1547
 msgid "<guilabel>Text Wrapping</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:690
+#: C/index.docbook:691
 msgid "Select the <guilabel>Enable text wrapping</guilabel> option to wrap text onto the next line, at a character level, when you print a file. The application counts wrapped lines as one line for line numbering purposes."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:691
+#: C/index.docbook:692
 msgid "Select the <guilabel>Do not split words over two lines</guilabel> option to wrap text onto the next line, at a word level, when you print a file."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:699
+#: C/index.docbook:700
 msgid "Fonts"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:703
+#: C/index.docbook:704
 msgid "<guilabel>Body</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:707
+#: C/index.docbook:708
 msgid "Click on this button to select the font used to print the body text of a file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:711
+#: C/index.docbook:712
 msgid "<guilabel>Line numbers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:715
+#: C/index.docbook:716
 msgid "Click on this button to select the font used to print line numbers."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:719
+#: C/index.docbook:720
 msgid "<guilabel>Headers and footers</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:723
+#: C/index.docbook:724
 msgid "Click on this button to select the font to use to print the headers and footers in a file."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:727
+#: C/index.docbook:728
 msgid "To reset the fonts to the default fonts for printing a file from <application>pluma</application>, click <guibutton>Restore Default Fonts</guibutton>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:734
+#: C/index.docbook:735
 msgid "Printing a Document"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:736
+#: C/index.docbook:737
 msgid "You can use <application>pluma</application> to perform the following print operations:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:739
+#: C/index.docbook:740
 msgid "Print a document to a printer."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:742
+#: C/index.docbook:743
 msgid "Print the output of the print command to a file."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:745
+#: C/index.docbook:746
 msgid "If you print to a file, <application>pluma</application> sends the output of the file to a pre-press format file. The most common pre-press formats are PostScript and Portable Document Format (PDF)."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:746
+#: C/index.docbook:747
 msgid "To preview the pages that you want to print, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print Preview</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:747
+#: C/index.docbook:748
 msgid "To print the current file to a printer or a file, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Print</guimenuitem> </menuchoice> to display the <guilabel>Print</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:748
+#: C/index.docbook:749
 msgid "The <guilabel>Print</guilabel> dialog enables you to specify the following print options:"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:752
+#: C/index.docbook:753
 msgid "Job Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:756
+#: C/index.docbook:757
 msgid "<guilabel>Print range</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:760
+#: C/index.docbook:761
 msgid "Select one of the following options to determine how many pages to print:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:763
+#: C/index.docbook:764
 msgid "<guilabel>All</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:766
+#: C/index.docbook:767
 msgid "Select this option to print all the pages in the file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:769
+#: C/index.docbook:770
 msgid "<guilabel>Lines</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:772
+#: C/index.docbook:773
 msgid "Select this option to print the specified lines only. Use the <guilabel>From</guilabel> and <guilabel>To</guilabel> spin boxes to specify the line range."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:775
+#: C/index.docbook:776
 msgid "<guilabel>Selection</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:778
+#: C/index.docbook:779
 msgid "Select this option to print the selected text only. This option is only available if you select text."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:784
+#: C/index.docbook:785
 msgid "<guilabel>Copies</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:788
+#: C/index.docbook:789
 msgid "Use the <guilabel>Number of copies</guilabel> spin box to specify the number of copies of the file that you want to print."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:789
+#: C/index.docbook:790
 msgid "If you print multiple copies of the file, select the <guilabel>Collate</guilabel> option to collate the printed copies."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:797
+#: C/index.docbook:798
 msgid "Printer Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:802
+#: C/index.docbook:803
 msgid "<guilabel>Printer</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:806
+#: C/index.docbook:807
 msgid "Use this drop-down list to select the printer to which you want to print the file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:810
+#: C/index.docbook:811
 msgid "<guilabel>Settings</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:814
+#: C/index.docbook:815
 msgid "Use this drop-down list to select the printer settings."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:815
+#: C/index.docbook:816
 msgid "To configure the printer, click <guibutton>Configure</guibutton>. For example, you can enable or disable duplex printing, or schedule delayed printing, if this functionality is supported by the printer."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:819
+#: C/index.docbook:820
 msgid "<guilabel>Location</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:823
+#: C/index.docbook:824
 msgid "Use this drop-down list to select one of the following print destinations:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:826
+#: C/index.docbook:827
 msgid "<guilabel>CUPS</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:830
+#: C/index.docbook:831
 msgid "Print the file to a CUPS printer."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:832
+#: C/index.docbook:833
 msgid "If the selected printer is a CUPS printer, <guilabel>CUPS</guilabel> is the only entry in this drop-down list."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:837
+#: C/index.docbook:838
 msgid "<guilabel>lpr</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:841
+#: C/index.docbook:842
 msgid "Print the file to a printer."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:845
+#: C/index.docbook:846
 msgid "<guilabel>File</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:849
+#: C/index.docbook:850
 msgid "Print the file to a PostScript file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:850
+#: C/index.docbook:851
 msgid "Click <guibutton>Save As</guibutton> to display a dialog where you specify the name and location of the PostScript file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:854
+#: C/index.docbook:855
 msgid "<guilabel>Custom</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:858
+#: C/index.docbook:859
 msgid "Use the specified command to print the file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:859
+#: C/index.docbook:860
 msgid "Type the name of the command in the text box. Include all command-line arguments."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:866
+#: C/index.docbook:867
 msgid "<guilabel>State</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:870
-#: C/index.docbook:878
-#: C/index.docbook:886
+#: C/index.docbook:871
+#: C/index.docbook:879
+#: C/index.docbook:887
 msgid "This functionality is not supported in this version of pluma."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:874
+#: C/index.docbook:875
 msgid "<guilabel>Type</guilabel>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:882
+#: C/index.docbook:883
 msgid "<guilabel>Comment</guilabel>"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:894
+#: C/index.docbook:895
 msgid "Paper Tabbed Section"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:899
+#: C/index.docbook:900
 msgid "<guilabel>Paper size</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:903
+#: C/index.docbook:904
 msgid "Use this drop-down list to select the size of the paper to which you want to print the file."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:907
+#: C/index.docbook:908
 msgid "<guilabel>Width</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:911
+#: C/index.docbook:912
 msgid "Use this spin box to specify the width of the paper. Use the adjacent drop-down list to change the measurement unit."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:915
+#: C/index.docbook:916
 msgid "<guilabel>Height</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:919
+#: C/index.docbook:920
 msgid "Use this spin box to specify the height of the paper."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:923
+#: C/index.docbook:924
 msgid "<guilabel>Feed orientation</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:927
+#: C/index.docbook:928
 msgid "Use this drop-down list to select the orientation of the paper in the printer."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:931
+#: C/index.docbook:932
 msgid "<guilabel>Page orientation</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:935
+#: C/index.docbook:936
 msgid "Use this drop-down list to select the page orientation."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:939
+#: C/index.docbook:940
 msgid "<guilabel>Layout</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:943
+#: C/index.docbook:944
 msgid "Use this drop-down list to select the page layout. A preview of each layout that you select is displayed in the <guilabel>Preview</guilabel> area."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:947
+#: C/index.docbook:948
 msgid "<guilabel>Paper tray</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:951
+#: C/index.docbook:952
 msgid "Use this drop-down list to select the paper tray."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:961
+#: C/index.docbook:962
 msgid "Programming Features"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:963
+#: C/index.docbook:964
 msgid "Several of <application>pluma</application>'s features for programming are provided with plugins. For example, the Tag List plugin provides a list of commonly-used tags for different markup languages: see <xref linkend=\"pluma-tag-list-plugin\"/>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:968
+#: C/index.docbook:969
 msgid "Syntax Highlighting"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:971
+#: C/index.docbook:972
 msgid "Syntax highlighting makes source code easier to read by showing different parts of the text in different colors."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:972
+#: C/index.docbook:973
 msgid "<application>pluma</application> chooses an appropriate syntax highlighting mode based on a document's type. To override the syntax highlighting mode, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Highlight Mode</guimenuitem> </menuchoice>, then choose one of the following menu items:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:975
+#: C/index.docbook:976
 msgid "<guimenuitem>Normal</guimenuitem>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:979
+#: C/index.docbook:980
 msgid "Do not display any syntax highlighting."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:983
+#: C/index.docbook:984
 msgid "<guisubmenu>Sources</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:987
+#: C/index.docbook:988
 msgid "Display syntax highlighting to edit source code. Use the <guisubmenu>Sources</guisubmenu> submenu to select the source code type."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:991
+#: C/index.docbook:992
 msgid "<guisubmenu>Markup</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:995
+#: C/index.docbook:996
 msgid "Display syntax highlighting to edit markup code. Use the <guisubmenu>Markup</guisubmenu> submenu to select the markup code type."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:999
+#: C/index.docbook:1000
 msgid "<guisubmenu>Scripts</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1003
+#: C/index.docbook:1004
 msgid "Display syntax highlighting to edit script code. Use the <guisubmenu>Scripts</guisubmenu> submenu to select the script code type."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1007
+#: C/index.docbook:1008
 msgid "<guisubmenu>Others</guisubmenu>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1011
+#: C/index.docbook:1012
 msgid "Display syntax highlighting to edit other types of code. Use the <guisubmenu>Others</guisubmenu> submenu to select the code type."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1020
+#: C/index.docbook:1021
 msgid "Piping the Output of a Command to a File"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1022
+#: C/index.docbook:1023
 msgid "You can use <application>pluma</application> to pipe the output of a command to a text file. For example, to pipe the output of an <command>ls</command> command to a text file, type <command>ls | pluma</command>, then press <keycap>Return</keycap>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1023
+#: C/index.docbook:1024
 msgid "The output of the <command>ls</command> command is displayed in a new text file in the <application>pluma</application> window."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1024
+#: C/index.docbook:1025
 msgid "Alternatively, you can use the <application>External tools</application> plugin to pipe command output to the current file."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1031
+#: C/index.docbook:1032
 msgid "Shortcut Keys"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1033
+#: C/index.docbook:1034
 msgid "Use shortcut keys to perform common tasks more quickly than with the mouse and menus. The following tables list all of <application>pluma</application>'s shortcut keys."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1034
+#: C/index.docbook:1035
 msgid "For more on shortcut keys, see the <link xlink:href=\"help:mate-user-guide/keyboard-skills\">Desktop User Guide</link>."
 msgstr ""
 
 #. (itstool) path: section/bridgehead
-#: C/index.docbook:1037
+#: C/index.docbook:1038
 msgid "Tabs"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1038
+#: C/index.docbook:1039
 msgid "Shortcuts for tabs:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1046
-#: C/index.docbook:1116
-#: C/index.docbook:1210
-#: C/index.docbook:1304
-#: C/index.docbook:1342
-#: C/index.docbook:1420
-#: C/index.docbook:1490
+#: C/index.docbook:1047
+#: C/index.docbook:1117
+#: C/index.docbook:1211
+#: C/index.docbook:1305
+#: C/index.docbook:1343
+#: C/index.docbook:1421
+#: C/index.docbook:1491
 msgid "Shortcut Key"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1049
-#: C/index.docbook:1119
-#: C/index.docbook:1213
-#: C/index.docbook:1307
-#: C/index.docbook:1345
-#: C/index.docbook:1423
-#: C/index.docbook:1493
+#: C/index.docbook:1050
+#: C/index.docbook:1120
+#: C/index.docbook:1214
+#: C/index.docbook:1308
+#: C/index.docbook:1346
+#: C/index.docbook:1424
+#: C/index.docbook:1494
 msgid "Command"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1056
+#: C/index.docbook:1057
 msgid "Ctrl + Alt + PageUp"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1059
+#: C/index.docbook:1060
 msgid "Switches to the next tab to the left."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1064
+#: C/index.docbook:1065
 msgid "Ctrl + Alt + PageDown"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1067
+#: C/index.docbook:1068
 msgid "Switches to the next tab to the right."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1072
-#: C/index.docbook:1182
+#: C/index.docbook:1073
+#: C/index.docbook:1183
 msgid "Ctrl + W"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1075
+#: C/index.docbook:1076
 msgid "Close tab."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1080
+#: C/index.docbook:1081
 msgid "Ctrl + Shift + L"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1083
+#: C/index.docbook:1084
 msgid "Save all tabs."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1088
+#: C/index.docbook:1089
 msgid "Ctrl + Shift + W"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1091
+#: C/index.docbook:1092
 msgid "Close all tabs."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1096
+#: C/index.docbook:1097
 msgid "Alt + n"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1099
+#: C/index.docbook:1100
 msgid "Jump to nth tab."
 msgstr ""
 
 #. (itstool) path: section/bridgehead
-#: C/index.docbook:1107
+#: C/index.docbook:1108
 msgid "Files"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1108
+#: C/index.docbook:1109
 msgid "Shortcuts for working with files:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1126
+#: C/index.docbook:1127
 msgid "Ctrl + N"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1129
+#: C/index.docbook:1130
 msgid "Create a new document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1134
+#: C/index.docbook:1135
 msgid "Ctrl + O"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1137
+#: C/index.docbook:1138
 msgid "Open a document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1142
+#: C/index.docbook:1143
 msgid "Ctrl + L"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1145
+#: C/index.docbook:1146
 msgid "Open a location."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1150
+#: C/index.docbook:1151
 msgid "Ctrl + S"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1153
+#: C/index.docbook:1154
 msgid "Save the current document to disk."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1158
+#: C/index.docbook:1159
 msgid "Ctrl + Shift + S"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1161
+#: C/index.docbook:1162
 msgid "Save the current document with a new filename."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1166
+#: C/index.docbook:1167
 msgid "Ctrl + P"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1169
+#: C/index.docbook:1170
 msgid "Print the current document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1174
+#: C/index.docbook:1175
 msgid "Ctrl + Shift + P"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1177
+#: C/index.docbook:1178
 msgid "Print preview."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1185
+#: C/index.docbook:1186
 msgid "Close the current document."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1190
+#: C/index.docbook:1191
 msgid "Ctrl + Q"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1193
+#: C/index.docbook:1194
 msgid "Quit Pluma."
 msgstr ""
 
 #. (itstool) path: section/bridgehead
-#: C/index.docbook:1201
+#: C/index.docbook:1202
 msgid "Edit"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1202
+#: C/index.docbook:1203
 msgid "Shortcuts for editing documents:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1220
+#: C/index.docbook:1221
 msgid "Ctrl + Z"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1223
+#: C/index.docbook:1224
 msgid "Undo the last action."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1228
+#: C/index.docbook:1229
 msgid "Ctrl + Shift + Z"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1231
+#: C/index.docbook:1232
 msgid "Redo the last undone action ."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1236
+#: C/index.docbook:1237
 msgid "Ctrl + X"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1239
+#: C/index.docbook:1240
 msgid "Cut the selected text or region and place it on the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1244
+#: C/index.docbook:1245
 msgid "Ctrl + C"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1247
+#: C/index.docbook:1248
 msgid "Copy the selected text or region onto the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1252
+#: C/index.docbook:1253
 msgid "Ctrl + V"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1255
+#: C/index.docbook:1256
 msgid "Paste the contents of the clipboard."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1260
+#: C/index.docbook:1261
 msgid "Ctrl + A"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1263
+#: C/index.docbook:1264
 msgid "Select all."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1268
+#: C/index.docbook:1269
 msgid "Ctrl + D"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1271
+#: C/index.docbook:1272
 msgid "Delete current line."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1276
+#: C/index.docbook:1277
 msgid "Alt + Up"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1279
+#: C/index.docbook:1280
 msgid "Move the selected line up one line."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1284
+#: C/index.docbook:1285
 msgid "Alt + Down"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1287
+#: C/index.docbook:1288
 msgid "Move the selected line down one line."
 msgstr ""
 
 #. (itstool) path: section/bridgehead
-#: C/index.docbook:1295
+#: C/index.docbook:1296
 msgid "Panes"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1296
+#: C/index.docbook:1297
 msgid "Shortcuts for showing and hiding panes:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1314
+#: C/index.docbook:1315
 msgid "F9"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1317
+#: C/index.docbook:1318
 msgid "Show/hide the side pane."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1322
+#: C/index.docbook:1323
 msgid "Ctrl + F9"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1325
+#: C/index.docbook:1326
 msgid "Show/hide the bottom pane."
 msgstr ""
 
 #. (itstool) path: section/bridgehead
-#: C/index.docbook:1333
+#: C/index.docbook:1334
 msgid "Search"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1334
+#: C/index.docbook:1335
 msgid "Shortcuts for searching:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1352
+#: C/index.docbook:1353
 msgid "Ctrl + F"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1355
+#: C/index.docbook:1356
 msgid "Find a string."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1360
+#: C/index.docbook:1361
 msgid "Ctrl + G"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1363
+#: C/index.docbook:1364
 msgid "Find the next instance of the string."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1368
+#: C/index.docbook:1369
 msgid "Ctrl + Shift + G"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1371
+#: C/index.docbook:1372
 msgid "Find the previous instance of the string."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1376
+#: C/index.docbook:1377
 msgid "Ctrl + K"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1379
+#: C/index.docbook:1380
 msgid "Interactive search."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1384
+#: C/index.docbook:1385
 msgid "Ctrl + H"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1387
+#: C/index.docbook:1388
 msgid "Search and replace."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1392
+#: C/index.docbook:1393
 msgid "Ctrl + Shift + K"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1395
+#: C/index.docbook:1396
 msgid "Clear highlight."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1400
+#: C/index.docbook:1401
 msgid "Ctrl + I"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1403
+#: C/index.docbook:1404
 msgid "Goto line."
 msgstr ""
 
 #. (itstool) path: section/bridgehead
-#: C/index.docbook:1411
+#: C/index.docbook:1412
 msgid "Tools"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1412
+#: C/index.docbook:1413
 msgid "Shortcuts for tools:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1430
+#: C/index.docbook:1431
 msgid "Shift + F7"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1433
+#: C/index.docbook:1434
 msgid "Check spelling (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1438
+#: C/index.docbook:1439
 msgid "Alt + F12"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1441
+#: C/index.docbook:1442
 msgid "Remove trailing spaces (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1446
+#: C/index.docbook:1447
 msgid "Ctrl + T"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1449
+#: C/index.docbook:1450
 msgid "Indent (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1454
+#: C/index.docbook:1455
 msgid "Ctrl + Shift + T"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1457
+#: C/index.docbook:1458
 msgid "Remove Indent (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1462
+#: C/index.docbook:1463
 msgid "F8"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1465
+#: C/index.docbook:1466
 msgid "Run \"make\" in current directory (with plugin)."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1470
+#: C/index.docbook:1471
 msgid "Ctrl + Shift + D"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1473
+#: C/index.docbook:1474
 msgid "Directory listing (with plugin)."
 msgstr ""
 
 #. (itstool) path: section/bridgehead
-#: C/index.docbook:1481
+#: C/index.docbook:1482
 msgid "Help"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1482
+#: C/index.docbook:1483
 msgid "Shortcuts for help:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1500
+#: C/index.docbook:1501
 msgid "F1"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1503
+#: C/index.docbook:1504
 msgid "Open <application>pluma</application>'s user manual."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1514
+#: C/index.docbook:1515
 msgid "Preferences"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1516
+#: C/index.docbook:1517
 msgid "To configure <application>pluma</application>, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>. The <guilabel>Preferences</guilabel> dialog contains the following categories:"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1542
+#: C/index.docbook:1543
 msgid "View Preferences"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1550
+#: C/index.docbook:1551
 msgid "Select the <guilabel>Enable text wrapping</guilabel> option to have long lines of text flow into paragraphs instead of running off the edge of the text window. This avoids having to scroll horizontally"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1551
+#: C/index.docbook:1552
 msgid "Select the <guilabel>Do not split words over two lines</guilabel> option to have the text wrapping option preserve whole words when flowing text to the next line. This makes text easier to read."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1559
+#: C/index.docbook:1560
 msgid "Select the <guilabel>Display line numbers</guilabel> option to display line numbers on the left side of the <application>pluma</application> window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1563
+#: C/index.docbook:1564
 msgid "<guilabel>Current Line</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1567
+#: C/index.docbook:1568
 msgid "Select the <guilabel>Highlight current line</guilabel> option to highlight the line where the cursor is placed."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1571
+#: C/index.docbook:1572
 msgid "<guilabel>Right Margin</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1575
+#: C/index.docbook:1576
 msgid "Select the <guilabel>Display right margin</guilabel> option to display a vertical line that indicates the right margin."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1576
+#: C/index.docbook:1577
 msgid "Use the <guilabel>Right margin at column</guilabel> spin box to specify the location of the vertical line."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1580
+#: C/index.docbook:1581
 msgid "<guilabel>Bracket Matching</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1584
+#: C/index.docbook:1585
 msgid "Select the <guilabel>Highlight matching bracket</guilabel> option to highlight the corresponding bracket when the cursor is positioned on a bracket character."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1592
+#: C/index.docbook:1593
 msgid "Editor Preferences"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1596
+#: C/index.docbook:1597
 msgid "<guilabel>Tabs</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1600
+#: C/index.docbook:1601
 msgid "Use the <guilabel>Tab width</guilabel> spin box to specify the width of the space that <application> pluma</application> inserts when you press the <keycap>Tab</keycap> key."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1601
+#: C/index.docbook:1602
 msgid "Select the <guilabel>Insert spaces instead of tabs</guilabel> option to specify that <application> pluma</application> inserts spaces instead of a tab character when you press the <keycap>Tab</keycap> key."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1605
+#: C/index.docbook:1606
 msgid "<guilabel>Auto Indentation</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1609
+#: C/index.docbook:1610
 msgid "Select the <guilabel>Enable auto indentation</guilabel> option to specify that the next line starts at the indentation level of the current line."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1613
+#: C/index.docbook:1614
 msgid "<guilabel>File Saving</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1617
+#: C/index.docbook:1618
 msgid "Select the <guilabel>Create a backup copy of files before saving</guilabel> option to create a backup copy of a file each time you save the file. The backup copy of the file contains a ~ at the end of the filename."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1618
+#: C/index.docbook:1619
 msgid "Select the <guilabel>Autosave files every ... minutes</guilabel> option to automatically save the current file at regular intervals. Use the spin box to specify how often you want to save the file."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1626
+#: C/index.docbook:1627
 msgid "Font &amp; Colors Preferences"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1631
+#: C/index.docbook:1632
 msgid "<guilabel>Font</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1635
+#: C/index.docbook:1636
 msgid "Select the <guilabel>Use default theme font</guilabel> option to use the default system font for the text in the <application>pluma</application> text window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1636
+#: C/index.docbook:1637
 msgid "The <guilabel>Editor font</guilabel> field displays the font that <application>pluma</application> uses to display text. Click on the button to specify the font type, style, and size to use for text."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1640
+#: C/index.docbook:1641
 msgid "<guilabel>Color Scheme</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1644
+#: C/index.docbook:1645
 msgid "You can choose a color scheme from the list of color schemes. By default, the following color schemes are installed:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1647
+#: C/index.docbook:1648
 msgid "<guilabel>Classic</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1651
+#: C/index.docbook:1652
 msgid "Classic color scheme based on the gvim color scheme."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1655
+#: C/index.docbook:1656
 msgid "<guilabel>Cobalt</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1659
+#: C/index.docbook:1660
 msgid "Blue based color scheme."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1663
+#: C/index.docbook:1664
 msgid "<guilabel>Kate</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1667
+#: C/index.docbook:1668
 msgid "Color scheme used in the Kate text editor."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1671
+#: C/index.docbook:1672
 msgid "<guilabel>Oblivion</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1675
+#: C/index.docbook:1676
 msgid "Dark color scheme using the Tango color palette."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1679
+#: C/index.docbook:1680
 msgid "<guilabel>Tango</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1683
+#: C/index.docbook:1684
 msgid "Color scheme using the Tango color scheme."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1687
+#: C/index.docbook:1688
 msgid "You can add a new color scheme by clicking on <guilabel>Add...</guilabel>, and selecting a color scheme file"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1688
+#: C/index.docbook:1689
 msgid "You can remove the selected color scheme by clicking on <guilabel>Remove</guilabel>"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1696
+#: C/index.docbook:1697
 msgid "Plugins Preferences"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1698
+#: C/index.docbook:1699
 msgid "Plugins add extra features to <application>pluma</application>. For more information on plugins and how to use the built-in plugins, see <xref linkend=\"pluma-plugins-overview\"/>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1703
+#: C/index.docbook:1704
 msgid "Enabling a Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1705
+#: C/index.docbook:1706
 msgid "To enable a <application>pluma</application> plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1708
-#: C/index.docbook:1732
-#: C/index.docbook:2161
+#: C/index.docbook:1709
+#: C/index.docbook:1733
+#: C/index.docbook:2162
 msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Preferences</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1711
-#: C/index.docbook:1735
-#: C/index.docbook:2164
+#: C/index.docbook:1712
+#: C/index.docbook:1736
+#: C/index.docbook:2165
 msgid "Select the <guilabel>Plugins</guilabel> tab."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1714
+#: C/index.docbook:1715
 msgid "Select the check box next to the name of the plugin that you want to enable."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1717
-#: C/index.docbook:1741
+#: C/index.docbook:1718
+#: C/index.docbook:1742
 msgid "Click <guibutton>Close</guibutton> to close the <guilabel>Preferences</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1725
+#: C/index.docbook:1726
 msgid "Disabling a Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1728
+#: C/index.docbook:1729
 msgid "A plugin remains enabled when you quit <application>pluma</application>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1729
+#: C/index.docbook:1730
 msgid "To disable a <application>pluma</application> plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1738
+#: C/index.docbook:1739
 msgid "Deselect the check box next to the name of the plugin that you want to disable."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1751
+#: C/index.docbook:1752
 msgid "Plugins"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1756
+#: C/index.docbook:1757
 msgid "Working with Plugins"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1758
+#: C/index.docbook:1759
 msgid "You can add extra features to <application>pluma</application> by enabling <firstterm>plugins</firstterm>. A plugin is a supplementary program that enhances the functionality of an application. Plugins add new items to the <application>pluma</application> menus for the new features they provide."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1760
+#: C/index.docbook:1761
 msgid "Several plugins come built-in with <application>pluma</application>, and you can install more. The <link xlink:href=\"http://live.gnome.org/Pluma/Plugins\">pluma website</link> lists third-party plugins."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1761
+#: C/index.docbook:1762
 msgid "To enable and disable plugins, or see which plugins are currently enabled, use the <link linkend=\"pluma-prefs-plugins\">Plugins Preferences</link>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1762
+#: C/index.docbook:1763
 msgid "The following plugins come built-in with <application>pluma</application>:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1768
+#: C/index.docbook:1769
 msgid "<link linkend=\"pluma-change-case-plugin\"> <application>Change Case</application> </link> allows you to change the case of the selected text."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1774
+#: C/index.docbook:1775
 msgid "<application> <link linkend=\"pluma-document-statistics-plugin\">Document Statistics</link> </application> shows the number of lines, words, and characters in the document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1780
+#: C/index.docbook:1781
 msgid "<application> <link linkend=\"pluma-external-tools-plugin\">External Tools</link> </application> allows you to execute external commands from <application>pluma</application>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1786
+#: C/index.docbook:1787
 msgid "<application>File Browser</application> allows you to browse your files and folders in the side pane."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1790
+#: C/index.docbook:1791
 msgid "<application> <link linkend=\"pluma-indent-lines-plugin\">Indent Lines</link> </application> adds or removes indentation from the selected lines."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1796
+#: C/index.docbook:1797
 msgid "<application> <link linkend=\"pluma-insert-date-time-plugin\">Insert Date/Time</link> </application> adds the current date and time into a document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1802
+#: C/index.docbook:1803
 msgid "<application> <link linkend=\"pluma-modelines-plugin\">Modelines</link> </application> allows you to set editing preferences for individual documents, and supports <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>-style modelines."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1808
+#: C/index.docbook:1809
 msgid "<application> <link linkend=\"pluma-python-console-plugin\">Python Console</link> </application> allows you to run commands in the python programming language."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1814
+#: C/index.docbook:1815
 msgid "<application> <link linkend=\"pluma-snippets-plugin\">Snippets</link> </application> allows you to store frequently-used pieces of text and insert them quickly into a document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1820
+#: C/index.docbook:1821
 msgid "<application> <link linkend=\"pluma-sort-plugin\">Sort</link> </application> arranges selected lines of text into alphabetical order."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1826
+#: C/index.docbook:1827
 msgid "<application> <link linkend=\"pluma-spell-checker-plugin\">Spell Checker</link> </application> corrects the spelling in the selected text, or marks errors automatically in the document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1832
+#: C/index.docbook:1833
 msgid "<application> <link linkend=\"pluma-tag-list-plugin\">Tag List</link> </application> lets you insert commonly-used tags for HTML and other languages from a list in the side pane."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:1840
+#: C/index.docbook:1841
 msgid "For more information on creating plugins, see the <link xlink:href=\"http://live.gnome.org/Pluma/Plugins\"> <application>pluma</application> website</link>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1846
+#: C/index.docbook:1847
 msgid "Change Case Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1848
+#: C/index.docbook:1849
 msgid "The <application>Change Case</application> plugin changes the case of the selected text."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1849
+#: C/index.docbook:1850
 msgid "The following items are added to the <guimenu>Edit</guimenu> menu when the <application>Change Case</application> plugin is enabled:"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1858
+#: C/index.docbook:1859
 msgid "Menu Item"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1861
+#: C/index.docbook:1862
 msgid "Action"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1864
+#: C/index.docbook:1865
 msgid "Example"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1871
+#: C/index.docbook:1872
 msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>All Upper Case</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1874
+#: C/index.docbook:1875
 msgid "Change each character to uppercase."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1877
+#: C/index.docbook:1878
 msgid "<literal>This text</literal> becomes <literal>THIS TEXT</literal>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1882
+#: C/index.docbook:1883
 msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>All Lower Case</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1885
+#: C/index.docbook:1886
 msgid "Change each character to lowercase."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1888
+#: C/index.docbook:1889
 msgid "<literal>This Text</literal> becomes <literal>this text</literal>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1893
+#: C/index.docbook:1894
 msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>Invert Case</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1896
+#: C/index.docbook:1897
 msgid "Change each lowercase character to uppercase, and change each uppercase character to lowercase."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1899
+#: C/index.docbook:1900
 msgid "<literal>This Text</literal> becomes <literal>tHIS tEXT</literal>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1904
+#: C/index.docbook:1905
 msgid "<menuchoice> <guimenu>Edit</guimenu> <guisubmenu>Change Case</guisubmenu> <guimenuitem>Title Case</guimenuitem> </menuchoice>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1907
+#: C/index.docbook:1908
 msgid "Change the first character of each word to uppercase."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1910
+#: C/index.docbook:1911
 msgid "<literal>this text</literal> becomes <literal>This Text</literal>"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1921
+#: C/index.docbook:1922
 msgid "Document Statistics Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1924
+#: C/index.docbook:1925
 msgid "The <application>Document Statistics</application> plugin counts the number of lines, words, characters with spaces, characters without spaces, and bytes in the current file. The plugin displays the results in a <guilabel>Document Statistics</guilabel> dialog. To use the Document Statistics plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1927
+#: C/index.docbook:1928
 msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Document Statistics</guimenuitem> </menuchoice> to display the <guilabel>Document Statistics</guilabel> dialog. The <guilabel>Document Statistics</guilabel> dialog displays the following information about the file:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1930
+#: C/index.docbook:1931
 msgid "Number of lines in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1933
+#: C/index.docbook:1934
 msgid "Number of words in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1936
+#: C/index.docbook:1937
 msgid "Number of characters, including spaces, in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1939
+#: C/index.docbook:1940
 msgid "Number of characters, not including spaces, in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1942
+#: C/index.docbook:1943
 msgid "Number of bytes in the current document."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1947
+#: C/index.docbook:1948
 msgid "You can continue to update the <application>pluma</application> file while the <guilabel>Document Statistics</guilabel> dialog is open. To refresh the contents of the <guilabel>Document Statistics</guilabel> dialog, click <guibutton>Update</guibutton>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1954
+#: C/index.docbook:1955
 msgid "External Tools Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1956
+#: C/index.docbook:1957
 msgid "The <application>External Tools</application> plugin allows you to execute external commands from <application>pluma</application>. You can pipe some content into a command and exploit its output (for example, <application>sed</application>), or launch a predefined command (for example, <application>make</application>)."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1957
+#: C/index.docbook:1958
 msgid "Use the <guilabel>External Tools Manager</guilabel> to create and edit commands. To run an external command, choose it from the <guimenu>Tools</guimenu> menu."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:1961
+#: C/index.docbook:1962
 msgid "Built-in Commands"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:1963
+#: C/index.docbook:1964
 msgid "The following commands are provided with the <application>External Tools</application> plugin:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1966
+#: C/index.docbook:1967
 msgid "Build"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1968
+#: C/index.docbook:1969
 msgid "Runs <application>make</application> in the current document's directory."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1972
+#: C/index.docbook:1973
 msgid "Directory Listing"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1974
+#: C/index.docbook:1975
 msgid "Lists the contents of the current document's directory in a new document."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1978
+#: C/index.docbook:1979
 msgid "Environment Variables"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1980
+#: C/index.docbook:1981
 msgid "Displays the environment variables list in the bottom pane."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1984
+#: C/index.docbook:1985
 msgid "Grep"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1986
+#: C/index.docbook:1987
 msgid "Searches for a term in all files in the current document directory, using pattern matching. Results are shown in the bottom pane."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1990
+#: C/index.docbook:1991
 msgid "Remove Trailing Spaces"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1992
+#: C/index.docbook:1993
 msgid "Removes all spaces from the end of lines in the document."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2000
+#: C/index.docbook:2001
 msgid "Defining a Command"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2002
+#: C/index.docbook:2003
 msgid "To add an external command, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>External Tools</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2003
+#: C/index.docbook:2004
 msgid "In the <guilabel>External Tools Manager</guilabel> window, click <guibutton>New</guibutton>. You can specify the following details for the new command:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2006
+#: C/index.docbook:2007
 msgid "Description"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2008
+#: C/index.docbook:2009
 msgid "This description is shown in the statusbar when the menu command is chosen."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2012
+#: C/index.docbook:2013
 msgid "Accelerator"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2014
+#: C/index.docbook:2015
 msgid "Enter a keyboard shortcut for the command."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2018
+#: C/index.docbook:2019
 msgid "Commands"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2020
+#: C/index.docbook:2021
 msgid "The actual commands to be run. Several <application>pluma</application> environment variables can be used to pass content to these commands: see <xref linkend=\"pluma-external-tools-plugin-variables\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2024
+#: C/index.docbook:2025
 msgid "Input"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2026
+#: C/index.docbook:2027
 msgid "The content to give to the commands (as <systemitem>stdin</systemitem>): the entire text of the current document, the current selection, line, or word."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2030
+#: C/index.docbook:2031
 msgid "Output"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2032
+#: C/index.docbook:2033
 msgid "What to do with the output of the commands: display in the bottom pane, put in a new document, or place in the current document, at the end, at the cursor position, or replacing the selection or the entire document."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2036
+#: C/index.docbook:2037
 msgid "Applicability"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2038
+#: C/index.docbook:2039
 msgid "Determines which sort of documents can be affected by the command, for example whether saved or not, and local or remote."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2046
+#: C/index.docbook:2047
 msgid "Editing and Removing Tools"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2048
+#: C/index.docbook:2049
 msgid "To edit a tool, select it in the list and make changes to its properties."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2049
+#: C/index.docbook:2050
 msgid "To rename a tool, click it again in the list."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2050
+#: C/index.docbook:2051
 msgid "To restore a built-in tool that you have changed, press <guilabel>Revert</guilabel>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2051
+#: C/index.docbook:2052
 msgid "To remove a tool, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in tools, only those you have created yourself."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2056
+#: C/index.docbook:2057
 msgid "Variables"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2058
+#: C/index.docbook:2059
 msgid "You can use the following variables in the <guilabel>Commands</guilabel> field of the command definition:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2061
+#: C/index.docbook:2062
 msgid "PLUMA_CURRENT_DOCUMENT_URI"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2064
+#: C/index.docbook:2065
 msgid "PLUMA_CURRENT_DOCUMENT_NAME"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2067
+#: C/index.docbook:2068
 msgid "PLUMA_CURRENT_DOCUMENT_SCHEME"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2070
+#: C/index.docbook:2071
 msgid "PLUMA_CURRENT_DOCUMENT_PATH"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2073
+#: C/index.docbook:2074
 msgid "PLUMA_CURRENT_DOCUMENT_DIR"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2076
+#: C/index.docbook:2077
 msgid "PLUMA_DOCUMENTS_URI"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2079
+#: C/index.docbook:2080
 msgid "PLUMA_DOCUMENTS_PATH"
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2087
+#: C/index.docbook:2088
 msgid "File Browser Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2089
+#: C/index.docbook:2090
 msgid "The <application>File Browser</application> Plugin shows your files and folders in the side pane, allowing you to quickly open files."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2090
+#: C/index.docbook:2091
 msgid "To view the File Browser, choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice> and then click on the tab showing the File Browser icon at the bottom of the side pane."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2094
+#: C/index.docbook:2095
 msgid "Browsing your Files"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2096
+#: C/index.docbook:2097
 msgid "The File Browser tab initially shows your file manager bookmarks. To browse the contents of any item, double-click it."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2097
+#: C/index.docbook:2098
 msgid "To show a parent folder, choose from the drop-down list, or press the up arrow on the File Browser's toolbar."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2098
+#: C/index.docbook:2099
 msgid "To show the folder that contains the document you are currently working on, right-click in the file list and choose <guimenuitem>Set root to active document</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2105
+#: C/index.docbook:2106
 msgid "To open a file in <application>pluma</application>, double-click it in the file list."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2110
+#: C/index.docbook:2111
 msgid "Creating Files and Folders"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2112
+#: C/index.docbook:2113
 msgid "To create a new, empty text file in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New File</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2113
+#: C/index.docbook:2114
 msgid "To create a new folder in the current folder shown in the browser, right-click in the file list and choose <guimenuitem>New Folder</guimenuitem>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2119
+#: C/index.docbook:2120
 msgid "Indent Lines Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2121
+#: C/index.docbook:2122
 msgid "The <application>Indent Lines</application> plugin adds or removes space from the beginning of lines of text."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2122
+#: C/index.docbook:2123
 msgid "To indent or unindent text, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2125
+#: C/index.docbook:2126
 msgid "Select the lines that you want to indent. To indent or unindent a single line, place the cursor anywhere on that line."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2130
+#: C/index.docbook:2131
 msgid "To indent the text, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Indent</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2133
+#: C/index.docbook:2134
 msgid "To remove the indentation, choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Unindent</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2138
+#: C/index.docbook:2139
 msgid "The amount of space used, and whether tab character or space characters are used, depends on the <guilabel>Tab Stops</guilabel> settings in the Editor Preferences: see <xref linkend=\"pluma-prefs-editor\"/>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2143
+#: C/index.docbook:2144
 msgid "Insert Date/Time Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2145
+#: C/index.docbook:2146
 msgid "The <application>Insert Date/Time</application> plugin inserts the current date and time into a document. To use the Insert Date/Time plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2148
+#: C/index.docbook:2149
 msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2149
+#: C/index.docbook:2150
 msgid "If you have not configured the Insert Date/Time plugin to automatically insert the date/time without prompting you for the format, <application>pluma</application> displays the <guilabel>Insert Date and Time</guilabel> dialog. Select the appropriate date/time format from the list. Click <guibutton>Insert</guibutton> to close the <guilabel>Insert Date and Time</guilabel> dialog. <application>pluma</application> inserts the date/time at the cursor position in the current file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2150
+#: C/index.docbook:2151
 msgid "If you have configured <application>pluma</application> to use one particular date/time format, the <guilabel>Insert Date and Time</guilabel> dialog is not displayed. The date/time is automatically entered at the cursor position in the current file."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2156
+#: C/index.docbook:2157
 msgid "Configuring the Insert Date/Time Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2158
+#: C/index.docbook:2159
 msgid "To configure the Insert Date/Time plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2167
+#: C/index.docbook:2168
 msgid "Select the <guilabel>Insert Date/Time</guilabel> plugin."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2170
+#: C/index.docbook:2171
 msgid "Click <guibutton>Configure Plugin</guibutton> to display the <guilabel>Configure insert date/time plugin</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2173
+#: C/index.docbook:2174
 msgid "Select one of the options, as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2176
+#: C/index.docbook:2177
 msgid "To specify the date/time format each time you insert the date/time, select the <guilabel>Prompt for a format</guilabel> option."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2179
+#: C/index.docbook:2180
 msgid "To use the same <application>pluma</application>-provided date/time format each time you insert the date/time, select the <guilabel>Use the selected format</guilabel> option, then select the appropriate format from the list. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2182
+#: C/index.docbook:2183
 msgid "To use the same customized date/time format each time you insert the date/time, select the <guilabel>Use custom format</guilabel> option, then enter the appropriate format in the text box. Refer to the <link xlink:href=\"man:strftime\"> <citerefentry> <refentrytitle>strftime</refentrytitle> <manvolnum>3</manvolnum> </citerefentry> </link> for more information on how to specify a custom format. When you select this option, <application>pluma</application> does not prompt you for the date/time format when you choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Insert Date and Time</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2193
+#: C/index.docbook:2194
 msgid "Click <guibutton>OK</guibutton> to close the <guilabel>Configure insert date/time plugin</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2197
+#: C/index.docbook:2198
 msgid "To close the <guilabel>Preferences</guilabel> dialog, click <guibutton>Close</guibutton>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2205
+#: C/index.docbook:2206
 msgid "Modelines Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2207
+#: C/index.docbook:2208
 msgid "The <application>Modelines</application> plugin allows you to set preferences for individual documents. A <firstterm>modeline</firstterm> is a line of text at the start or end of the document with settings that <application>pluma</application> recognizes."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2208
+#: C/index.docbook:2209
 msgid "Preferences set using modelines take precedence over the ones specified in the preference dialog."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2209
+#: C/index.docbook:2210
 msgid "You can set the following preferences with modelines:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2212
+#: C/index.docbook:2213
 msgid "Tab width"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2215
+#: C/index.docbook:2216
 msgid "Indent width"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2218
+#: C/index.docbook:2219
 msgid "Insert spaces instead of tabs"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2221
+#: C/index.docbook:2222
 msgid "Text Wrapping"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2224
+#: C/index.docbook:2225
 msgid "Right margin width"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2227
+#: C/index.docbook:2228
 msgid "The <application>Modelines</application> plugin supports a subset of the options used by other text editors <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2231
+#: C/index.docbook:2232
 msgid "Emacs Modelines"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2233
+#: C/index.docbook:2234
 msgid "The first two lines of a document are scanned for <application>Emacs</application> modelines."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2234
+#: C/index.docbook:2235
 msgid "The <application>Emacs</application> options for tab-width, indent-offset, indent-tabs-mode and autowrap are supported. For more information, see the <link xlink:href=\"http://www.delorie.com/gnu/docs/emacs/emacs_486.html\">GNU Emacs Manual</link>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2239
+#: C/index.docbook:2240
 msgid "Kate Modelines"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2241
+#: C/index.docbook:2242
 msgid "The first and last ten lines a document are scanned for <application>Kate</application> modelines."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2242
+#: C/index.docbook:2243
 msgid "The <application>Kate</application> options for tab-width, indent-width, space-indent, word-wrap and word-wrap-column are supported. For more information, see the <link xlink:href=\"http://www.kate-editor.org/article/katepart_modelines\">Kate website</link>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2247
+#: C/index.docbook:2248
 msgid "Vim Modelines"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2249
+#: C/index.docbook:2250
 msgid "The first and last three lines a document are scanned for <application>Vim</application> modelines."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2250
+#: C/index.docbook:2251
 msgid "The <application>Vim</application> options for et, expandtab, ts, tabstop, sw, shiftwidth, wrap, and textwidth are supported. For more information, see the <link xlink:href=\"http://vimdoc.sourceforge.net/htmldoc/options.html#modeline\">Vim website</link>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2256
+#: C/index.docbook:2257
 msgid "Python Console Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2258
+#: C/index.docbook:2259
 msgid "The <application>Python Console</application> Plugin allows you to run commands in the python programming language from <application>pluma</application>. Enabling the plugin adds a tab to the bottom pane. This shows recent output and a command prompt field."
 msgstr ""
 
 #. (itstool) path: caution/para
-#: C/index.docbook:2260
+#: C/index.docbook:2261
 msgid "Commands entered into the python console are not checked before they are run. It is therefore possible to hang <application>pluma</application>, for example by entering an infinite loop."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2266
+#: C/index.docbook:2267
 msgid "Snippets Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2268
+#: C/index.docbook:2269
 msgid "The <application>Snippets</application> plugin allows you to store frequently-used pieces of text, called <firstterm>snippets</firstterm>, and insert them quickly into a document."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2269
+#: C/index.docbook:2270
 msgid "Snippets are specific to the language syntax of the current document. For example, when you are working with an HTML document, you can choose from a list of snippets that are useful for HTML. In addition, some snippets are global, and are available in all documents."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2270
+#: C/index.docbook:2271
 msgid "A number of built-in snippets are installed with <application>pluma</application>, which can be modified."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2274
+#: C/index.docbook:2275
 msgid "Inserting Snippets"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2276
+#: C/index.docbook:2277
 msgid "To insert a snippet into a document, type its <firstterm>tab trigger</firstterm> and press <keycap>Tab</keycap>. A snippet's tab trigger is usually the first few letters of the snippet, or something else that is short and easy to remember."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2277
+#: C/index.docbook:2278
 msgid "Alternatively, press <keycombo> <keycap>Ctrl</keycap> <keycap>Space</keycap> </keycombo> to see a list of snippets you can insert."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2282
+#: C/index.docbook:2283
 msgid "Adding Snippets"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2284
+#: C/index.docbook:2285
 msgid "To create a new snippet, do the following:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2287
+#: C/index.docbook:2288
 msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Manage Snippets</guimenuitem> </menuchoice>. The <guilabel>Snippets Manager</guilabel> window opens."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2290
+#: C/index.docbook:2291
 msgid "The list of snippets is grouped by language. Select the language you want to add a snippet to, or a snippet in that language group. To add a snippet for all languages, choose Global at the top of the list. The syntax of the document you are currently working with is shown by default."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2293
+#: C/index.docbook:2294
 msgid "Click <guibutton>New</guibutton>. A new snippet appears in the list."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2296
+#: C/index.docbook:2297
 msgid "Enter the following information for the new snippet:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2299
+#: C/index.docbook:2300
 msgid "Name"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2301
+#: C/index.docbook:2302
 msgid "Enter a name for the snippet in the text field within the snippet list. The name of a snippet serves only as a reminder of its purpose. You can change name of a snippet you create by clicking on it in the list."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2305
+#: C/index.docbook:2306
 msgid "Snippet text"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2307
+#: C/index.docbook:2308
 msgid "Enter the text of the snippet in the <guilabel>Edit snippet</guilabel> text box. For special codes you can use, see <xref linkend=\"pluma-snippets-plugin-syntax\"/>."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/index.docbook:2309
+#: C/index.docbook:2310
 msgid "You can switch back to the document window to copy text without closing the <guilabel>Snippets Manager</guilabel> window."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2314
+#: C/index.docbook:2315
 msgid "Tab Trigger"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2316
+#: C/index.docbook:2317
 msgid "Enter the tab trigger for the snippet. This is the text that you type before pressing <keycap>Tab</keycap> to insert the snippet."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2317
+#: C/index.docbook:2318
 msgid "The tag must be either a single word comprising only letters, or any single character. The <guilabel>Tab trigger</guilabel> will highlight in red if an invalid tab trigger is entered."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2321
+#: C/index.docbook:2322
 msgid "Shortcut key"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2323
+#: C/index.docbook:2324
 msgid "Type a shortcut key to use for inserting the snippet."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2333
+#: C/index.docbook:2334
 msgid "Editing and Removing Snippets"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2335
+#: C/index.docbook:2336
 msgid "To edit a snippet, select it in the list and make changes to its text and activation properties."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2336
+#: C/index.docbook:2337
 msgid "To rename a snippet, click it again in the list."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2337
+#: C/index.docbook:2338
 msgid "To restore a built-in snippet that you have changed, press <guilabel>Revert</guilabel>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2338
+#: C/index.docbook:2339
 msgid "To remove a snippet, select it in the list and press <guibutton>Remove</guibutton>. You can not remove built-in snippets, only those you have created yourself."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2343
+#: C/index.docbook:2344
 msgid "Snippet Substitutions"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2345
+#: C/index.docbook:2346
 msgid "In addition to inserting stored text, a snippet can include customizable text, or mark spaces where you can add text once the snippet is inserted in your document."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2346
+#: C/index.docbook:2347
 msgid "You can use the following placeholder codes in snippet text:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2349
+#: C/index.docbook:2350
 msgid "Tab placeholders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2351
+#: C/index.docbook:2352
 msgid "<literal>$<replaceable>n</replaceable></literal> defines a tab placeholder, where <literal>n</literal> is any number from 1 upwards."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2352
+#: C/index.docbook:2353
 msgid "<literal>${<replaceable>n</replaceable>:<replaceable>default</replaceable>}</literal> defines a tab placeholder with a default value."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2353
+#: C/index.docbook:2354
 msgid "A tab placeholder marks a place in the snippet text where you can add extra text after the snippet is inserted."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2354
+#: C/index.docbook:2355
 msgid "To use tab placeholders, insert the snippet as normal. The cursor is placed at the first tab placeholder. Type text, and press <keycap>Tab</keycap> to advance to the next tab placeholder. The number in the placeholder code defines the order in which tab advances to each place in the text."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2355
+#: C/index.docbook:2356
 msgid "Press <keycombo> <keycap>Shift</keycap> <keycap>Tab</keycap> </keycombo> to return to the previous tab placeholder. Pressing <keycap>Tab</keycap> when there are no more tab placeholders moves the cursor to the end of the snippet text, or to the end placeholder if it exists."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2359
+#: C/index.docbook:2360
 msgid "Mirror placeholders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2361
+#: C/index.docbook:2362
 msgid "A repeated tab placeholder will mirror the placeholder already defined. This allows you to type in text only once that you want to appear several times in the snippet."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2365
+#: C/index.docbook:2366
 msgid "End placeholder"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2367
+#: C/index.docbook:2368
 msgid "<literal>$0</literal> defines the end placeholder. This allows you to finish working with the snippet with the cursor at a point other than the end of the snippet text."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2371
+#: C/index.docbook:2372
 msgid "Environmental variables"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2373
+#: C/index.docbook:2374
 msgid "Environmental variable such as <literal>$PATH</literal> and <literal>$HOME</literal> are substituted in snippet text. The following variables specific to <application>pluma</application> can also be used:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2376
+#: C/index.docbook:2377
 msgid "$PLUMA_SELECTED_TEXT"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2378
+#: C/index.docbook:2379
 msgid "The currently selected text."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2382
+#: C/index.docbook:2383
 msgid "$PLUMA_FILENAME"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2384
+#: C/index.docbook:2385
 msgid "The full filename of the document, or an empty string if the document isn't saved yet."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2388
+#: C/index.docbook:2389
 msgid "$PLUMA_BASENAME"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2390
+#: C/index.docbook:2391
 msgid "The basename of the filename of the document, or an empty string if the document isn't saved yet."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2394
+#: C/index.docbook:2395
 msgid "$PLUMA_CURRENT_WORD"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2396
+#: C/index.docbook:2397
 msgid "The word at the cursor's location in the document. When this variable is used, the current word will be replaced by the snippet text."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2403
+#: C/index.docbook:2404
 msgid "Shell placeholders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2405
+#: C/index.docbook:2406
 msgid "<literal>$(<replaceable>cmd</replaceable>)</literal> is replaced by the result of executing <replaceable>cmd</replaceable> in a shell."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2406
+#: C/index.docbook:2407
 msgid "<literal>$(<replaceable>n</replaceable>:<replaceable>cmd</replaceable>)</literal> allows you to give this placeholder a reference, where <replaceable>n</replaceable> is any number from 1 upwards. Use <literal>$<replaceable>n</replaceable></literal> to use the output from one shell placeholder as input in another."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:2410
+#: C/index.docbook:2411
 msgid "Python placeholders"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2412
+#: C/index.docbook:2413
 msgid "<literal>$&lt;<replaceable>cmd</replaceable>&gt;</literal> is replaced by the result of evaluating <replaceable>cmd</replaceable> in the python interpreter."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2413
+#: C/index.docbook:2414
 msgid "<literal>$&lt;<replaceable>a</replaceable>:<replaceable>cmd</replaceable>&gt;</literal> specifies another python placeholder as a dependency, where <replaceable>a</replaceable> gives its order in the snippet. This allows you to use python functions defined in another snippet. To specify several dependencies, separate the numbers with commas thus: <literal>$&lt;<replaceable>a</replaceable>,<replaceable>b</replaceable>:<replaceable>cmd</replaceable>&gt;</literal>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2414
+#: C/index.docbook:2415
 msgid "To use a variable in all other python snippets, declare it as <literal>global</literal>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2423
+#: C/index.docbook:2424
 msgid "Sort Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2425
+#: C/index.docbook:2426
 msgid "The <application>Sort</application> plugin arranges selected lines of text into alphabetical order."
 msgstr ""
 
 #. (itstool) path: caution/para
-#: C/index.docbook:2427
+#: C/index.docbook:2428
 msgid "You cannot undo the Sort operation, so you should save the file before performing the sort. To revert to the saved version of the file after the sort operation, choose <menuchoice> <guimenu>File</guimenu> <guimenuitem>Revert</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2429
+#: C/index.docbook:2430
 msgid "To use the Sort plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2432
+#: C/index.docbook:2433
 msgid "Select the lines of text you want to sort."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2435
+#: C/index.docbook:2436
 msgid "Choose <menuchoice> <guimenu>Edit</guimenu> <guimenuitem>Sort</guimenuitem> </menuchoice>. The <guilabel>Sort</guilabel> dialog opens."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2438
+#: C/index.docbook:2439
 msgid "Choose the options you want for the sort:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2441
+#: C/index.docbook:2442
 msgid "To arrange the text in reverse order, select <guilabel>Reverse order</guilabel>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2444
+#: C/index.docbook:2445
 msgid "To delete duplicate lines, select <guilabel>Remove duplicates</guilabel>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2447
+#: C/index.docbook:2448
 msgid "To ignore case sensitivity, select <guilabel>Ignore case</guilabel>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2450
+#: C/index.docbook:2451
 msgid "To have the sort ignore the characters at the start of the lines, set the first character that should be used for sorting in the <guilabel>Start at column</guilabel> spin box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2455
+#: C/index.docbook:2456
 msgid "To perform the sort operation, click <guibutton>Sort</guibutton>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2462
+#: C/index.docbook:2463
 msgid "Spell Checker Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2464
+#: C/index.docbook:2465
 msgid "The <application>Spell Checker</application> plugin checks the spelling in the selected text. You can configure <application>pluma</application> to check the spelling automatically, or you can check the spelling manually, in the specified language. The language setting, and the autocheck spelling properties, apply per document. To use the Spell checker plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2467
+#: C/index.docbook:2468
 msgid "Choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Set Language</guimenuitem> </menuchoice> to display the <guilabel>Set language</guilabel> dialog. Select the appropriate language from the list. Click <guibutton>OK</guibutton> to close the <guilabel>Set language</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2470
+#: C/index.docbook:2471
 msgid "To check the spelling automatically, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice>. To unset the automatic spell check, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Autocheck Spelling</guimenuitem> </menuchoice> again. When automatic spell checking is set, an icon is displayed beside the <guimenuitem>Autocheck Spelling</guimenuitem> menu item. Automatic spell checking is unset by default, each time <application>pluma</application> starts."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2471
+#: C/index.docbook:2472
 msgid "Unknown spellings are displayed in a different color, and underlined. Right-click on an unknown spelling, then select <guimenu>Spelling Suggestions</guimenu> from the popup menu:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2474
+#: C/index.docbook:2475
 msgid "To replace the unknown spelling with another spelling in the list, select the replacement spelling from the <guimenu>Spelling Suggestions</guimenu> popup menu."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2477
+#: C/index.docbook:2478
 msgid "To add the unknown spelling to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Add</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2480
+#: C/index.docbook:2481
 msgid "To ignore all occurrences of the unknown spelling, so that they are no longer flagged as unknown but are not added to your personal dictionary, select <menuchoice> <guimenu>Spelling Suggestions</guimenu> <guimenuitem>Ignore All</guimenuitem> </menuchoice>. The unknown word is ignored in the current <application>pluma</application> session only."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2485
+#: C/index.docbook:2486
 msgid "To check the spelling manually, choose <menuchoice> <guimenu>Tools</guimenu> <guimenuitem>Check Spelling</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2486
+#: C/index.docbook:2487
 msgid "If there are no spelling errors, an <guilabel>Information</guilabel> dialog displays a message stating that the document does not contain misspelled words. Click <guibutton>OK</guibutton> to close the <guilabel>Information</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2487
+#: C/index.docbook:2488
 msgid "If there are spelling errors, the <guilabel>Check Spelling</guilabel> dialog is displayed:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2490
+#: C/index.docbook:2491
 msgid "The <guilabel>Misspelled word</guilabel> is displayed at the top of the dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2493
+#: C/index.docbook:2494
 msgid "A suggested known spelling is displayed in the <guilabel>Change to</guilabel> text box. You can replace this with another known spelling by selecting a spelling from the <guilabel>Suggestions</guilabel> list, or you can enter text directly into the <guilabel>Change to</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2496
+#: C/index.docbook:2497
 msgid "To check the spelling of the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Check Word</guibutton>. If this is a known word, the <guilabel>Suggestions</guilabel> list is replaced with the text <literal>(correct spelling)</literal>. If the word is not known, new entries appear in the <guilabel>Suggestions</guilabel> list."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2499
+#: C/index.docbook:2500
 msgid "To ignore the current occurrence of the unknown word, click <guibutton>Ignore</guibutton>. To ignore all occurrences of the unknown word, click <guibutton>Ignore All</guibutton>. The unknown word is ignored in the current <application>pluma</application> session only."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2502
+#: C/index.docbook:2503
 msgid "To change the current occurrence of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change</guibutton>. To change all occurrences of the unknown word to the text in the <guilabel>Change to</guilabel> text box, click <guibutton>Change All</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2505
+#: C/index.docbook:2506
 msgid "To add the unknown word to your personal dictionary, click <guibutton>Add word</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2508
+#: C/index.docbook:2509
 msgid "To close the <guilabel>Check Spelling</guilabel> dialog, click <guibutton>Close</guibutton>."
 msgstr ""
 
 #. (itstool) path: info/title
-#: C/index.docbook:2517
+#: C/index.docbook:2518
 msgid "Tag List Plugin"
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2519
+#: C/index.docbook:2520
 msgid "The <application>Tag List</application> plugin allows you to insert common tags from a list in the side pane."
 msgstr ""
 
 #. (itstool) path: section/para
-#: C/index.docbook:2520
+#: C/index.docbook:2521
 msgid "To use the Tag List plugin, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2523
+#: C/index.docbook:2524
 msgid "Choose <menuchoice> <guimenu>View</guimenu> <guimenuitem>Side Pane</guimenuitem> </menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2526
+#: C/index.docbook:2527
 msgid "By default, the side pane shows a tab containing a list of open documents. Click on the tab showing a + icon at the bottom of the side pane to show the tag list tab."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2529
+#: C/index.docbook:2530
 msgid "Select the appropriate tag category from the drop-down list. For example, <guilabel>HTML - Tags</guilabel>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2532
+#: C/index.docbook:2533
 msgid "Scroll through the tag list to find the required tag."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2535
+#: C/index.docbook:2536
 msgid "To insert a tag at the cursor position in the current file, double-click on the tag in the tag list. You can also insert a tag as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2538
+#: C/index.docbook:2539
 msgid "To insert a tag in the current file and change the focus from the side pane to the display area, press <keycap>Return</keycap>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:2541
+#: C/index.docbook:2542
 msgid "To insert a tag in the current file and maintain the focus on the <guilabel>Tag list plugin</guilabel> window, press <keycombo> <keycap>Shift</keycap> <keycap>Return</keycap> </keycombo>."
 msgstr ""
 


### PR DESCRIPTION
To upgrade the manual:
  sudo dnf install -y docbook5-schemas
  xsltproc --output index-new.docbook /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl index.docbook
  xsltproc --output legal-new.xml /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl legal.xml

To validate the manual:
  xmllint --noout --relaxng /usr/share/xml/docbook5/schema/rng/5.0/docbook.rng help/C/index.docbook
  jing /usr/share/xml/docbook5/schema/rng/5.0/docbook.rng help/C/index.docbook
  yelp-check validate help/C/index.docbook

To view the manual:
  yelp file:///full_path/index.docbook

Note: docbook5-schemas should be installed in your system in order to view the manual (DEPENDENCY)