### PR TITLE
Draw spaces, tabs, newlines and nbsp

### DIFF
--- a/data/org.mate.pluma.gschema.xml.in
+++ b/data/org.mate.pluma.gschema.xml.in
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
+  <enum id="org.mate.pluma.SpaceDrawer">
+    <value nick="draw-none" value="0"/>
+    <value nick="draw-trailing" value="1"/>
+    <value nick="draw-all" value="2"/>
+  </enum>
   <schema id="org.mate.pluma" path="/org/mate/pluma/">
     <key name="use-default-font" type="b">
       <default>true</default>
@@ -215,6 +220,26 @@
       <default>[ 'docinfo', 'modelines', 'filebrowser', 'spell', 'time' ]</default>
       <summary>Active plugins</summary>
       <description>List of active plugins. It contains the "Location" of the active plugins. See the .pluma-plugin file for obtaining the "Location" of a given plugin.</description>
+    </key>
+    <key name="enable-space-drawer-newline" type="b">
+      <default>false</default>
+      <summary>Draw newline</summary>
+      <description>Whether pluma should draw newlines in the editor window.</description>
+    </key>
+    <key name="enable-space-drawer-nbsp" enum="org.mate.pluma.SpaceDrawer">
+      <default>'draw-none'</default>
+      <summary>Draw nbsp</summary>
+      <description>Whether pluma should draw not breaking spaces in the editor window: 'draw-none' no drawing; 'draw-trailing' drawing only trailing spaces; 'draw-all' drawing all spaces.</description>
+    </key>
+    <key name="enable-space-drawer-tab" enum="org.mate.pluma.SpaceDrawer">
+      <default>'draw-none'</default>
+      <summary>Draw tabs</summary>
+      <description>Whether pluma should draw tabs in the editor window: 'draw-none' no drawing; 'draw-trailing' drawing only trailing spaces; 'draw-all' drawing all spaces.</description>
+    </key>
+    <key name="enable-space-drawer-space" enum="org.mate.pluma.SpaceDrawer">
+      <default>'draw-none'</default>
+      <summary>Draw spaces</summary>
+      <description>Whether pluma should draw spaces in the editor window: 'draw-none' no drawing; 'draw-trailing' drawing only trailing spaces; 'draw-all' drawing all spaces.</description>
     </key>
   </schema>
 </schemalist>

--- a/pluma/dialogs/pluma-preferences-dialog.c
+++ b/pluma/dialogs/pluma-preferences-dialog.c
@@ -71,6 +71,12 @@ enum
 	NUM_COLUMNS
 };
 
+typedef enum
+{
+  DRAW_NONE = 0,
+  DRAW_TRAILING = 1,
+  DRAW_ALL = 2
+} DrawSpacesSettings;
 
 #define PLUMA_PREFERENCES_DIALOG_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), \
 						     PLUMA_TYPE_PREFERENCES_DIALOG, \
@@ -100,6 +106,13 @@ struct _PlumaPreferencesDialogPrivate
 
 	/* Auto indentation */
 	GtkWidget	*auto_indent_checkbutton;
+
+	/* Draw spaces... */
+	GtkWidget	*draw_spaces_checkbutton;
+	GtkWidget	*draw_trailing_spaces_checkbutton;
+	GtkWidget	*draw_tabs_checkbutton;
+	GtkWidget	*draw_trailing_tabs_checkbutton;
+	GtkWidget	*draw_newlines_checkbutton;
 
 	/* Text Wrapping */
 	GtkWidget	*wrap_text_checkbutton;
@@ -200,6 +213,88 @@ auto_indent_checkbutton_toggled (GtkToggleButton        *button,
 }
 
 static void
+draw_spaces_checkbutton_toggled (GtkToggleButton        *button,
+                                 PlumaPreferencesDialog *dlg)
+{
+	int v;
+        pluma_debug (DEBUG_PREFS);
+
+        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_spaces_checkbutton));
+
+        if (gtk_toggle_button_get_active (button))
+                v = DRAW_ALL;
+        else
+                v = DRAW_NONE;
+
+        pluma_prefs_manager_set_draw_spaces (v);
+#ifdef GTK_SOURCE_VERSION_3_24
+        gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), v > DRAW_NONE);
+        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), v == DRAW_NONE);
+#endif
+
+}
+
+static void
+draw_trailing_spaces_checkbutton_toggled (GtkToggleButton        *button,
+                                          PlumaPreferencesDialog *dlg)
+{
+        pluma_debug (DEBUG_PREFS);
+
+        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton));
+
+        if (gtk_toggle_button_get_active (button))
+                pluma_prefs_manager_set_draw_spaces (DRAW_TRAILING);
+        else
+                pluma_prefs_manager_set_draw_spaces (DRAW_ALL);
+}
+
+static void
+draw_tabs_checkbutton_toggled (GtkToggleButton        *button,
+                               PlumaPreferencesDialog *dlg)
+{
+	int v;
+        pluma_debug (DEBUG_PREFS);
+
+        g_return_if_fail (button == GTK_TOGGLE_BUTTON(dlg->priv->draw_tabs_checkbutton));
+
+        if (gtk_toggle_button_get_active (button))
+                v = DRAW_ALL;
+        else
+                v = DRAW_NONE;
+
+        pluma_prefs_manager_set_draw_tabs (v);
+#ifdef GTK_SOURCE_VERSION_3_24
+        gtk_widget_set_sensitive (GTK_WIDGET(dlg->priv->draw_trailing_tabs_checkbutton), v > DRAW_NONE);
+        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON(dlg->priv->draw_trailing_tabs_checkbutton), v == DRAW_NONE);
+#endif
+}
+
+static void
+draw_trailing_tabs_checkbutton_toggled (GtkToggleButton        *button,
+                                        PlumaPreferencesDialog *dlg)
+{
+        pluma_debug (DEBUG_PREFS);
+
+        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton));
+
+        if (gtk_toggle_button_get_active (button))
+                pluma_prefs_manager_set_draw_tabs (DRAW_TRAILING);
+        else
+                pluma_prefs_manager_set_draw_tabs (DRAW_ALL);
+}
+
+static void
+draw_newlines_checkbutton_toggled (GtkToggleButton        *button,
+                                   PlumaPreferencesDialog *dlg)
+{
+        pluma_debug (DEBUG_PREFS);
+
+        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_newlines_checkbutton));
+
+        pluma_prefs_manager_set_draw_newlines (gtk_toggle_button_get_active (button));
+}
+
+static void
 auto_save_checkbutton_toggled (GtkToggleButton        *button,
 			       PlumaPreferencesDialog *dlg)
 {
@@ -257,6 +352,36 @@ setup_editor_page (PlumaPreferencesDialog *dlg)
 				      pluma_prefs_manager_get_insert_spaces ());
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->auto_indent_checkbutton), 
 				      pluma_prefs_manager_get_auto_indent ());
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_spaces_checkbutton),
+				      pluma_prefs_manager_get_draw_spaces () > 0);
+#ifdef GTK_SOURCE_VERSION_3_24
+	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton),
+				      pluma_prefs_manager_get_draw_spaces () > 0);
+	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton),
+				      pluma_prefs_manager_get_draw_spaces () == 0);
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton),
+				      pluma_prefs_manager_get_draw_spaces () == 1);
+#else
+	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
+	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), TRUE);
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
+#endif
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_tabs_checkbutton),
+				      pluma_prefs_manager_get_draw_tabs () > 0);
+#ifdef GTK_SOURCE_VERSION_3_24
+	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_tabs_checkbutton),
+				      pluma_prefs_manager_get_draw_tabs () > 0);
+	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton),
+				      pluma_prefs_manager_get_draw_tabs () == 0);
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton),
+				      pluma_prefs_manager_get_draw_tabs () == 1);
+#else
+	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
+	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
+#endif
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_newlines_checkbutton),
+				      pluma_prefs_manager_get_draw_newlines ());
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->backup_copy_checkbutton),
 				      pluma_prefs_manager_get_create_backup_copy ());
 
