### PR TITLE
pythonconsole plugin: change source code for Python 2 & 3 compatibility.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,7 @@ plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml
 plugins/modelines/Makefile
 plugins/pythonconsole/Makefile
 plugins/pythonconsole/pythonconsole/Makefile
+plugins/pythonconsole/org.mate.pluma.plugins.pythonconsole.gschema.xml
 plugins/quickopen/Makefile
 plugins/quickopen/quickopen/Makefile
 plugins/snippets/data/lang/Makefile

--- a/plugins/pythonconsole/Makefile.am
+++ b/plugins/pythonconsole/Makefile.am
@@ -7,9 +7,22 @@ plugin_in_files = pythonconsole.plugin.desktop.in
 
 plugin_DATA = $(plugin_in_files:.plugin.desktop.in=.plugin)
 
-EXTRA_DIST = $(plugin_in_files)
+pythonconsole_gschema_in = org.mate.pluma.plugins.pythonconsole.gschema.xml.in
+gsettings_SCHEMAS = $(pythonconsole_gschema_in:.xml.in=.xml)
+@GSETTINGS_RULES@
 
-CLEANFILES = $(plugin_DATA)
-DISTCLEANFILES = $(plugin_DATA)
+EXTRA_DIST = \
+	$(plugin_in_files) \
+	$(pythonconsole_gschema_in)
+
+CLEANFILES = \
+	$(plugin_DATA) \
+	$(gsettings_SCHEMAS_in)		\
+	$(gsettings_SCHEMAS)
+
+DISTCLEANFILES = \
+	$(plugin_DATA) \
+	$(gsettings_SCHEMAS_in)		\
+	$(gsettings_SCHEMAS)
 
 -include $(top_srcdir)/git.mk

--- a/plugins/pythonconsole/org.mate.pluma.plugins.pythonconsole.gschema.xml.in
+++ b/plugins/pythonconsole/org.mate.pluma.plugins.pythonconsole.gschema.xml.in
@@ -1,0 +1,30 @@
+<schemalist>
+  <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.mate.pluma.plugins.pythonconsole" path="/org/mate/pluma/plugins/pythonconsole/">
+    <key name="command-color" type="s">
+      <default>'#314e6c'</default>
+      <summary>Command Color Text</summary>
+      <description>The command color text</description>
+    </key>
+    <key name="error-color" type="s">
+      <default>'#990000'</default>
+      <summary>Error Color Text</summary>
+      <description>The error color text</description>
+    </key>
+    <key name="use-system-font" type="b">
+      <default>true</default>
+      <summary>Whether to use the system font</summary>
+      <description>
+        If true, the terminal will use the desktop-global standard
+        font if it’s monospace (and the most similar font it can
+        come up with otherwise).
+      </description>
+    </key>
+    <key name="font" type="s">
+      <default>'Monospace 10'</default>
+      <summary>Font</summary>
+      <description>
+        A Pango font name. Examples are “Sans 12” or “Monospace Bold 14”.
+      </description>
+    </key>
+  </schema>
+</schemalist>

--- a/plugins/pythonconsole/pythonconsole/__init__.py
+++ b/plugins/pythonconsole/pythonconsole/__init__.py
@@ -24,22 +24,22 @@
 # Bits from pluma Python Console Plugin
 #     Copyrignt (C), 2005 Raphaël Slinckx
 
-from gi.repository import GObject, Gtk, Peas, Pluma
+from gi.repository import GObject, Gtk, Peas, PeasGtk, Pluma
 
-from console import PythonConsole
-from config import PythonConsoleConfigDialog
-from config import PythonConsoleConfig
+from .console import PythonConsole
+from .config import PythonConsoleConfigWidget
+from .config import PythonConsoleConfig
 
 PYTHON_ICON = 'text-x-python'
 
-class PythonConsolePlugin(GObject.Object, Peas.Activatable):
+class PythonConsolePlugin(GObject.Object, Peas.Activatable, PeasGtk.Configurable):
     __gtype_name__ = "PythonConsolePlugin"
 
     object = GObject.Property(type=GObject.Object)
 
     def __init__(self):
         GObject.Object.__init__(self)
-        self.dlg = None
+        self.config_widget = None
 
     def do_activate(self):
         window = self.object
@@ -47,8 +47,8 @@ class PythonConsolePlugin(GObject.Object, Peas.Activatable):
         self._console = PythonConsole(namespace = {'__builtins__' : __builtins__,
                                              'pluma' : Pluma,
                                              'window' : window})
