### PR TITLE
snippets plugin: change code for Python 2 & 3 compatibility

### DIFF
--- a/plugins/snippets/snippets/Completion.py
+++ b/plugins/snippets/snippets/Completion.py
@@ -1,14 +1,14 @@
 from gi.repository import GObject, Gtk, GtkSource, Pluma
 
-from Library import Library
-from LanguageManager import get_language_manager
-from Snippet import Snippet
+from .Library import Library
+from .LanguageManager import get_language_manager
+from .Snippet import Snippet
 
 class Proposal(GObject.Object, GtkSource.CompletionProposal):
     __gtype_name__ = "PlumaSnippetsProposal"
 
     def __init__(self, snippet):
-        GObject.Object.__init__(self)
+        super(Proposal, self).__init__()
         self._snippet = Snippet(snippet)
 
     def snippet(self):
@@ -25,7 +25,7 @@ class Provider(GObject.Object, GtkSource.CompletionProvider):
     __gtype_name__ = "PlumaSnippetsProvider"
 
     def __init__(self, name, language_id, handler):
-        GObject.Object.__init__(self)
+        super(Provider, self).__init__()
 
         self.name = name
         self.info_widget = None
@@ -38,7 +38,10 @@ class Provider(GObject.Object, GtkSource.CompletionProvider):
         theme = Gtk.IconTheme.get_default()
         f, w, h = Gtk.icon_size_lookup(Gtk.IconSize.MENU)
 
-        self.icon = theme.load_icon(Gtk.STOCK_JUSTIFY_LEFT, w, 0)
+        try:
+            self.icon = theme.load_icon("format-justify-left", w, 0)
+        except:
+            self.icon = None
 
     def __del__(self):
         if self.mark:
@@ -89,9 +92,9 @@ class Provider(GObject.Object, GtkSource.CompletionProvider):
 
         # Filter based on the current word
         if word:
-            proposals = filter(lambda x: x['tag'].startswith(word), proposals)
+            proposals = (x for x in proposals if x['tag'].startswith(word))
 
-        return map(lambda x: Proposal(x), proposals)
+        return [Proposal(x) for x in proposals]
 
     def do_populate(self, context):
         proposals = self.get_proposals(self.get_word(context))
@@ -113,6 +116,10 @@ class Provider(GObject.Object, GtkSource.CompletionProvider):
 
             sw = Gtk.ScrolledWindow()
             sw.add(view)
+            sw.show_all()
+
+            # Fixed size
+            sw.set_size_request(300, 200)
 
             self.info_view = view
             self.info_widget = sw

--- a/plugins/snippets/snippets/Exporter.py
+++ b/plugins/snippets/snippets/Exporter.py
@@ -3,9 +3,9 @@ import tempfile
 import sys
 import shutil
 
-from Library import *
+from .Library import *
 import xml.etree.ElementTree as et
-from Helper import *
+from .Helper import *
 
 class Exporter:
     def __init__(self, filename, snippets):

--- a/plugins/snippets/snippets/Helper.py
+++ b/plugins/snippets/snippets/Helper.py
@@ -15,10 +15,10 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-import string
 from xml.sax import saxutils
-from xml.etree.ElementTree import *
+import xml.etree.ElementTree as et
 import re
+import codecs
 
 from gi.repository import Gtk
 
@@ -93,7 +93,7 @@ def write_xml(node, f, cdata_nodes=()):
     assert node is not None
 
     if not hasattr(f, "write"):
-        f = open(f, "wb")
+        f = codecs.open(f, "wb", encoding="utf-8")
 
     # Encoding
     f.write("<?xml version='1.0' encoding='utf-8'?>\n")
@@ -107,27 +107,27 @@ def _write_node(node, file, cdata_nodes=(), indent=0):
     # write XML to file
     tag = node.tag
 