@@ -278,6 +403,12 @@ setup_editor_page (PlumaPreferencesDialog *dlg)
 				  pluma_prefs_manager_insert_spaces_can_set ());
 	gtk_widget_set_sensitive (dlg->priv->auto_indent_checkbutton,
 				  pluma_prefs_manager_auto_indent_can_set ());
+	gtk_widget_set_sensitive (dlg->priv->draw_spaces_checkbutton,
+				  pluma_prefs_manager_draw_spaces_can_set ());
+	gtk_widget_set_sensitive (dlg->priv->draw_tabs_checkbutton,
+				  pluma_prefs_manager_draw_tabs_can_set ());
+	gtk_widget_set_sensitive (dlg->priv->draw_newlines_checkbutton,
+				  pluma_prefs_manager_draw_newlines_can_set ());
 	gtk_widget_set_sensitive (dlg->priv->backup_copy_checkbutton,
 				  pluma_prefs_manager_create_backup_copy_can_set ());
 	gtk_widget_set_sensitive (dlg->priv->autosave_hbox, 
@@ -298,6 +429,26 @@ setup_editor_page (PlumaPreferencesDialog *dlg)
 	g_signal_connect (dlg->priv->auto_indent_checkbutton,
 			  "toggled",
 			  G_CALLBACK (auto_indent_checkbutton_toggled),
+			  dlg);
+	g_signal_connect (dlg->priv->draw_spaces_checkbutton,
+			  "toggled",
+			  G_CALLBACK (draw_spaces_checkbutton_toggled),
+			  dlg);
+	g_signal_connect (dlg->priv->draw_trailing_spaces_checkbutton,
+			  "toggled",
+			  G_CALLBACK (draw_trailing_spaces_checkbutton_toggled),
+			  dlg);
+	g_signal_connect (dlg->priv->draw_tabs_checkbutton,
+			  "toggled",
+			  G_CALLBACK (draw_tabs_checkbutton_toggled),
+			  dlg);
+	g_signal_connect (dlg->priv->draw_trailing_tabs_checkbutton,
+			  "toggled",
+			  G_CALLBACK (draw_trailing_tabs_checkbutton_toggled),
+			  dlg);
+	g_signal_connect (dlg->priv->draw_newlines_checkbutton,
+			  "toggled",
+			  G_CALLBACK (draw_newlines_checkbutton_toggled),
 			  dlg);
 	g_signal_connect (dlg->priv->auto_save_checkbutton,
 			  "toggled",
@@ -1172,6 +1323,12 @@ pluma_preferences_dialog_init (PlumaPreferencesDialog *dlg)
 		"insert_spaces_checkbutton", &dlg->priv->insert_spaces_checkbutton,
 
 		"auto_indent_checkbutton", &dlg->priv->auto_indent_checkbutton,
+
+		"draw_spaces_checkbutton", &dlg->priv->draw_spaces_checkbutton,
+		"draw_trailing_spaces_checkbutton", &dlg->priv->draw_trailing_spaces_checkbutton,
+		"draw_tabs_checkbutton", &dlg->priv->draw_tabs_checkbutton,
+		"draw_trailing_tabs_checkbutton", &dlg->priv->draw_trailing_tabs_checkbutton,
+		"draw_newlines_checkbutton", &dlg->priv->draw_newlines_checkbutton,
 
 		"autosave_hbox", &dlg->priv->autosave_hbox,
 		"backup_copy_checkbutton", &dlg->priv->backup_copy_checkbutton,

--- a/pluma/dialogs/pluma-preferences-dialog.c
+++ b/pluma/dialogs/pluma-preferences-dialog.c
@@ -216,20 +216,22 @@ static void
 draw_spaces_checkbutton_toggled (GtkToggleButton        *button,
                                  PlumaPreferencesDialog *dlg)
 {
-	int v;
+        DrawSpacesSettings setting;
         pluma_debug (DEBUG_PREFS);
 
         g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_spaces_checkbutton));
 
         if (gtk_toggle_button_get_active (button))
-                v = DRAW_ALL;
+                setting = DRAW_ALL;
         else
-                v = DRAW_NONE;
+                setting = DRAW_NONE;
 
-        pluma_prefs_manager_set_draw_spaces (v);
+        pluma_prefs_manager_set_draw_spaces (setting);
 #ifdef GTK_SOURCE_VERSION_3_24
-        gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), v > DRAW_NONE);
-        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), v == DRAW_NONE);
+        if (setting == DRAW_NONE)
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
+        gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), setting > DRAW_NONE);
+        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), setting == DRAW_NONE);
 #endif
 
 }
@@ -245,27 +247,34 @@ draw_trailing_spaces_checkbutton_toggled (GtkToggleButton        *button,
         if (gtk_toggle_button_get_active (button))
                 pluma_prefs_manager_set_draw_spaces (DRAW_TRAILING);
         else
-                pluma_prefs_manager_set_draw_spaces (DRAW_ALL);
+        {
+                if (pluma_prefs_manager_get_draw_spaces ())
+                        pluma_prefs_manager_set_draw_spaces (DRAW_ALL);
+                else
+                        pluma_prefs_manager_set_draw_spaces (DRAW_NONE);
+        }
 }
 
 static void
 draw_tabs_checkbutton_toggled (GtkToggleButton        *button,
                                PlumaPreferencesDialog *dlg)
 {
-	int v;
+        DrawSpacesSettings setting;
         pluma_debug (DEBUG_PREFS);
 
         g_return_if_fail (button == GTK_TOGGLE_BUTTON(dlg->priv->draw_tabs_checkbutton));
 
         if (gtk_toggle_button_get_active (button))
-                v = DRAW_ALL;
+                setting = DRAW_ALL;
         else
-                v = DRAW_NONE;
+                setting = DRAW_NONE;
 
-        pluma_prefs_manager_set_draw_tabs (v);
+        pluma_prefs_manager_set_draw_tabs (setting);
 #ifdef GTK_SOURCE_VERSION_3_24
-        gtk_widget_set_sensitive (GTK_WIDGET(dlg->priv->draw_trailing_tabs_checkbutton), v > DRAW_NONE);
-        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON(dlg->priv->draw_trailing_tabs_checkbutton), v == DRAW_NONE);
+        if (setting == DRAW_NONE)
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
+        gtk_widget_set_sensitive (GTK_WIDGET(dlg->priv->draw_trailing_tabs_checkbutton), setting > DRAW_NONE);
+        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON(dlg->priv->draw_trailing_tabs_checkbutton), setting == DRAW_NONE);
 #endif
 }
 
@@ -280,7 +289,12 @@ draw_trailing_tabs_checkbutton_toggled (GtkToggleButton        *button,
         if (gtk_toggle_button_get_active (button))
                 pluma_prefs_manager_set_draw_tabs (DRAW_TRAILING);
         else
-                pluma_prefs_manager_set_draw_tabs (DRAW_ALL);
+        {
+                if (pluma_prefs_manager_get_draw_tabs ())
+                        pluma_prefs_manager_set_draw_tabs (DRAW_ALL);
+                else
+                        pluma_prefs_manager_set_draw_tabs (DRAW_NONE);
+        }
 }
 
 static void
