### PR TITLE
pluma-print-preview: Fix warning: identical expressions

### DIFF
--- a/pluma/pluma-print-preview.c
+++ b/pluma/pluma-print-preview.c
@@ -740,7 +740,7 @@ get_page_at_coords (PlumaPrintPreview *preview,
 
 	priv = preview->priv;
 
-	if (priv->tile_h <= 0 || priv->tile_h <= 0)
+	if (priv->tile_h <= 0 || priv->tile_w <= 0)
 		return -1;
 
 	hadj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE (priv->layout));


### PR DESCRIPTION
based in gedit commit:
https://gitlab.gnome.org/GNOME/gedit/commit/e30939812fcf884d031757fb3cc2a8383f3ce21f

Fixes Clang analyzer warning:
```
pluma-print-preview.c:743:24: warning: identical expressions on both sides of logical operator
        if (priv->tile_h <= 0 || priv->tile_h <= 0)
            ~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~
```

Fixes cppcheck warning:
`[pluma/pluma-print-preview.c:743]: (style) Same expression on both sides of '||'.`