-    if node is Comment:
-        _write_indent(file, "<!-- %s -->\n" % saxutils.escape(node.text.encode('utf-8')), indent)
-    elif node is ProcessingInstruction:
-        _write_indent(file, "<?%s?>\n" % saxutils.escape(node.text.encode('utf-8')), indent)
+    if node is et.Comment:
+        _write_indent(file, "<!-- %s -->\n" % saxutils.escape(node.text), indent)
+    elif node is et.ProcessingInstruction:
+        _write_indent(file, "<?%s?>\n" % saxutils.escape(node.text), indent)
     else:
         items = node.items()
 
         if items or node.text or len(node):
-            _write_indent(file, "<" + tag.encode('utf-8'), indent)
+            _write_indent(file, "<" + tag, indent)
 
             if items:
                 items.sort() # lexical order
                 for k, v in items:
-                    file.write(" %s=%s" % (k.encode('utf-8'), saxutils.quoteattr(v.encode('utf-8'))))
+                    file.write(" %s=%s" % (k, saxutils.quoteattr(v)))
             if node.text or len(node):
                 file.write(">")
                 if node.text and node.text.strip() != "":
                     if tag in cdata_nodes:
                         file.write(_cdata(node.text))
                     else:
-                        file.write(saxutils.escape(node.text.encode('utf-8')))
+                        file.write(saxutils.escape(node.text))
                 else:
                     file.write("\n")
 
@@ -135,19 +135,17 @@ def _write_node(node, file, cdata_nodes=(), indent=0):
                     _write_node(n, file, cdata_nodes, indent + 1)
 
                 if not len(node):
-                    file.write("</" + tag.encode('utf-8') + ">\n")
+                    file.write("</" + tag + ">\n")
                 else:
-                    _write_indent(file, "</" + tag.encode('utf-8') + ">\n", \
-                            indent)
+                    _write_indent(file, "</" + tag + ">\n", indent)
             else:
                 file.write(" />\n")
 
         if node.tail and node.tail.strip() != "":
-            file.write(saxutils.escape(node.tail.encode('utf-8')))
+            file.write(saxutils.escape(node.tail))
 
-def _cdata(text, replace=string.replace):
-    text = text.encode('utf-8')
-    return '<![CDATA[' + replace(text, ']]>', ']]]]><![CDATA[>') + ']]>'
+def _cdata(text):
+    return '<![CDATA[' + text.replace(']]>', ']]]]><![CDATA[>') + ']]>'
 
 def buffer_word_boundary(buf):
     iter = buf.get_iter_at_mark(buf.get_insert())

--- a/plugins/snippets/snippets/Importer.py
+++ b/plugins/snippets/snippets/Importer.py
@@ -3,7 +3,7 @@ import tempfile
 import sys
 import shutil
 
-from Library import *
+from .Library import *
 
 class Importer:
     def __init__(self, filename):

--- a/plugins/snippets/snippets/LanguageManager.py
+++ b/plugins/snippets/snippets/LanguageManager.py
@@ -1,7 +1,7 @@
 import os
 from gi.repository import GtkSource
 
-from Library import Library
+from .Library import Library
 
 global manager
 manager = None
@@ -19,4 +19,5 @@ def get_language_manager():
         manager.set_search_path(dirs + manager.get_search_path())
 
     return manager
+
 # ex:ts=4:et:

--- a/plugins/snippets/snippets/Parser.py
+++ b/plugins/snippets/snippets/Parser.py
@@ -18,7 +18,7 @@
 import os
 import re
 import sys
-from SubstitutionParser import SubstitutionParser
+from .SubstitutionParser import SubstitutionParser
 
 class Token:
     def __init__(self, klass, data):

--- a/plugins/snippets/snippets/WindowHelper.py
+++ b/plugins/snippets/snippets/WindowHelper.py
@@ -21,8 +21,8 @@ import gettext
 
 from gi.repository import GObject, Gtk, Pluma
 
-from Document import Document
-from Library import Library
+from .Document import Document
+from .Library import Library
 
 class WindowHelper:
     def __init__(self, plugin):

--- a/plugins/snippets/snippets/__init__.py
+++ b/plugins/snippets/snippets/__init__.py
@@ -18,9 +18,9 @@
 import os
 from gi.repository import GObject, GLib, Gtk, Peas, Pluma
 