@@ -348,33 +362,33 @@ setup_editor_page (PlumaPreferencesDialog *dlg)
 	/* Set initial state */
 	gtk_spin_button_set_value (GTK_SPIN_BUTTON (dlg->priv->tabs_width_spinbutton),
 				   (guint) pluma_prefs_manager_get_tabs_size ());
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->insert_spaces_checkbutton), 
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->insert_spaces_checkbutton),
 				      pluma_prefs_manager_get_insert_spaces ());
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->auto_indent_checkbutton), 
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->auto_indent_checkbutton),
 				      pluma_prefs_manager_get_auto_indent ());
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_spaces_checkbutton),
-				      pluma_prefs_manager_get_draw_spaces () > 0);
+				      pluma_prefs_manager_get_draw_spaces () > DRAW_NONE);
 #ifdef GTK_SOURCE_VERSION_3_24
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton),
-				      pluma_prefs_manager_get_draw_spaces () > 0);
+				      pluma_prefs_manager_get_draw_spaces () > DRAW_NONE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton),
-				      pluma_prefs_manager_get_draw_spaces () == 0);
+				      pluma_prefs_manager_get_draw_spaces () == DRAW_NONE);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton),
-				      pluma_prefs_manager_get_draw_spaces () == 1);
+				      pluma_prefs_manager_get_draw_spaces () == DRAW_TRAILING);
 #else
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), TRUE);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
 #endif
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () > 0);
+				      pluma_prefs_manager_get_draw_tabs () > DRAW_NONE);
 #ifdef GTK_SOURCE_VERSION_3_24
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () > 0);
+				      pluma_prefs_manager_get_draw_tabs () > DRAW_NONE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () == 0);
+				      pluma_prefs_manager_get_draw_tabs () == DRAW_NONE);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () == 1);
+				      pluma_prefs_manager_get_draw_tabs () == DRAW_TRAILING);
 #else
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);

--- a/pluma/dialogs/pluma-preferences-dialog.c
+++ b/pluma/dialogs/pluma-preferences-dialog.c
@@ -73,9 +73,9 @@ enum
 
 typedef enum
 {
-  DRAW_NONE = 0,
-  DRAW_TRAILING = 1,
-  DRAW_ALL = 2
+	DRAW_NONE = 0,
+	DRAW_TRAILING = 1,
+	DRAW_ALL = 2
 } DrawSpacesSettings;
 
 #define PLUMA_PREFERENCES_DIALOG_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), \
@@ -108,11 +108,11 @@ struct _PlumaPreferencesDialogPrivate
 	GtkWidget	*auto_indent_checkbutton;
 
 	/* Draw spaces... */
-	GtkWidget	*draw_spaces_checkbutton;
-	GtkWidget	*draw_trailing_spaces_checkbutton;
-	GtkWidget	*draw_tabs_checkbutton;
-	GtkWidget	*draw_trailing_tabs_checkbutton;
-	GtkWidget	*draw_newlines_checkbutton;
+	GtkWidget       *draw_spaces_checkbutton;
+	GtkWidget       *draw_trailing_spaces_checkbutton;
+	GtkWidget       *draw_tabs_checkbutton;
+	GtkWidget       *draw_trailing_tabs_checkbutton;
+	GtkWidget       *draw_newlines_checkbutton;
 
 	/* Text Wrapping */
 	GtkWidget	*wrap_text_checkbutton;
@@ -216,65 +216,64 @@ static void
 draw_spaces_checkbutton_toggled (GtkToggleButton        *button,
                                  PlumaPreferencesDialog *dlg)
 {
-        DrawSpacesSettings setting;
-        pluma_debug (DEBUG_PREFS);
+	DrawSpacesSettings setting;
+	pluma_debug (DEBUG_PREFS);
 
-        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_spaces_checkbutton));
+	g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_spaces_checkbutton));
 
-        if (gtk_toggle_button_get_active (button))
-                setting = DRAW_ALL;
-        else
-                setting = DRAW_NONE;
+	if (gtk_toggle_button_get_active (button))
+		setting = DRAW_ALL;
+	else
+		setting = DRAW_NONE;
 
-        pluma_prefs_manager_set_draw_spaces (setting);
+	pluma_prefs_manager_set_draw_spaces (setting);
 #ifdef GTK_SOURCE_VERSION_3_24
-        if (setting == DRAW_NONE)
-                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
-        gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), setting > DRAW_NONE);
-        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), setting == DRAW_NONE);
+	if (setting == DRAW_NONE)
+		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
+	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), setting > DRAW_NONE);
+	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), setting == DRAW_NONE);
 #endif
-
 }
 
 static void
 draw_trailing_spaces_checkbutton_toggled (GtkToggleButton        *button,
                                           PlumaPreferencesDialog *dlg)
 {
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton));
+	g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton));
 
-        if (gtk_toggle_button_get_active (button))
-                pluma_prefs_manager_set_draw_spaces (DRAW_TRAILING);
-        else
-        {
-                if (pluma_prefs_manager_get_draw_spaces ())
-                        pluma_prefs_manager_set_draw_spaces (DRAW_ALL);
-                else
-                        pluma_prefs_manager_set_draw_spaces (DRAW_NONE);
-        }
+	if (gtk_toggle_button_get_active (button))
+		pluma_prefs_manager_set_draw_spaces (DRAW_TRAILING);
+	else
+	{
+		if (pluma_prefs_manager_get_draw_spaces ())
+			pluma_prefs_manager_set_draw_spaces (DRAW_ALL);
+		else
+			pluma_prefs_manager_set_draw_spaces (DRAW_NONE);
+	}
 }
 
 static void
 draw_tabs_checkbutton_toggled (GtkToggleButton        *button,
                                PlumaPreferencesDialog *dlg)
 {
-        DrawSpacesSettings setting;
-        pluma_debug (DEBUG_PREFS);
+	DrawSpacesSettings setting;
+	pluma_debug (DEBUG_PREFS);
 
-        g_return_if_fail (button == GTK_TOGGLE_BUTTON(dlg->priv->draw_tabs_checkbutton));
+	g_return_if_fail (button == GTK_TOGGLE_BUTTON(dlg->priv->draw_tabs_checkbutton));
 
-        if (gtk_toggle_button_get_active (button))
-                setting = DRAW_ALL;
-        else
-                setting = DRAW_NONE;
+	if (gtk_toggle_button_get_active (button))
+		setting = DRAW_ALL;
+	else
+		setting = DRAW_NONE;
 
-        pluma_prefs_manager_set_draw_tabs (setting);
+	pluma_prefs_manager_set_draw_tabs (setting);
 #ifdef GTK_SOURCE_VERSION_3_24
-        if (setting == DRAW_NONE)
-                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
-        gtk_widget_set_sensitive (GTK_WIDGET(dlg->priv->draw_trailing_tabs_checkbutton), setting > DRAW_NONE);
-        gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON(dlg->priv->draw_trailing_tabs_checkbutton), setting == DRAW_NONE);
+	if (setting == DRAW_NONE)
+		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
+	gtk_widget_set_sensitive (GTK_WIDGET(dlg->priv->draw_trailing_tabs_checkbutton), setting > DRAW_NONE);
+	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON(dlg->priv->draw_trailing_tabs_checkbutton), setting == DRAW_NONE);
 #endif
 }
 
@@ -282,30 +281,30 @@ static void
 draw_trailing_tabs_checkbutton_toggled (GtkToggleButton        *button,
                                         PlumaPreferencesDialog *dlg)
 {
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton));
+	g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton));
 
-        if (gtk_toggle_button_get_active (button))
-                pluma_prefs_manager_set_draw_tabs (DRAW_TRAILING);
-        else
-        {
-                if (pluma_prefs_manager_get_draw_tabs ())
-                        pluma_prefs_manager_set_draw_tabs (DRAW_ALL);
-                else
-                        pluma_prefs_manager_set_draw_tabs (DRAW_NONE);
-        }
+	if (gtk_toggle_button_get_active (button))
+		pluma_prefs_manager_set_draw_tabs (DRAW_TRAILING);
+	else
+	{
+		if (pluma_prefs_manager_get_draw_tabs ())
+			pluma_prefs_manager_set_draw_tabs (DRAW_ALL);
+		else
+			pluma_prefs_manager_set_draw_tabs (DRAW_NONE);
+	}
 }
 
 static void
 draw_newlines_checkbutton_toggled (GtkToggleButton        *button,
                                    PlumaPreferencesDialog *dlg)
 {
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_newlines_checkbutton));
+	g_return_if_fail (button == GTK_TOGGLE_BUTTON (dlg->priv->draw_newlines_checkbutton));
 
