### PR TITLE
remove live.gnome from plugins section

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1758,7 +1758,7 @@
             </info>
             <para>You can add extra features to <application>pluma</application> by enabling <firstterm>plugins</firstterm>. A plugin is a supplementary program that enhances the functionality of an application. Plugins add new items to the <application>pluma</application> menus for the new features they provide.
             </para>
-            <para>Several plugins come built-in with <application>pluma</application>, and you can install more. The <link xlink:href="http://live.gnome.org/Pluma/Plugins">pluma website</link> lists third-party plugins.</para>
+            <para>Several plugins come built-in with <application>pluma</application>.</para>
             <para>To enable and disable plugins, or see which plugins are currently enabled, use the <xref linkend="pluma-prefs-plugins"/>.</para>
             <para>The following plugins come built-in with <application>pluma</application>:</para>
             <!-- Not yet documented:
@@ -1832,7 +1832,7 @@
             </itemizedlist>
 
             <note>
-                <para>For more information on creating plugins, see the <link xlink:href="http://live.gnome.org/Pluma/Plugins"> <application>pluma</application> website</link>.</para>
+                <para>For more information on creating plugins, see <link xlink:href="https://github.com/mate-desktop/pluma/tree/master/plugins"></link>.</para>
             </note>
         </section>
 


### PR DESCRIPTION
With this I have also removed how we can install third-party plugins... we aren't offering that any more are we?