-from WindowHelper import WindowHelper
-from Library import Library
-from Manager import Manager
+from .WindowHelper import WindowHelper
+from .Library import Library
+from .Manager import Manager
 
 class SnippetsPlugin(GObject.Object, Peas.Activatable):
     __gtype_name__ = "SnippetsPlugin"
@@ -53,7 +53,7 @@ class SnippetsPlugin(GObject.Object, Peas.Activatable):
         library = Library()
         library.add_accelerator_callback(self.accelerator_activated)
 
-        snippetsdir = os.path.join(GLib.get_user_config_dir(), '/pluma/snippets')
+        snippetsdir = os.path.join(GLib.get_user_config_dir(), 'pluma/snippets')
         library.set_dirs(snippetsdir, self.system_dirs())
 
         self._helper = WindowHelper(self)
@@ -72,15 +72,12 @@ class SnippetsPlugin(GObject.Object, Peas.Activatable):
         self._helper.update()
 
     def create_configure_dialog(self):
-        if not self.dlg:
-            self.dlg = Manager(self.plugin_info.get_data_dir())
-        else:
-            self.dlg.run()
-
         window = Pluma.App.get_default().get_active_window()
 
-        if window:
-            self.dlg.dlg.set_transient_for(window)
+        if not self.dlg:
+            self.dlg = Manager(self.plugin_info.get_data_dir(), window)
+        else:
+            self.dlg.run(window)
 
         return self.dlg.dlg
 

--- a/plugins/snippets/snippets/snippets.ui
+++ b/plugins/snippets/snippets/snippets.ui
@@ -1,8 +1,11 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkListStore" id="model1">
     <columns>
+      <!-- column-name gchararray -->
       <column type="gchararray"/>
     </columns>
     <data>
@@ -32,303 +35,249 @@
       </row>
     </data>
   </object>
-  <object class="PlumaDocument" id="source_buffer">
-    <property name="highlight-matching-brackets">True</property>
-  </object>
   <object class="GtkDialog" id="dialog_snippets">
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Snippets Manager</property>
-    <property name="type">GTK_WINDOW_TOPLEVEL</property>
-    <property name="window_position">GTK_WIN_POS_NONE</property>
-    <property name="modal">False</property>
     <property name="default_width">750</property>
     <property name="default_height">500</property>
-    <property name="resizable">True</property>
     <property name="destroy_with_parent">True</property>
-    <property name="decorated">True</property>
+    <property name="type_hint">dialog</property>
     <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">False</property>
-    <property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
-    <property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
-    <property name="focus_on_map">True</property>
-    <property name="urgency_hint">False</property>
-    <signal handler="on_dialog_snippets_response" last_modification_time="Mon, 19 Dec 2005 11:20:00 GMT" name="response"/>
-    <signal handler="on_dialog_snippets_destroy" last_modification_time="Sun, 22 Jun 2008 13:22:00 GMT" name="destroy"/>
+    <signal name="destroy" handler="on_dialog_snippets_destroy" swapped="no"/>
+    <signal name="response" handler="on_dialog_snippets_response" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
-        <property name="spacing">0</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
-            <child>
-              <object class="GtkButton" id="closebutton1">
-                <property name="visible">True</property>
-                <property name="can_default">True</property>
-                <property name="can_focus">True</property>
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
-                <property name="focus_on_click">True</property>
-              </object>
-            </child>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="visible">True</property>
-                <property name="can_default">True</property>
-                <property name="can_focus">True</property>
                 <property name="label">gtk-help</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
-                <property name="focus_on_click">True</property>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="closebutton1">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHPaned" id="hpaned_paned">
-            <property name="border_width">6</property>
+          <object class="GtkPaned">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="position">275</property>
             <child>