-        pluma_prefs_manager_set_draw_newlines (gtk_toggle_button_get_active (button));
+	pluma_prefs_manager_set_draw_newlines (gtk_toggle_button_get_active (button));
 }
 
 static void
@@ -370,32 +369,32 @@ setup_editor_page (PlumaPreferencesDialog *dlg)
 				      pluma_prefs_manager_get_draw_spaces () > DRAW_NONE);
 #ifdef GTK_SOURCE_VERSION_3_24
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton),
-				      pluma_prefs_manager_get_draw_spaces () > DRAW_NONE);
+	                          pluma_prefs_manager_get_draw_spaces () > DRAW_NONE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton),
-				      pluma_prefs_manager_get_draw_spaces () == DRAW_NONE);
+	                                    pluma_prefs_manager_get_draw_spaces () == DRAW_NONE);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton),
-				      pluma_prefs_manager_get_draw_spaces () == DRAW_TRAILING);
+	                              pluma_prefs_manager_get_draw_spaces () == DRAW_TRAILING);
 #else
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), TRUE);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_spaces_checkbutton), FALSE);
 #endif
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () > DRAW_NONE);
+	                              pluma_prefs_manager_get_draw_tabs () > DRAW_NONE);
 #ifdef GTK_SOURCE_VERSION_3_24
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () > DRAW_NONE);
+	                          pluma_prefs_manager_get_draw_tabs () > DRAW_NONE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () == DRAW_NONE);
+	                                    pluma_prefs_manager_get_draw_tabs () == DRAW_NONE);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton),
-				      pluma_prefs_manager_get_draw_tabs () == DRAW_TRAILING);
+	                              pluma_prefs_manager_get_draw_tabs () == DRAW_TRAILING);
 #else
 	gtk_widget_set_sensitive (GTK_WIDGET (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
 	gtk_toggle_button_set_inconsistent (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_trailing_tabs_checkbutton), FALSE);
 #endif
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->draw_newlines_checkbutton),
-				      pluma_prefs_manager_get_draw_newlines ());
+	                              pluma_prefs_manager_get_draw_newlines ());
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dlg->priv->backup_copy_checkbutton),
 				      pluma_prefs_manager_get_create_backup_copy ());
 
@@ -445,25 +444,25 @@ setup_editor_page (PlumaPreferencesDialog *dlg)
 			  G_CALLBACK (auto_indent_checkbutton_toggled),
 			  dlg);
 	g_signal_connect (dlg->priv->draw_spaces_checkbutton,
-			  "toggled",
-			  G_CALLBACK (draw_spaces_checkbutton_toggled),
-			  dlg);
+	                  "toggled",
+	                  G_CALLBACK (draw_spaces_checkbutton_toggled),
+	                  dlg);
 	g_signal_connect (dlg->priv->draw_trailing_spaces_checkbutton,
-			  "toggled",
-			  G_CALLBACK (draw_trailing_spaces_checkbutton_toggled),
-			  dlg);
+	                  "toggled",
+	                  G_CALLBACK (draw_trailing_spaces_checkbutton_toggled),
+	                  dlg);
 	g_signal_connect (dlg->priv->draw_tabs_checkbutton,
-			  "toggled",
-			  G_CALLBACK (draw_tabs_checkbutton_toggled),
-			  dlg);
+	                  "toggled",
+	                  G_CALLBACK (draw_tabs_checkbutton_toggled),
+	                  dlg);
 	g_signal_connect (dlg->priv->draw_trailing_tabs_checkbutton,
-			  "toggled",
-			  G_CALLBACK (draw_trailing_tabs_checkbutton_toggled),
-			  dlg);
+	                  "toggled",
+	                  G_CALLBACK (draw_trailing_tabs_checkbutton_toggled),
+	                  dlg);
 	g_signal_connect (dlg->priv->draw_newlines_checkbutton,
-			  "toggled",
-			  G_CALLBACK (draw_newlines_checkbutton_toggled),
-			  dlg);
+	                  "toggled",
+	                  G_CALLBACK (draw_newlines_checkbutton_toggled),
+	                  dlg);
 	g_signal_connect (dlg->priv->auto_save_checkbutton,
 			  "toggled",
 			  G_CALLBACK (auto_save_checkbutton_toggled),

--- a/pluma/dialogs/pluma-preferences-dialog.ui
+++ b/pluma/dialogs/pluma-preferences-dialog.ui
@@ -905,6 +905,264 @@
                     <property name="position">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Draw spaces, tabs, newlines</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox" id="hbox2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">    </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="draw_tabs_checkbutton">
+                                <property name="label" translatable="yes">Draw _tabs</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox1_4">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label2_2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">    </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label2_4">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">    </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="draw_trailing_tabs_checkbutton">
+                                <property name="label" translatable="yes">Draw _trailing tabs only</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox3">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label4">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">    </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="draw_newlines_checkbutton">
+                                <property name="label" translatable="yes">Draw _newlines</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">    </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="draw_spaces_checkbutton">
+                                <property name="label" translatable="yes">Draw _spaces</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox1_1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label2_3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">    </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label2_1">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">    </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="draw_trailing_spaces_checkbutton">
+                                <property name="label" translatable="yes">Draw _trailing spaces only</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">5</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="position">1</property>

--- a/pluma/pluma-prefs-manager-app.c
+++ b/pluma/pluma-prefs-manager-app.c
@@ -116,21 +116,21 @@ static void pluma_prefs_manager_lockdown_changed	(GSettings *settings,
 							 gchar       *key,
 							 gpointer     user_data);
 
-static void pluma_prefs_manager_draw_spaces_changed	(GSettings *settings,
-							 gchar       *key,
-							 gpointer     user_data);
+static void pluma_prefs_manager_draw_spaces_changed (GSettings *settings,
+                                                     gchar     *key,
+                                                     gpointer   user_data);
 
-static void pluma_prefs_manager_draw_tabs_changed	(GSettings *settings,
-							 gchar       *key,
-							 gpointer     user_data);
+static void pluma_prefs_manager_draw_tabs_changed (GSettings *settings,
+                                                   gchar     *key,
+                                                   gpointer   user_data);
 
-static void pluma_prefs_manager_draw_newlines_changed	(GSettings *settings,
-							 gchar       *key,
-							 gpointer     user_data);
+static void pluma_prefs_manager_draw_newlines_changed (GSettings *settings,
+                                                       gchar     *key,
+                                                       gpointer   user_data);
 
-static void pluma_prefs_manager_draw_nbsp_changed	(GSettings *settings,
-							 gchar       *key,
-							 gpointer     user_data);
+static void pluma_prefs_manager_draw_nbsp_changed (GSettings *settings,
+                                                   gchar     *key,
+                                                   gpointer   user_data);
 
 /* GUI state is serialized to a .desktop file, not in GSettings */
 
@@ -731,24 +731,24 @@ pluma_prefs_manager_app_init (void)
 				NULL);
 
 		g_signal_connect (pluma_prefs_manager->settings,
-				"changed::" GPM_SPACE_DRAWER_SPACE,
-				G_CALLBACK (pluma_prefs_manager_draw_spaces_changed),
-				NULL);
+		                  "changed::" GPM_SPACE_DRAWER_SPACE,
+		                  G_CALLBACK (pluma_prefs_manager_draw_spaces_changed),
+		                  NULL);
 
 		g_signal_connect (pluma_prefs_manager->settings,
-				"changed::" GPM_SPACE_DRAWER_TAB,
-				G_CALLBACK (pluma_prefs_manager_draw_tabs_changed),
-				NULL);
+		                  "changed::" GPM_SPACE_DRAWER_TAB,
+		                  G_CALLBACK (pluma_prefs_manager_draw_tabs_changed),
+		                  NULL);
 
 		g_signal_connect (pluma_prefs_manager->settings,
-				"changed::" GPM_SPACE_DRAWER_NEWLINE,
-				G_CALLBACK (pluma_prefs_manager_draw_newlines_changed),
-				NULL);
+		                  "changed::" GPM_SPACE_DRAWER_NEWLINE,
+		                  G_CALLBACK (pluma_prefs_manager_draw_newlines_changed),
+		                  NULL);
 
 		g_signal_connect (pluma_prefs_manager->settings,
-				"changed::" GPM_SPACE_DRAWER_NBSP,
-				G_CALLBACK (pluma_prefs_manager_draw_nbsp_changed),
-				NULL);
+		                  "changed::" GPM_SPACE_DRAWER_NBSP,
+		                  G_CALLBACK (pluma_prefs_manager_draw_nbsp_changed),
+		                  NULL);
 
 	}
 
