### PR TITLE
quickopen plugin: change code for Python 2 & 3 compatibility.

### DIFF
--- a/plugins/quickopen/quickopen/__init__.py
+++ b/plugins/quickopen/quickopen/__init__.py
@@ -18,7 +18,7 @@
 #  Boston, MA 02110-1301, USA.
 
 from gi.repository import GObject, Peas
-from windowhelper import WindowHelper
+from .windowhelper import WindowHelper
 
 class QuickOpenPlugin(GObject.Object, Peas.Activatable):
     __gtype_name__ = "QuickOpenPlugin"

--- a/plugins/quickopen/quickopen/virtualdirs.py
+++ b/plugins/quickopen/quickopen/virtualdirs.py
@@ -38,7 +38,9 @@ class VirtualDirectory(object):
             return
 
         try:
-            info = child.query_info("standard::*", Gio.FileQueryInfoFlags.NONE, None)
+            info = child.query_info("standard::*",
+                                    Gio.FileQueryInfoFlags.NONE,
+                                    None)
 
             if info:
                 self._children.append((child, info))
@@ -46,7 +48,7 @@ class VirtualDirectory(object):
             pass
 
 class RecentDocumentsDirectory(VirtualDirectory):
-    def __init__(self, maxitems=10):
+    def __init__(self, maxitems=200):
         VirtualDirectory.__init__(self, 'recent')
 
         self._maxitems = maxitems
@@ -56,7 +58,7 @@ class RecentDocumentsDirectory(VirtualDirectory):
         manager = Gtk.RecentManager.get_default()
 
         items = manager.get_items()
-        items.sort(lambda a, b: cmp(b.get_visited(), a.get_visited()))
+        items.sort(key=lambda a: a.get_visited(), reverse=True)
 
         added = 0
 


### PR DESCRIPTION
This rewrites the plugin in Python 3, while retaining Python 2 compatibility.

In addition, some bugs are fixed and the Gtk-3 compatibility is improved (mainly regarding widget deprecation).