-              <object class="GtkVBox" id="vbox_selection">
-                <property name="width_request">230</property>
+              <object class="GtkGrid" id="grid_selection">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkLabel" id="label1">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">_Snippets:</property>
-                    <property name="use_underline">True</property>
-                    <property name="use_markup">False</property>
-                    <property name="justify">GTK_JUSTIFY_LEFT</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="xalign">0</property>
-                    <property name="yalign">0.5</property>
-                    <property name="xpad">0</property>
-                    <property name="ypad">0</property>
-                    <property name="mnemonic_widget">tree_view_snippets</property>
-                    <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
-                    <property name="angle">0</property>
-                  </object>
-                  <packing>
-                    <property name="padding">0</property>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                  </packing>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="orientation">vertical</property>
+                <property name="row_spacing">6</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolled_window_snippets">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                    <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                    <property name="shadow_type">GTK_SHADOW_IN</property>
-                    <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkTreeView" id="tree_view_snippets">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="headers_visible">False</property>
-                        <property name="rules_hint">False</property>
-                        <property name="reorderable">False</property>
-                        <property name="enable_search">True</property>
-                        <property name="fixed_height_mode">False</property>
-                        <property name="hover_selection">False</property>
-                        <property name="hover_expand">False</property>
-                        <signal handler="on_tree_view_snippets_row_expanded" last_modification_time="Tue, 03 Jan 2006 22:06:02 GMT" name="row_expanded"/>
-                        <signal handler="on_tree_view_snippets_key_press" last_modification_time="Tue, 03 Jan 2006 22:07:00 GMT" name="key_press_event"/>
+                        <signal name="key-press-event" handler="on_tree_view_snippets_key_press" swapped="no"/>
+                        <signal name="row-expanded" handler="on_tree_view_snippets_row_expanded" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox_buttons">
+                  <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
-                    <property name="spacing">6</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">_Snippets:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">tree_view_snippets</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkGrid" id="grid_buttons">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="column_spacing">6</property>
                     <child>
                       <object class="GtkButton" id="button_new_snippet">
                         <property name="visible">True</property>
-                        <property name="tooltip-text" translatable="yes">Create new snippet</property>
-                        <property name="can_default">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
-                        <property name="focus_on_click">True</property>
-                        <signal handler="on_button_new_snippet_clicked" last_modification_time="Tue, 20 Dec 2005 19:50:58 GMT" name="clicked"/>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Create new snippet</property>
+                        <signal name="clicked" handler="on_button_new_snippet_clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="image1">
                             <property name="visible">True</property>
-                            <property name="stock">gtk-new</property>
-                            <property name="icon_size">4</property>
-                            <property name="xalign">0.5</property>
-                            <property name="yalign">0.5</property>
-                            <property name="xpad">0</property>
-                            <property name="ypad">0</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">document-new</property>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_import_snippets">
                         <property name="visible">True</property>
-                        <property name="tooltip-text" translatable="yes">Import snippets</property>
-                        <property name="can_default">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
-                        <property name="focus_on_click">True</property>
-                        <signal handler="on_button_import_snippets_clicked" last_modification_time="Tue, 10 Jul 2007 18:37:11 GMT" name="clicked"/>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Import snippets</property>
+                        <signal name="clicked" handler="on_button_import_snippets_clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="image5">
                             <property name="visible">True</property>
-                            <property name="stock">gtk-open</property>
-                            <property name="icon_size">4</property>
-                            <property name="xalign">0.5</property>
-                            <property name="yalign">0.5</property>
-                            <property name="xpad">0</property>
-                            <property name="ypad">0</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">document-open</property>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_export_snippets">
                         <property name="visible">True</property>
-                        <property name="tooltip-text" translatable="yes">Export selected snippets</property>
-                        <property name="can_default">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
-                        <property name="focus_on_click">True</property>
-                        <signal handler="on_button_export_snippets_clicked" last_modification_time="Tue, 10 Jul 2007 18:37:25 GMT" name="clicked"/>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Export selected snippets</property>
+                        <signal name="clicked" handler="on_button_export_snippets_clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="image4">
                             <property name="visible">True</property>