@@ -1479,143 +1479,141 @@ pluma_prefs_manager_lockdown_changed (GSettings *settings,
 
 #ifdef GTK_SOURCE_VERSION_3_24
 static void
-pluma_prefs_manager_space_drawer_generic (GSettings  *settings,
-                                          gint       level,
+pluma_prefs_manager_space_drawer_generic (GSettings              *settings,
+                                          gint                    level,
                                           GtkSourceSpaceTypeFlags type)
 {
 
-        GList *views;
-        GList *l;
+	GList *views;
+	GList *l;
 
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        views = pluma_app_get_views (pluma_app_get_default ());
-        l = views;
+	views = pluma_app_get_views (pluma_app_get_default ());
+	l = views;
 
-        while (l != NULL)
-        {
+	while (l != NULL)
+	{
 		pluma_set_source_space_drawer_by_level (GTK_SOURCE_VIEW (l->data),
-                                                        level, type);
-                l = l->next;
-        }
+		                                        level, type);
+		l = l->next;
+	}
 
-        g_list_free (views);
+	g_list_free (views);
 }
 #else
 static void
-pluma_prefs_manager_draw_generic (GSettings  *settings,
-                                  gint       level,
-                                  GtkSourceDrawSpacesFlags type)
+pluma_prefs_manager_draw_generic (GSettings              *settings,
+                                  gint                    level,
+                                  GtkSourceSpaceTypeFlags type)
 {
 
-        GList *views;
-        GList *l;
+	GList *views;
+	GList *l;
 
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        views = pluma_app_get_views (pluma_app_get_default ());
-        l = views;
+	views = pluma_app_get_views (pluma_app_get_default ());
+	l = views;
 
-        while (l != NULL)
-        {
-                GtkSourceSpaceTypeFlags value;
+	while (l != NULL)
+	{
+		GtkSourceSpaceTypeFlags value;
 
-                value = gtk_source_view_get_draw_spaces (GTK_SOURCE_VIEW (l->data));
-                if (level > 0)
-                        value |= type;
-                else
-                        value &= ~type;
-                gtk_source_view_set_draw_spaces (GTK_SOURCE_VIEW (l->data),
-                                                 value);
-                l = l->next;
-        }
+		value = gtk_source_view_get_draw_spaces (GTK_SOURCE_VIEW (l->data));
+		if (level > 0)
+			value |= type;
+		else
+			value &= ~type;
+		gtk_source_view_set_draw_spaces (GTK_SOURCE_VIEW (l->data),
+		                                 value);
+		l = l->next;
+	}
 
-        g_list_free (views);
+	g_list_free (views);
 }
 #endif
 
 static void
 pluma_prefs_manager_draw_spaces_changed (GSettings *settings,
-                                         gchar       *key,
-                                         gpointer     user_data)
+                                         gchar     *key,
+                                         gpointer   user_data)
 {
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        if (strcmp (key, GPM_SPACE_DRAWER_SPACE))
-                return;
+	if (strcmp (key, GPM_SPACE_DRAWER_SPACE))
+		return;
 
 #ifdef GTK_SOURCE_VERSION_3_24
-        pluma_prefs_manager_space_drawer_generic (settings,
-                                                  g_settings_get_enum (settings, key),
-                                                  GTK_SOURCE_SPACE_TYPE_SPACE);
+	pluma_prefs_manager_space_drawer_generic (settings,
+	                                          g_settings_get_enum (settings, key),
+	                                          GTK_SOURCE_SPACE_TYPE_SPACE);
 #else
-        pluma_prefs_manager_draw_generic (settings,
-                                          g_settings_get_enum (settings, key),
-                                          GTK_SOURCE_DRAW_SPACES_SPACE);
+	pluma_prefs_manager_draw_generic (settings,
+	                                  g_settings_get_enum (settings, key),
+	                                  GTK_SOURCE_DRAW_SPACES_SPACE);
 #endif
 }
 
 static void
 pluma_prefs_manager_draw_tabs_changed (GSettings *settings,
-                                       gchar       *key,
-                                       gpointer     user_data)
+                                       gchar     *key,
+                                       gpointer   user_data)
 {
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        if (strcmp (key, GPM_SPACE_DRAWER_TAB))
-                return;
+	if (strcmp (key, GPM_SPACE_DRAWER_TAB))
+		return;
 
 #ifdef GTK_SOURCE_VERSION_3_24
-        pluma_prefs_manager_space_drawer_generic (settings,
-                                                  g_settings_get_enum (settings, key),
-                                                  GTK_SOURCE_SPACE_TYPE_TAB);
+	pluma_prefs_manager_space_drawer_generic (settings,
+	                                          g_settings_get_enum (settings, key),
+	                                          GTK_SOURCE_SPACE_TYPE_TAB);
 #else
-        pluma_prefs_manager_draw_generic (settings,
-                                          g_settings_get_enum (settings, key),
-                                          GTK_SOURCE_DRAW_SPACES_TAB);
+	pluma_prefs_manager_draw_generic (settings,
+	                                  g_settings_get_enum (settings, key),
+	                                  GTK_SOURCE_DRAW_SPACES_TAB);
 #endif
-
 }
 
 static void
 pluma_prefs_manager_draw_newlines_changed (GSettings *settings,
-                                           gchar       *key,
-                                           gpointer     user_data)
+                                           gchar     *key,
+                                           gpointer   user_data)
 {
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        if (strcmp (key, GPM_SPACE_DRAWER_NEWLINE))
-                return;
+	if (strcmp (key, GPM_SPACE_DRAWER_NEWLINE))
+		return;
 
 #ifdef GTK_SOURCE_VERSION_3_24
-        pluma_prefs_manager_space_drawer_generic (settings,
-                                                  g_settings_get_boolean (settings, key) ? 1 : 0,
-                                                  GTK_SOURCE_SPACE_TYPE_NEWLINE);
+	pluma_prefs_manager_space_drawer_generic (settings,
+	                                          g_settings_get_boolean (settings, key) ? 1 : 0,
+	                                          GTK_SOURCE_SPACE_TYPE_NEWLINE);
 #else
-        pluma_prefs_manager_draw_generic (settings,
-                                          g_settings_get_boolean (settings, key) ? 1 : 0,
-                                          GTK_SOURCE_DRAW_SPACES_NEWLINE);
+	pluma_prefs_manager_draw_generic (settings,
+	                                  g_settings_get_boolean (settings, key) ? 1 : 0,
+	                                  GTK_SOURCE_DRAW_SPACES_NEWLINE);
 #endif
-
 }
 
 static void
 pluma_prefs_manager_draw_nbsp_changed (GSettings *settings,
-                                       gchar       *key,
-                                       gpointer     user_data)
+                                       gchar     *key,
+                                       gpointer   user_data)
 {
-        pluma_debug (DEBUG_PREFS);
+	pluma_debug (DEBUG_PREFS);
 
-        if (strcmp (key, GPM_SPACE_DRAWER_NBSP))
-                return;
+	if (strcmp (key, GPM_SPACE_DRAWER_NBSP))
+		return;
 
 #ifdef GTK_SOURCE_VERSION_3_24
-        pluma_prefs_manager_space_drawer_generic (settings,
-                                                  g_settings_get_enum (settings, key),
-                                                  GTK_SOURCE_SPACE_TYPE_NBSP);
+	pluma_prefs_manager_space_drawer_generic (settings,
+	                                          g_settings_get_enum (settings, key),
+	                                          GTK_SOURCE_SPACE_TYPE_NBSP);
 #else
-        pluma_prefs_manager_draw_generic (settings,
-                                          g_settings_get_enum (settings, key),
-                                          GTK_SOURCE_DRAW_SPACES_NBSP);
+	pluma_prefs_manager_draw_generic (settings,
+	                                  g_settings_get_enum (settings, key),
+	                                  GTK_SOURCE_DRAW_SPACES_NBSP);
 #endif
 }

