### PR TITLE
Switch to Python 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,7 @@ else
 	have_introspection=no
 fi
 
-AM_PATH_PYTHON([2.7])
+AM_PATH_PYTHON([3.0])
 
 dnl ================================================================
 dnl GSettings related settings

--- a/plugins/externaltools/externaltools.plugin.desktop.in
+++ b/plugins/externaltools/externaltools.plugin.desktop.in
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=externaltools
 IAge=2
 _Name=External Tools

--- a/plugins/pythonconsole/pythonconsole.plugin.desktop.in
+++ b/plugins/pythonconsole/pythonconsole.plugin.desktop.in
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=pythonconsole
 IAge=2
 _Name=Python Console

--- a/plugins/quickopen/quickopen.plugin.desktop.in
+++ b/plugins/quickopen/quickopen.plugin.desktop.in
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=quickopen
 IAge=2
 _Name=Quick Open

--- a/plugins/snippets/snippets.plugin.desktop.in
+++ b/plugins/snippets/snippets.plugin.desktop.in
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=snippets
 IAge=2
 _Name=Snippets

--- a/pluma/pluma-plugins-engine.c
+++ b/pluma/pluma-plugins-engine.c
@@ -60,7 +60,7 @@ pluma_plugins_engine_init (PlumaPluginsEngine *engine)
 
 	pluma_debug (DEBUG_PLUGINS);
 
-	peas_engine_enable_loader (PEAS_ENGINE (engine), "python");
+	peas_engine_enable_loader (PEAS_ENGINE (engine), "python3");
 
 	engine->priv = G_TYPE_INSTANCE_GET_PRIVATE (engine,
 	                                            PLUMA_TYPE_PLUGINS_ENGINE,


### PR DESCRIPTION
Now that Python plugins have been updated to Python 3 compatible code, this PR can be merged to switch the whole Pluma package to use Python 3.