-                            <property name="stock">gtk-save</property>
-                            <property name="icon_size">4</property>
-                            <property name="xalign">0.5</property>
-                            <property name="yalign">0.5</property>
-                            <property name="xpad">0</property>
-                            <property name="ypad">0</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">document-save</property>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="left_attach">2</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="button_remove_snippet">
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
-                        <property name="tooltip-text" translatable="yes">Delete selected snippet</property>
-                        <property name="can_default">True</property>
                         <property name="can_focus">True</property>
-                        <property name="relief">GTK_RELIEF_NORMAL</property>
-                        <property name="focus_on_click">True</property>
-                        <signal handler="on_button_remove_snippet_clicked" last_modification_time="Mon, 19 Dec 2005 13:15:14 GMT" name="clicked"/>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Delete selected snippet</property>
+                        <property name="halign">end</property>
+                        <property name="hexpand">True</property>
+                        <signal name="clicked" handler="on_button_remove_snippet_clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="image_remove">
                             <property name="visible">True</property>
-                            <property name="stock">gtk-delete</property>
-                            <property name="icon_size">4</property>
-                            <property name="xalign">0.5</property>
-                            <property name="yalign">0.5</property>
-                            <property name="xpad">0</property>
-                            <property name="ypad">0</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">edit-delete</property>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="pack_type">GTK_PACK_END</property>
+                        <property name="left_attach">3</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="shrink">False</property>
                 <property name="resize">False</property>
+                <property name="shrink">True</property>
               </packing>
             </child>
             <child>
-              <object class="GtkVBox" id="vbox_snippet">
+              <object class="GtkGrid" id="grid_snippet">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
-                <property name="spacing">12</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="orientation">vertical</property>
+                <property name="row_spacing">12</property>
                 <child>
-                  <object class="GtkVBox" id="vbox2">
+                  <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkLabel" id="label4">
-                        <property name="visible">True</property>
-                        <property name="label" translatable="yes">_Edit:</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_markup">False</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
-                        <property name="xpad">0</property>
-                        <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
-                      </object>
-                      <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="orientation">vertical</property>
+                    <property name="row_spacing">6</property>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolled_window_snippet">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="shadow_type">GTK_SHADOW_IN</property>
-                        <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow_type">in</property>
                         <child>
                           <object class="PlumaView" id="source_view_snippet">
                             <property name="buffer">source_buffer</property>
@@ -346,302 +295,198 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">_Edit:</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVBox" id="vbox1">
+                  <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="homogeneous">False</property>
-                    <property name="spacing">6</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="orientation">vertical</property>
+                    <property name="row_spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Activation</property>
-                        <property name="use_underline">False</property>
                         <property name="use_markup">True</property>
-                        <property name="justify">GTK_JUSTIFY_LEFT</property>
-                        <property name="wrap">False</property>
-                        <property name="selectable">False</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0.5</property>
-                        <property name="xpad">0</property>
-                        <property name="ypad">0</property>
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="width_chars">-1</property>
-                        <property name="single_line_mode">False</property>
-                        <property name="angle">0</property>
                         <attributes>
-                          <attribute name="weight" value="PANGO_WEIGHT_BOLD"/>
+                          <attribute name="weight" value="bold"/>
                         </attributes>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbox1">
+                      <object class="GtkGrid">
                         <property name="visible">True</property>
-                        <property name="homogeneous">False</property>
-                        <property name="spacing">0</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="hexpand">True</property>
+                        <property name="row_spacing">6</property>
+                        <property name="column_spacing">6</property>
                         <child>
-                          <object class="GtkLabel" id="label2">
+                          <object class="GtkComboBox" id="combo_drop_targets">
                             <property name="visible">True</property>