-        self._console.eval('print "You can access the main window through ' \
-                     '\'window\' :\\n%s" % window', False)
+        self._console.eval('print("You can access the main window through ' \
+                           '\'window\' :\\n%s" % window)', False)
         bottom = window.get_bottom_panel()
         image = Gtk.Image()
         image.set_from_icon_name(PYTHON_ICON, Gtk.IconSize.MENU)
@@ -61,22 +61,9 @@ class PythonConsolePlugin(GObject.Object, Peas.Activatable):
         bottom = window.get_bottom_panel()
         bottom.remove_item(self._console)
 
-def create_configure_dialog(self):
-
-    if not self.dlg:
-        self.dlg = PythonConsoleConfigDialog(self.get_data_dir())
-
-    dialog = self.dlg.dialog()
-    window = pluma.app_get_default().get_active_window()
-    if window:
-        dialog.set_transient_for(window)
-
-    return dialog
-
-# Here we dynamically insert create_configure_dialog based on if configuration
-# is enabled. This has to be done like this because pluma checks if a plugin
-# is configurable solely on the fact that it has this member defined or not
-if PythonConsoleConfig.enabled():
-    PythonConsolePlugin.create_configure_dialog = create_configure_dialog
+    def do_create_configure_widget(self):
+        if not self.config_widget:
+            self.config_widget = PythonConsoleConfigWidget(self.plugin_info.get_data_dir())
+        return self.config_widget.configure_widget()
 
 # ex:et:ts=4:

--- a/plugins/pythonconsole/pythonconsole/config.ui
+++ b/plugins/pythonconsole/pythonconsole/config.ui
@@ -1,126 +1,124 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
-  <object class="GtkImage" id="image1">
+  <object class="GtkGrid" id="widget-config">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">window-close</property>
-  </object>
-  <object class="GtkDialog" id="dialog-config">
-    <property name="can_focus">False</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">dialog</property>
-    <signal name="destroy" handler="on_dialog_config_destroy" swapped="no"/>
-    <signal name="response" handler="on_dialog_config_response" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox1">
+    <property name="margin_left">6</property>
+    <property name="margin_right">6</property>
+    <property name="margin_top">6</property>
+    <property name="margin_bottom">6</property>
+    <property name="orientation">vertical</property>
+    <property name="row_spacing">6</property>
+    <property name="column_spacing">6</property>
+    <signal name="parent-set" handler="on_widget_config_parent_set" swapped="no"/>
+    <child>
+      <object class="GtkLabel" id="label-error">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button1">
-                <property name="label" translatable="yes">_Close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">image1</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkTable" id="table2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">6</property>
-            <property name="n_rows">2</property>
-            <property name="n_columns">2</property>
-            <property name="column_spacing">6</property>
-            <property name="row_spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="label-command">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">C_ommand color:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">colorbutton-command</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label-error">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Error color:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">colorbutton-error</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkColorButton" id="colorbutton-command">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="color">#31314e4e6c6c</property>
-                <signal name="color-set" handler="on_colorbutton_command_color_set" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkColorButton" id="colorbutton-error">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="color">#999900000000</property>
-                <signal name="color-set" handler="on_colorbutton_error_color_set" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
+        <property name="label" translatable="yes">_Error color:</property>
+        <property name="use_underline">True</property>
+        <property name="xalign">0</property>
       </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
     </child>
-    <action-widgets>
-      <action-widget response="-7">button1</action-widget>
-    </action-widgets>
     <child>
-      <placeholder/>
+      <object class="GtkColorButton" id="colorbutton-error">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <property name="rgba">rgb(153,0,0)</property>
+        <signal name="color-set" handler="on_colorbutton_error_color_set" swapped="no"/>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkColorButton" id="colorbutton-command">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <property name="rgba">rgb(49,78,108)</property>
+        <signal name="color-set" handler="on_colorbutton_command_color_set" swapped="no"/>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label-command">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">C_ommand color:</property>
+        <property name="use_underline">True</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="vexpand">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">2</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="checkbox-system-font">
+        <property name="label" translatable="yes">Use system fixed width font</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="halign">start</property>
+        <property name="hexpand">True</property>
+        <property name="draw_indicator">True</property>
+        <signal name="toggled" handler="on_checkbox_system_font_toggled" swapped="no"/>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Font:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkFontButton" id="fontbutton-font">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <property name="font">Sans 12</property>
+        <property name="preview_text"/>
+        <signal name="font-set" handler="on_fontbutton_font_set" swapped="no"/>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">4</property>
+      </packing>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
This rewrites the plugin in Python 3, while retaining Python 2 compatibility.

In addition, some bugs are fixed and the Gtk-3 compatibility is improved (mainly regarding UI and widget deprecation). The mateconf parameters have been replaced by GSettings.