### PR TITLE
Change url project's website

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ the file 'COPYING' for more information.
 
 The official web site is:
 
-    http://www.mate-desktop.org/
+    https://mate-desktop.org/
 
 You can download the latest pluma tarball from:
 

--- a/data/pluma.appdata.xml.in
+++ b/data/pluma.appdata.xml.in
@@ -37,7 +37,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/plugins/changecase/changecase.plugin.desktop.in
+++ b/plugins/changecase/changecase.plugin.desktop.in
@@ -5,4 +5,4 @@ _Name=Change Case
 _Description=Changes the case of selected text.
 Authors=Paolo Borelli <pborelli@katamail.com>
 Copyright=Copyright © 2004-2005 Paolo Borelli
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/externaltools/externaltools.plugin.desktop.in
+++ b/plugins/externaltools/externaltools.plugin.desktop.in
@@ -6,4 +6,4 @@ _Name=External Tools
 _Description=Execute external commands and shell scripts.
 Authors=Steve Frécinaux <steve@istique.net>
 Copyright=Copyright © 2005 Steve Frécinaux
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/filebrowser/filebrowser.plugin.desktop.in
+++ b/plugins/filebrowser/filebrowser.plugin.desktop.in
@@ -7,4 +7,4 @@ _Description=Easy file access from the side pane
 Icon=system-file-manager
 Authors=Jesse van den Kieboom <jesse@icecrew.nl>
 Copyright=Copyright © 2006 Jesse van den Kieboom
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/modelines/modelines.plugin.desktop.in
+++ b/plugins/modelines/modelines.plugin.desktop.in
@@ -5,4 +5,4 @@ _Name=Modelines
 _Description=Emacs, Kate and Vim-style modelines support for pluma.
 Authors=Steve Frécinaux <steve@istique.net>
 Copyright=Copyright © 2005 Steve Frécinaux
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/pythonconsole/pythonconsole.plugin.desktop.in
+++ b/plugins/pythonconsole/pythonconsole.plugin.desktop.in
@@ -7,4 +7,4 @@ _Description=Interactive Python console standing in the bottom panel
 Icon=text-x-python
 Authors=Steve Frécinaux <steve@istique.net>
 Copyright=Copyright © 2006 Steve Frécinaux
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/quickopen/quickopen.plugin.desktop.in
+++ b/plugins/quickopen/quickopen.plugin.desktop.in
@@ -7,4 +7,4 @@ _Description=Quickly open files
 Icon=document-open
 Authors=Jesse van den Kieboom  <jessevdk@gnome.org>
 Copyright=Copyright © 2009 Jesse van den Kieboom
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/snippets/snippets.plugin.desktop.in
+++ b/plugins/snippets/snippets.plugin.desktop.in
@@ -6,4 +6,4 @@ _Name=Snippets
 _Description=Insert often-used pieces of text in a fast way
 Authors=Jesse van den Kieboom <jesse@icecrew.nl>
 Copyright=Copyright © 2005 Jesse van den Kieboom
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/sort/sort.plugin.desktop.in
+++ b/plugins/sort/sort.plugin.desktop.in
@@ -6,4 +6,4 @@ _Description=Sorts a document or selected text.
 Icon=view-sort-ascending
 Authors=Carlo Borreo <borreo@softhome.net>;Lee Mallabone <mate@fonicmonkey.net>;Paolo Maggi <paolo.maggi@polito.it>;Jorge Alberto Torres H. <jorge@deadoak.com>
 Copyright=Copyright © 2001 Carlo Borreo\nCopyright © 2002-2003 Lee Mallabone, Paolo Maggi\nCopyright © 2004-2005 Paolo Maggi
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/spell/spell.plugin.desktop.in
+++ b/plugins/spell/spell.plugin.desktop.in
@@ -6,4 +6,4 @@ _Description=Checks the spelling of the current document.
 Icon=tools-check-spelling
 Authors=Paolo Maggi <paolo@gnome.org>
 Copyright=Copyright © 2002-2005 Paolo Maggi
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/taglist/taglist.plugin.desktop.in
+++ b/plugins/taglist/taglist.plugin.desktop.in
@@ -5,4 +5,4 @@ _Name=Tag list
 _Description=Provides a method to easily insert commonly used tags/strings into a document without having to type them.
 Authors=Paolo Maggi <paolo.maggi@polito.it>
 Copyright=Copyright © 2002-2005 Paolo Maggi
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/time/time.plugin.desktop.in
+++ b/plugins/time/time.plugin.desktop.in
@@ -5,4 +5,4 @@ _Name=Insert Date/Time
 _Description=Inserts current date and time at the cursor position.
 Authors=Paolo Maggi <paolo.maggi@polito.it>;Lee Mallabone <mate@fonicmonkey.net>
 Copyright=Copyright © 2002-2005 Paolo Maggi
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/plugins/trailsave/trailsave.plugin.desktop.in
+++ b/plugins/trailsave/trailsave.plugin.desktop.in
@@ -6,4 +6,4 @@ _Description=Removes trailing spaces from lines before saving.
 Icon=edit-cut
 Authors=Marty Mills <daggerbot@gmail.com>
 Copyright=Copyright © 2015 Marty Mills
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org

--- a/tools/plugin_template/pluma-plugin.desktop.in
+++ b/tools/plugin_template/pluma-plugin.desktop.in
@@ -6,4 +6,4 @@ _Description=##(DESCRIPTION)
 Icon=pluma-plugin
 Authors=##(AUTHOR_FULLNAME) <##(AUTHOR_EMAIL.lower)>
 Copyright=Copyright © ##(DATE_YEAR) ##(AUTHOR_FULLNAME)
-Website=http://www.mate-desktop.org
+Website=https://mate-desktop.org


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.