-                            <property name="label" translatable="yes">    </property>
-                            <property name="use_underline">False</property>
-                            <property name="use_markup">False</property>
-                            <property name="justify">GTK_JUSTIFY_LEFT</property>
-                            <property name="wrap">False</property>
-                            <property name="selectable">False</property>
-                            <property name="xalign">0.5</property>
-                            <property name="yalign">0.5</property>
-                            <property name="xpad">0</property>
-                            <property name="ypad">0</property>
-                            <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                            <property name="width_chars">-1</property>
-                            <property name="single_line_mode">False</property>
-                            <property name="angle">0</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="model">model1</property>
+                            <property name="has_entry">True</property>
+                            <property name="entry_text_column">0</property>
+                            <child internal-child="entry">
+                              <object class="GtkEntry">
+                                <property name="can_focus">True</property>
+                              </object>
+                            </child>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkTable" id="table1">
+                          <object class="GtkLabel" id="label_drop_targets">
                             <property name="visible">True</property>
-                            <property name="n_rows">3</property>
-                            <property name="n_columns">2</property>
-                            <property name="homogeneous">False</property>
-                            <property name="row_spacing">6</property>
-                            <property name="column_spacing">6</property>
-                            <child>
-                              <object class="GtkLabel" id="label_tab_trigger">
-                                <property name="visible">True</property>
-                                <property comments="&quot;tab&quot; here means the tab key, not the notebook tab!" name="label" translatable="yes">_Tab trigger:</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_markup">False</property>
-                                <property name="justify">GTK_JUSTIFY_LEFT</property>
-                                <property name="wrap">False</property>
-                                <property name="selectable">False</property>
-                                <property name="xalign">0</property>
-                                <property name="yalign">0.5</property>
-                                <property name="xpad">0</property>
-                                <property name="ypad">0</property>
-                                <property name="mnemonic_widget">entry_tab_trigger</property>
-                                <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                                <property name="width_chars">-1</property>
-                                <property name="single_line_mode">False</property>
-                                <property name="angle">0</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="right_attach">1</property>
-                                <property name="top_attach">0</property>
-                                <property name="bottom_attach">1</property>
-                                <property name="x_options">fill</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkHBox" id="hbox_tab_trigger">
-                                <property name="visible">True</property>
-                                <child>
-                                  <object class="GtkEntry" id="entry_tab_trigger">
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="tooltip-text" translatable="yes">Single word the snippet is activated with after pressing Tab</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="editable">True</property>
-                                    <property name="visibility">True</property>
-                                    <property name="max_length">0</property>
-                                    <property name="text" translatable="yes"/>
-                                    <property name="has_frame">True</property>
-                                    <property name="invisible_char">*</property>
-                                    <property name="activates_default">False</property>
-                                    <signal handler="on_entry_tab_trigger_focus_out" last_modification_time="Wed, 04 Jan 2006 14:07:29 GMT" name="focus_out_event"/>
-                                    <signal handler="on_entry_tab_trigger_changed" last_modification_time="Fri, 28 Apr 2006 16:50:34 GMT" name="changed"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkImage" id="image_tab_trigger">
-                                    <property name="visible">False</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="position">1</property>
-                                    <property name="padding">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">0</property>
-                                <property name="bottom_attach">1</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="entry_accelerator">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="tooltip-text" translatable="yes">Shortcut key with which the snippet is activated</property>
-                                <property name="can_focus">True</property>
-                                <property name="editable">False</property>
-                                <property name="visibility">True</property>
-                                <property name="max_length">0</property>
-                                <property name="text" translatable="yes"/>
-                                <property name="has_frame">True</property>
-                                <property name="invisible_char">*</property>
-                                <property name="activates_default">False</property>
-                                <signal handler="on_entry_accelerator_focus_out" last_modification_time="Wed, 04 Jan 2006 14:07:20 GMT" name="focus_out_event"/>
-                                <signal handler="on_entry_accelerator_key_press" last_modification_time="Wed, 04 Jan 2006 14:07:23 GMT" name="key_press_event"/>
-                                <signal handler="on_entry_accelerator_focus_in" last_modification_time="Wed, 04 Jan 2006 14:09:06 GMT" name="focus_in_event"/>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label_accelerator">
-                                <property name="visible">True</property>
-                                <property name="label" translatable="yes">S_hortcut key:</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_markup">False</property>
-                                <property name="justify">GTK_JUSTIFY_LEFT</property>
-                                <property name="wrap">False</property>
-                                <property name="selectable">False</property>
-                                <property name="xalign">0</property>
-                                <property name="yalign">0.5</property>
-                                <property name="xpad">0</property>
-                                <property name="ypad">0</property>
-                                <property name="mnemonic_widget">entry_accelerator</property>
-                                <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                                <property name="width_chars">-1</property>
-                                <property name="single_line_mode">False</property>
-                                <property name="angle">0</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="right_attach">1</property>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
-                                <property name="x_options">fill</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label_drop_targets">
-                                <property name="visible">True</property>
-                                <property name="label" translatable="yes">_Drop targets:</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_markup">False</property>
-                                <property name="justify">GTK_JUSTIFY_LEFT</property>
-                                <property name="wrap">False</property>
-                                <property name="selectable">False</property>
-                                <property name="xalign">0</property>
-                                <property name="yalign">0.5</property>
-                                <property name="xpad">0</property>
-                                <property name="ypad">0</property>
-                                <property name="mnemonic_widget">entry_accelerator</property>
-                                <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                                <property name="width_chars">-1</property>
-                                <property name="single_line_mode">False</property>
-                                <property name="angle">0</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="right_attach">1</property>
-                                <property name="top_attach">2</property>
-                                <property name="bottom_attach">3</property>
-                                <property name="x_options">fill</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="combo_drop_targets">
-                                <property name="visible">True</property>
-                                <property name="add_tearoffs">False</property>
-                                <property name="has_frame">True</property>
-                                <property name="has_entry">True</property>
-                                <property name="focus_on_click">True</property>
-                                <property name="model">model1</property>
-                                <child>
-                                  <object class="GtkCellRendererText" id="renderer1"/>
-                                  <attributes>
-                                    <attribute name="text">0</attribute>
-                                  </attributes>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">2</property>
-                                <property name="bottom_attach">3</property>
-                                <property name="x_options">fill</property>
-                                <property name="y_options">fill</property>
-                              </packing>
-                            </child>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">_Drop targets:</property>
+                            <property name="use_underline">True</property>
                           </object>
                           <packing>
