### PR TITLE
Fix build fail on Archlinux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,7 +98,7 @@ dnl ================================================================
 dnl spell plugins checks: enchant and iso-codes
 dnl ================================================================
 
-ENCHANT_REQUIRED=1.2.0
+ENCHANT_REQUIRED=1.6.0
 ISO_CODES_REQUIRED=0.35
 
 AC_ARG_ENABLE([spell],
@@ -107,15 +107,19 @@ AC_ARG_ENABLE([spell],
 	[enable_enchant=yes])
 
 if test "x$enable_enchant" = "xyes" ; then
-
-	PKG_CHECK_MODULES(ENCHANT, enchant-2 >= $ENCHANT_REQUIRED, \
-			  have_enchant_2=yes, have_enchant_2=no)
-
-	if test "x$have_enchant_2" = "xno"; then
-                PKG_CHECK_MODULES(ENCHANT, enchant >= $ENCHANT_REQUIRED, \
-                                  have_enchant=yes, have_enchant=no)
+        ENCHANT_MODNAME=enchant
+        PKG_CHECK_EXISTS([enchant-2 >= $ENCHANT_REQUIRED], [have_enchant_2=yes], [have_enchant_2=no])
+        if test "x$have_enchant_2" = "xyes"; then
+                ENCHANT_MODNAME=enchant-2
         fi
-	if test "x$have_enchant_2" = "xyes" || test "x$have_enchant" = "xyes"; then
+
+        AC_MSG_CHECKING([the version of enchant])
+        ENCHANT_VERSION=`pkg-config --modversion $ENCHANT_MODNAME`
+        AC_MSG_RESULT([$ENCHANT_VERSION])
+
+        PKG_CHECK_MODULES(ENCHANT, [$ENCHANT_MODNAME >= $ENCHANT_REQUIRED], \
+                          have_enchant=yes, have_enchant=no)
+	if test "x$have_enchant" = "xyes"; then
 
 		PKG_CHECK_EXISTS([iso-codes >= $ISO_CODES_REQUIRED],
 				 [have_iso_codes=yes],[have_iso_codes=no])

--- a/configure.ac
+++ b/configure.ac
@@ -108,10 +108,14 @@ AC_ARG_ENABLE([spell],
 
 if test "x$enable_enchant" = "xyes" ; then
 
-	PKG_CHECK_MODULES(ENCHANT, enchant >= $ENCHANT_REQUIRED, \
-			  have_enchant=yes, have_enchant=no)
+	PKG_CHECK_MODULES(ENCHANT, enchant-2 >= $ENCHANT_REQUIRED, \
+			  have_enchant_2=yes, have_enchant_2=no)
 
-	if test "x$have_enchant" = "xyes"; then
+	if test "x$have_enchant_2" = "xno"; then
+                PKG_CHECK_MODULES(ENCHANT, enchant >= $ENCHANT_REQUIRED, \
+                                  have_enchant=yes, have_enchant=no)
+        fi
+	if test "x$have_enchant_2" = "xyes" || test "x$have_enchant" = "xyes"; then
 
 		PKG_CHECK_EXISTS([iso-codes >= $ISO_CODES_REQUIRED],
 				 [have_iso_codes=yes],[have_iso_codes=no])

--- a/plugins/spell/pluma-spell-checker.c
+++ b/plugins/spell/pluma-spell-checker.c
@@ -433,7 +433,8 @@ pluma_spell_checker_add_word_to_personal (PlumaSpellChecker *spell,
 	if (len < 0)
 		len = strlen (word);
 
-	enchant_dict_add_to_pwl (spell->dict, word, len);
+        enchant_dict_add (spell->dict, word, len);
+
 
 	g_signal_emit (G_OBJECT (spell), signals[ADD_WORD_TO_PERSONAL], 0, word, len);
 

--- a/plugins/spell/pluma-spell-checker.c
+++ b/plugins/spell/pluma-spell-checker.c
@@ -433,7 +433,7 @@ pluma_spell_checker_add_word_to_personal (PlumaSpellChecker *spell,
 	if (len < 0)
 		len = strlen (word);
 
-        enchant_dict_add (spell->dict, word, len);
+	enchant_dict_add (spell->dict, word, len);
 
 
 	g_signal_emit (G_OBJECT (spell), signals[ADD_WORD_TO_PERSONAL], 0, word, len);


### PR DESCRIPTION
The enchant on Archlinux is 2.2.3-2, that include enchant-2.pc.
This commit first check enchant-2, then check enchant.

Here can see the file list of enchant on archlinux:
https://www.archlinux.org/packages/extra/x86_64/enchant/

```
usr/lib/libenchant-2.so
usr/lib/libenchant-2.so.2
usr/lib/libenchant-2.so.2.2.3
usr/lib/pkgconfig/
usr/lib/pkgconfig/enchant-2.pc
```
