### PR TITLE
Help: replace link linkend with xref linkend

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1759,7 +1759,7 @@
             <para>You can add extra features to <application>pluma</application> by enabling <firstterm>plugins</firstterm>. A plugin is a supplementary program that enhances the functionality of an application. Plugins add new items to the <application>pluma</application> menus for the new features they provide.
             </para>
             <para>Several plugins come built-in with <application>pluma</application>, and you can install more. The <link xlink:href="http://live.gnome.org/Pluma/Plugins">pluma website</link> lists third-party plugins.</para>
-            <para>To enable and disable plugins, or see which plugins are currently enabled, use the <link linkend="pluma-prefs-plugins">Plugins Preferences</link>.</para>
+            <para>To enable and disable plugins, or see which plugins are currently enabled, use the <xref linkend="pluma-prefs-plugins"/>.</para>
             <para>The following plugins come built-in with <application>pluma</application>:</para>
             <!-- Not yet documented:
                     File browser
@@ -1767,21 +1767,18 @@
             <itemizedlist>
                 <listitem>
                     <para>
-                        <link linkend="pluma-change-case-plugin">
-                            <application>Change Case</application>
-                        </link> allows you to change the case of the selected text.</para>
+                        <xref linkend="pluma-change-case-plugin"/> allows you to change the case of the selected text.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-document-statistics-plugin">Document Statistics</link>
-                        </application> shows the number of lines, words, and characters in the document. </para>
+                        <xref linkend="pluma-document-statistics-plugin"/> shows the number of lines, words, and characters in the document.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-external-tools-plugin">External Tools</link>
-                        </application> allows you to execute external commands from <application>pluma</application>.</para>
+                        <xref linkend="pluma-external-tools-plugin"/> allows you to execute external commands from <application>pluma</application>.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
@@ -1789,51 +1786,43 @@
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-indent-lines-plugin">Indent Lines</link>
-                        </application> adds or removes indentation from the selected lines.</para>
+                        <xref linkend="pluma-indent-lines-plugin"/> adds or removes indentation from the selected lines.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-insert-date-time-plugin">Insert Date/Time</link>
-                        </application> adds the current date and time into a document.</para>
+                        <xref linkend="pluma-insert-date-time-plugin"/> adds the current date and time into a document.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-modelines-plugin">Modelines</link>
-                        </application> allows you to set editing preferences for individual documents, and supports <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>-style modelines.</para>
+                        <xref linkend="pluma-modelines-plugin"/> allows you to set editing preferences for individual documents, and supports <application>Emacs</application>, <application>Kate</application> and <application>Vim</application>-style modelines.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-python-console-plugin">Python Console</link>
-                        </application> allows you to run commands in the python programming language.</para>
+                        <xref linkend="pluma-python-console-plugin"/> allows you to run commands in the python programming language.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-snippets-plugin">Snippets</link>
-                        </application> allows you to store frequently-used pieces of text and insert them quickly into a document.</para>
+                        <xref linkend="pluma-snippets-plugin"/> allows you to store frequently-used pieces of text and insert them quickly into a document.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-sort-plugin">Sort</link>
-                        </application> arranges selected lines of text into alphabetical order.</para>
+                        <xref linkend="pluma-sort-plugin"/> arranges selected lines of text into alphabetical order.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-spell-checker-plugin">Spell Checker</link>
-                        </application> corrects the spelling in the selected text, or marks errors automatically in the document.</para>
+                        <xref linkend="pluma-spell-checker-plugin"/> corrects the spelling in the selected text, or marks errors automatically in the document.
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
-                        <application>
-                            <link linkend="pluma-tag-list-plugin">Tag List</link>
-                        </application> lets you insert commonly-used tags for HTML and other languages from a list in the side pane.</para>
+                        <xref linkend="pluma-tag-list-plugin"/> lets you insert commonly-used tags for HTML and other languages from a list in the side pane.
+                    </para>
                 </listitem>
             </itemizedlist>
 


### PR DESCRIPTION
Yelp viewer can't open cross-references to other parts of
the manual using link linkend.