-                            <property name="padding">0</property>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="entry_accelerator">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">Shortcut key with which the snippet is activated</property>
+                            <property name="hexpand">True</property>
+                            <property name="editable">False</property>
+                            <property name="invisible_char">*</property>
+                            <signal name="focus-in-event" handler="on_entry_accelerator_focus_in" swapped="no"/>
+                            <signal name="focus-out-event" handler="on_entry_accelerator_focus_out" swapped="no"/>
+                            <signal name="key-press-event" handler="on_entry_accelerator_key_press" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_accelerator">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">S_hortcut key:</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_tab_trigger">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes" comments="&quot;tab&quot; here means the tab key, not the notebook tab!">_Tab trigger:</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkImage" id="image_tab_trigger">
+                            <property name="can_focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="entry_tab_trigger">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">Single word the snippet is activated with after pressing Tab</property>
+                            <property name="hexpand">True</property>
+                            <property name="invisible_char">*</property>
+                            <signal name="changed" handler="on_entry_tab_trigger_changed" swapped="no"/>
+                            <signal name="focus-out-event" handler="on_entry_tab_trigger_focus_out" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="padding">0</property>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="shrink">True</property>
                 <property name="resize">True</property>
+                <property name="shrink">True</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-7">closebutton1</action-widget>
       <action-widget response="-11">button1</action-widget>
+      <action-widget response="-7">closebutton1</action-widget>
     </action-widgets>
+  </object>
+  <object class="PlumaDocument" id="source_buffer">
+    <property name="highlight-matching-brackets">True</property>
   </object>
 </interface>


### PR DESCRIPTION
This rewrites the plugin in Python 3, while retaining Python 2 compatibility.

In addition, some bugs are fixed and the Gtk-3 compatibility is improved (mainly regarding UI and widget deprecation). 