--- a/pluma/pluma-prefs-manager.c
+++ b/pluma/pluma-prefs-manager.c
@@ -990,16 +990,16 @@ pluma_prefs_manager_get_lockdown (void)
 
 /* enable drawing 'normal' spaces */
 DEFINE_ENUM_PREF(draw_spaces,
-        GPM_SPACE_DRAWER_SPACE)
+                 GPM_SPACE_DRAWER_SPACE)
 
 /* enable drawing tabs */
 DEFINE_ENUM_PREF(draw_tabs,
-        GPM_SPACE_DRAWER_TAB)
+                 GPM_SPACE_DRAWER_TAB)
 
 /* enable drawing newline */
 DEFINE_BOOL_PREF(draw_newlines,
-        GPM_SPACE_DRAWER_NEWLINE)
+                 GPM_SPACE_DRAWER_NEWLINE)
 
 /* enable drawing nbsp */
 DEFINE_ENUM_PREF(draw_nbsp,
-        GPM_SPACE_DRAWER_NBSP)
+                 GPM_SPACE_DRAWER_NBSP)

--- a/pluma/pluma-prefs-manager.c
+++ b/pluma/pluma-prefs-manager.c
@@ -122,6 +122,33 @@ pluma_prefs_manager_ ## name ## _can_set (void)				\
 }		
 
 
+
+#define DEFINE_ENUM_PREF(name, key) gint				\
+pluma_prefs_manager_get_ ## name (void)			 		\
+{									\
+	pluma_debug (DEBUG_PREFS);					\
+									\
+	return pluma_prefs_manager_get_enum (key);			\
+}									\
+									\
+void 									\
+pluma_prefs_manager_set_ ## name (gint v)				\
+{									\
+	pluma_debug (DEBUG_PREFS);					\
+									\
+	pluma_prefs_manager_set_enum (key,				\
+				      v);				\
+}									\
+									\
+gboolean								\
+pluma_prefs_manager_ ## name ## _can_set (void)				\
+{									\
+	pluma_debug (DEBUG_PREFS);					\
+									\
+	return pluma_prefs_manager_key_is_writable (key);		\
+}
+
+
 PlumaPrefsManager *pluma_prefs_manager = NULL;
 
 
@@ -132,6 +159,8 @@ static gboolean		 pluma_prefs_manager_get_bool		(const gchar* key);
 static gint		 pluma_prefs_manager_get_int		(const gchar* key);
 
 static gchar		*pluma_prefs_manager_get_string		(const gchar* key);
+
+static gint		 pluma_prefs_manager_get_enum		(const gchar* key);
 
 
 gboolean
@@ -189,6 +218,14 @@ pluma_prefs_manager_get_string (const gchar* key)
 	return g_settings_get_string (pluma_prefs_manager->settings, key);
 }
 
+static gint
+pluma_prefs_manager_get_enum (const gchar* key)
+{
+	pluma_debug (DEBUG_PREFS);
+
+	return g_settings_get_enum (pluma_prefs_manager->settings, key);
+}
+
 static void		 
 pluma_prefs_manager_set_bool (const gchar* key, gboolean value)
 {
@@ -222,6 +259,17 @@ pluma_prefs_manager_set_string (const gchar* key, const gchar* value)
 				pluma_prefs_manager->settings, key));
 
 	g_settings_set_string (pluma_prefs_manager->settings, key, value);
+}
+
+static void
+pluma_prefs_manager_set_enum (const gchar* key, gint value)
+{
+	pluma_debug (DEBUG_PREFS);
+
+	g_return_if_fail (g_settings_is_writable (
+				pluma_prefs_manager->settings, key));
+
+	g_settings_set_enum (pluma_prefs_manager->settings, key, value);
 }
 
 static gboolean 
@@ -939,3 +987,19 @@ pluma_prefs_manager_get_lockdown (void)
 
 	return lockdown;
 }
+
+/* enable drawing 'normal' spaces */
+DEFINE_ENUM_PREF(draw_spaces,
+        GPM_SPACE_DRAWER_SPACE)
+
+/* enable drawing tabs */
+DEFINE_ENUM_PREF(draw_tabs,
+        GPM_SPACE_DRAWER_TAB)
+
+/* enable drawing newline */
+DEFINE_BOOL_PREF(draw_newlines,
+        GPM_SPACE_DRAWER_NEWLINE)
+
+/* enable drawing nbsp */
+DEFINE_ENUM_PREF(draw_nbsp,
+        GPM_SPACE_DRAWER_NBSP)

--- a/pluma/pluma-prefs-manager.h
+++ b/pluma/pluma-prefs-manager.h
@@ -122,6 +122,12 @@
 #define GPM_DEFAULT_AUTO_SAVE_INTERVAL	10 /* minutes */
 #define GPM_DEFAULT_MAX_RECENTS			5
 
+/* space drawer settings */
+#define GPM_SPACE_DRAWER_SPACE		"enable-space-drawer-space"
+#define GPM_SPACE_DRAWER_TAB		"enable-space-drawer-tab"
+#define GPM_SPACE_DRAWER_NEWLINE	"enable-space-drawer-newline"
+#define GPM_SPACE_DRAWER_NBSP		"enable-space-drawer-nbsp"
+
 typedef enum {
 	PLUMA_TOOLBAR_SYSTEM = 0,
 	PLUMA_TOOLBAR_ICONS,
@@ -329,6 +335,26 @@ PlumaLockdownMask	 pluma_prefs_manager_get_lockdown			(void);
 /* GSettings utilities */
 GSList*				 pluma_prefs_manager_get_gslist (GSettings *settings, const gchar *key);
 void				 pluma_prefs_manager_set_gslist (GSettings *settings, const gchar *key, GSList *list);
+
+/* Enable drawing space */
+gint                    pluma_prefs_manager_get_draw_spaces     (void);
+void                    pluma_prefs_manager_set_draw_spaces     (gint enable_draw_spaces);
+gboolean                pluma_prefs_manager_draw_spaces_can_set (void);
+
+/* Enable drawing tab */
+gint                    pluma_prefs_manager_get_draw_tabs       (void);
+void                    pluma_prefs_manager_set_draw_tabs       (gint enable_draw_tabs);
+gboolean                pluma_prefs_manager_draw_tabs_can_set   (void);
+
+/* Enable drawing newline */
+gboolean                pluma_prefs_manager_get_draw_newlines           (void);
+void                    pluma_prefs_manager_set_draw_newlines           (gboolean enable_draw_newlines);
+gboolean                pluma_prefs_manager_draw_newlines_can_set       (void);
+
+/* Enable drawing nbsp */
+gint                    pluma_prefs_manager_get_draw_nbsp       (void);
+void                    pluma_prefs_manager_set_draw_nbsp       (gint enable_draw_nbsp);
+gboolean                pluma_prefs_manager_draw_nbsp_can_set   (void);
 
 
 #endif  /* __PLUMA_PREFS_MANAGER_H__ */

--- a/pluma/pluma-prefs-manager.h
+++ b/pluma/pluma-prefs-manager.h
@@ -337,26 +337,23 @@ GSList*				 pluma_prefs_manager_get_gslist (GSettings *settings, const gchar *ke
 void				 pluma_prefs_manager_set_gslist (GSettings *settings, const gchar *key, GSList *list);
 
 /* Enable drawing space */
-gint                    pluma_prefs_manager_get_draw_spaces     (void);
-void                    pluma_prefs_manager_set_draw_spaces     (gint enable_draw_spaces);
-gboolean                pluma_prefs_manager_draw_spaces_can_set (void);
+gint     pluma_prefs_manager_get_draw_spaces     (void);
+void     pluma_prefs_manager_set_draw_spaces     (gint enable_draw_spaces);
+gboolean pluma_prefs_manager_draw_spaces_can_set (void);
 
 /* Enable drawing tab */
-gint                    pluma_prefs_manager_get_draw_tabs       (void);
-void                    pluma_prefs_manager_set_draw_tabs       (gint enable_draw_tabs);
-gboolean                pluma_prefs_manager_draw_tabs_can_set   (void);
+gint     pluma_prefs_manager_get_draw_tabs     (void);
+void     pluma_prefs_manager_set_draw_tabs     (gint enable_draw_tabs);
+gboolean pluma_prefs_manager_draw_tabs_can_set (void);
 
 /* Enable drawing newline */
-gboolean                pluma_prefs_manager_get_draw_newlines           (void);
-void                    pluma_prefs_manager_set_draw_newlines           (gboolean enable_draw_newlines);
-gboolean                pluma_prefs_manager_draw_newlines_can_set       (void);
+gboolean pluma_prefs_manager_get_draw_newlines     (void);
+void     pluma_prefs_manager_set_draw_newlines     (gboolean enable_draw_newlines);
+gboolean pluma_prefs_manager_draw_newlines_can_set (void);
 
 /* Enable drawing nbsp */
-gint                    pluma_prefs_manager_get_draw_nbsp       (void);
-void                    pluma_prefs_manager_set_draw_nbsp       (gint enable_draw_nbsp);
-gboolean                pluma_prefs_manager_draw_nbsp_can_set   (void);
-
+gint     pluma_prefs_manager_get_draw_nbsp     (void);
+void     pluma_prefs_manager_set_draw_nbsp     (gint enable_draw_nbsp);
+gboolean pluma_prefs_manager_draw_nbsp_can_set (void);
 
 #endif  /* __PLUMA_PREFS_MANAGER_H__ */
-
-

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -378,35 +378,35 @@ pluma_set_source_space_drawer_by_level (GtkSourceView *view,
                                         gint level,
                                         GtkSourceSpaceTypeFlags type)
 {
-        GtkSourceSpaceLocationFlags locs[] = {GTK_SOURCE_SPACE_LOCATION_LEADING,
-                                              GTK_SOURCE_SPACE_LOCATION_INSIDE_TEXT,
-                                              GTK_SOURCE_SPACE_LOCATION_TRAILING};
-        /* this array links the level to the location */
-        GtkSourceSpaceLocationFlags levels[] = {
-                                        0,
-                                        GTK_SOURCE_SPACE_LOCATION_TRAILING,
-                                        GTK_SOURCE_SPACE_LOCATION_INSIDE_TEXT |
-                                               GTK_SOURCE_SPACE_LOCATION_TRAILING |
-                                               GTK_SOURCE_SPACE_LOCATION_LEADING
-        };
+	GtkSourceSpaceLocationFlags locs[] = {GTK_SOURCE_SPACE_LOCATION_LEADING,
+	                                      GTK_SOURCE_SPACE_LOCATION_INSIDE_TEXT,
+	                                      GTK_SOURCE_SPACE_LOCATION_TRAILING};
+	/* this array links the level to the location */
+	GtkSourceSpaceLocationFlags levels[] = {
+	                                        0,
+	                                        GTK_SOURCE_SPACE_LOCATION_TRAILING,
+	                                        GTK_SOURCE_SPACE_LOCATION_INSIDE_TEXT |
+	                                        	GTK_SOURCE_SPACE_LOCATION_TRAILING |
+	                                        	GTK_SOURCE_SPACE_LOCATION_LEADING
+	};
 
-        gint i;
+	gint i;
 
-        GtkSourceSpaceDrawer *drawer =  gtk_source_view_get_space_drawer (view);
+	GtkSourceSpaceDrawer *drawer = gtk_source_view_get_space_drawer (view);
 
-        if (level >= G_N_ELEMENTS(levels) || level < 0)
-                level = 0;
+	if (level >= G_N_ELEMENTS(levels) || level < 0)
+		level = 0;
 
-        for (i = 0 ; i < G_N_ELEMENTS(locs) ; i++ ) {
-                GtkSourceSpaceTypeFlags f;
-                f = gtk_source_space_drawer_get_types_for_locations (drawer,
-                                                                     locs[i]);
-                if (locs[i] & levels[level])
-                        f |= type;
-                else
-                        f &= ~type;
-                gtk_source_space_drawer_set_types_for_locations (drawer, locs[i], f);
-        }
+	for (i = 0 ; i < G_N_ELEMENTS(locs) ; i++ ) {
+		GtkSourceSpaceTypeFlags f;
+		f = gtk_source_space_drawer_get_types_for_locations (drawer,
+		                                                     locs[i]);
+		if (locs[i] & levels[level])
+			f |= type;
+		else
+			f &= ~type;
+		gtk_source_space_drawer_set_types_for_locations (drawer, locs[i], f);
+	}
 }
 #endif
 
@@ -414,42 +414,42 @@ pluma_set_source_space_drawer_by_level (GtkSourceView *view,
 static void
 pluma_set_source_space_drawer (GtkSourceView *view)
 {
-        pluma_set_source_space_drawer_by_level (view,
-                                                pluma_prefs_manager_get_draw_spaces (),
-                                                GTK_SOURCE_SPACE_TYPE_SPACE);
-        pluma_set_source_space_drawer_by_level (view,
-                                                pluma_prefs_manager_get_draw_tabs (),
-                                                GTK_SOURCE_SPACE_TYPE_TAB);
-        pluma_set_source_space_drawer_by_level (view,
-                                                pluma_prefs_manager_get_draw_newlines () ? 2 : 0,
-                                                GTK_SOURCE_SPACE_TYPE_NEWLINE);
-        pluma_set_source_space_drawer_by_level (view,
-                                                pluma_prefs_manager_get_draw_nbsp (),
-                                                GTK_SOURCE_SPACE_TYPE_NBSP);
-        gtk_source_space_drawer_set_enable_matrix (gtk_source_view_get_space_drawer (view),
-                                                   TRUE);
+	pluma_set_source_space_drawer_by_level (view,
+	                                        pluma_prefs_manager_get_draw_spaces (),
+	                                        GTK_SOURCE_SPACE_TYPE_SPACE);
+	pluma_set_source_space_drawer_by_level (view,
+	                                        pluma_prefs_manager_get_draw_tabs (),
+	                                        GTK_SOURCE_SPACE_TYPE_TAB);
+	pluma_set_source_space_drawer_by_level (view,
+	                                        pluma_prefs_manager_get_draw_newlines () ? 2 : 0,
+	                                        GTK_SOURCE_SPACE_TYPE_NEWLINE);
+	pluma_set_source_space_drawer_by_level (view,
+	                                        pluma_prefs_manager_get_draw_nbsp (),
+	                                        GTK_SOURCE_SPACE_TYPE_NBSP);
+	gtk_source_space_drawer_set_enable_matrix (gtk_source_view_get_space_drawer (view),
+	                                           TRUE);
 
 }
 #else
 static void
 pluma_set_source_space_drawer (GtkSourceView *view)
 {
-        GtkSourceSpaceTypeFlags flags = 0;
+	GtkSourceSpaceTypeFlags flags = 0;
 
-        if (pluma_prefs_manager_get_draw_spaces () > 0)
-                flags |= GTK_SOURCE_DRAW_SPACES_SPACE;
-        if (pluma_prefs_manager_get_draw_tabs () > 0)
-                flags |= GTK_SOURCE_DRAW_SPACES_TAB;
-        if (pluma_prefs_manager_get_draw_newlines ())
-                flags |= GTK_SOURCE_DRAW_SPACES_NEWLINE;
-        if (pluma_prefs_manager_get_draw_nbsp () > 0)
-                flags |= GTK_SOURCE_DRAW_SPACES_NBSP;
+	if (pluma_prefs_manager_get_draw_spaces () > 0)
+		flags |= GTK_SOURCE_DRAW_SPACES_SPACE;
+	if (pluma_prefs_manager_get_draw_tabs () > 0)
+		flags |= GTK_SOURCE_DRAW_SPACES_TAB;
+	if (pluma_prefs_manager_get_draw_newlines ())
+		flags |= GTK_SOURCE_DRAW_SPACES_NEWLINE;
+	if (pluma_prefs_manager_get_draw_nbsp () > 0)
+		flags |= GTK_SOURCE_DRAW_SPACES_NBSP;
 
-        flags |= GTK_SOURCE_DRAW_SPACES_TRAILING |
-                 GTK_SOURCE_DRAW_SPACES_TEXT |
-                 GTK_SOURCE_DRAW_SPACES_LEADING;
+	flags |= GTK_SOURCE_DRAW_SPACES_TRAILING |
+		GTK_SOURCE_DRAW_SPACES_TEXT |
+		GTK_SOURCE_DRAW_SPACES_LEADING;
 
-        gtk_source_view_set_draw_spaces (view, flags);
+	gtk_source_view_set_draw_spaces (view, flags);
 }
 #endif
 
@@ -494,7 +494,7 @@ pluma_view_init (PlumaView *view)
 		      "indent_on_tab", TRUE,
 		      NULL);
 
-	pluma_set_source_space_drawer(GTK_SOURCE_VIEW (view));
+	pluma_set_source_space_drawer (GTK_SOURCE_VIEW (view));
 
 	view->priv->typeselect_flush_timeout = 0;
 	view->priv->wrap_around = TRUE;

--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -372,6 +372,87 @@ on_notify_buffer_cb (PlumaView  *view,
 			  view);
 }
 
+#ifdef GTK_SOURCE_VERSION_3_24
+void
+pluma_set_source_space_drawer_by_level (GtkSourceView *view,
+                                        gint level,
+                                        GtkSourceSpaceTypeFlags type)
+{
+        GtkSourceSpaceLocationFlags locs[] = {GTK_SOURCE_SPACE_LOCATION_LEADING,
+                                              GTK_SOURCE_SPACE_LOCATION_INSIDE_TEXT,
+                                              GTK_SOURCE_SPACE_LOCATION_TRAILING};
+        /* this array links the level to the location */
+        GtkSourceSpaceLocationFlags levels[] = {
+                                        0,
+                                        GTK_SOURCE_SPACE_LOCATION_TRAILING,
+                                        GTK_SOURCE_SPACE_LOCATION_INSIDE_TEXT |
+                                               GTK_SOURCE_SPACE_LOCATION_TRAILING |
+                                               GTK_SOURCE_SPACE_LOCATION_LEADING
+        };
+
+        gint i;
+
+        GtkSourceSpaceDrawer *drawer =  gtk_source_view_get_space_drawer (view);
+
+        if (level >= G_N_ELEMENTS(levels) || level < 0)
+                level = 0;
+
+        for (i = 0 ; i < G_N_ELEMENTS(locs) ; i++ ) {
+                GtkSourceSpaceTypeFlags f;
+                f = gtk_source_space_drawer_get_types_for_locations (drawer,
+                                                                     locs[i]);
+                if (locs[i] & levels[level])
+                        f |= type;
+                else
+                        f &= ~type;
+                gtk_source_space_drawer_set_types_for_locations (drawer, locs[i], f);
+        }
+}
+#endif
+
+#ifdef GTK_SOURCE_VERSION_3_24
+static void
+pluma_set_source_space_drawer (GtkSourceView *view)
+{
+        pluma_set_source_space_drawer_by_level (view,
+                                                pluma_prefs_manager_get_draw_spaces (),
+                                                GTK_SOURCE_SPACE_TYPE_SPACE);
+        pluma_set_source_space_drawer_by_level (view,
+                                                pluma_prefs_manager_get_draw_tabs (),
+                                                GTK_SOURCE_SPACE_TYPE_TAB);
+        pluma_set_source_space_drawer_by_level (view,
+                                                pluma_prefs_manager_get_draw_newlines () ? 2 : 0,
+                                                GTK_SOURCE_SPACE_TYPE_NEWLINE);
+        pluma_set_source_space_drawer_by_level (view,
+                                                pluma_prefs_manager_get_draw_nbsp (),
+                                                GTK_SOURCE_SPACE_TYPE_NBSP);
+        gtk_source_space_drawer_set_enable_matrix (gtk_source_view_get_space_drawer (view),
+                                                   TRUE);
+
+}
+#else
+static void
+pluma_set_source_space_drawer (GtkSourceView *view)
+{
+        GtkSourceSpaceTypeFlags flags = 0;
+
+        if (pluma_prefs_manager_get_draw_spaces () > 0)
+                flags |= GTK_SOURCE_DRAW_SPACES_SPACE;
+        if (pluma_prefs_manager_get_draw_tabs () > 0)
+                flags |= GTK_SOURCE_DRAW_SPACES_TAB;
+        if (pluma_prefs_manager_get_draw_newlines ())
+                flags |= GTK_SOURCE_DRAW_SPACES_NEWLINE;
+        if (pluma_prefs_manager_get_draw_nbsp () > 0)
+                flags |= GTK_SOURCE_DRAW_SPACES_NBSP;
+
+        flags |= GTK_SOURCE_DRAW_SPACES_TRAILING |
+                 GTK_SOURCE_DRAW_SPACES_TEXT |
+                 GTK_SOURCE_DRAW_SPACES_LEADING;
+
+        gtk_source_view_set_draw_spaces (view, flags);
+}
+#endif
+
 static void 
 pluma_view_init (PlumaView *view)
 {
@@ -412,6 +493,8 @@ pluma_view_init (PlumaView *view)
 		      "smart_home_end", pluma_prefs_manager_get_smart_home_end (),
 		      "indent_on_tab", TRUE,
 		      NULL);
+
+	pluma_set_source_space_drawer(GTK_SOURCE_VIEW (view));
 
 	view->priv->typeselect_flush_timeout = 0;
 	view->priv->wrap_around = TRUE;

--- a/pluma/pluma-view.h
+++ b/pluma/pluma-view.h
@@ -109,8 +109,8 @@ void 		 pluma_view_set_font		(PlumaView       *view,
 
 #ifdef GTK_SOURCE_VERSION_3_24
 void
-pluma_set_source_space_drawer_by_level (GtkSourceView *view,
-                                        gint level,
+pluma_set_source_space_drawer_by_level (GtkSourceView          *view,
+                                        gint                    level,
                                         GtkSourceSpaceTypeFlags type);
 #endif
 

--- a/pluma/pluma-view.h
+++ b/pluma/pluma-view.h
@@ -107,6 +107,14 @@ void 		 pluma_view_set_font		(PlumaView       *view,
 						 gboolean         def,
 						 const gchar     *font_name);
 
+#ifdef GTK_SOURCE_VERSION_3_24
+void
+pluma_set_source_space_drawer_by_level (GtkSourceView *view,
+                                        gint level,
+                                        GtkSourceSpaceTypeFlags type);
+#endif
+
+
 G_END_DECLS
 
 #endif /* __PLUMA_VIEW_H__ */


### PR DESCRIPTION
This pull request allows to draw spaces, tabs, newlines and nbsp in Pluma. This capability is useful when you want to control if spaces or tab are used.

This pull request consists of two commits: the first one allow to control the drawing of these entities via gsettings:
- spaces (org.mate.pluma.enable-space-drawer-space)
- tabs (org.mate.pluma.enable-space-drawer-tab)
- newlines (org.mate.pluma.enable-space-drawer-newline)
- not blank space (org.mate.pluma.enable-space-drawer-nbsp)

The second commits allow to (un)set these options in the preferences dialog ('Editor' tab)
![sc](https://user-images.githubusercontent.com/4663983/54865022-66984d80-4d5f-11e9-9703-57e4f45b3c6b.png)

Please merge.

BR
G.Baroncelli <kreijack@inwind.it>