### PR TITLE
Fix French translation of the "Windows" line ending type

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -1571,7 +1571,7 @@ msgstr "Mac OS Classic"
 
 #: ../pluma/pluma-file-chooser-dialog.c:179
 msgid "Windows"
-msgstr "Fenêtres"
+msgstr "Windows"
 
 #: ../pluma/pluma-file-chooser-dialog.c:442
 #: ../plugins/filebrowser/pluma-file-browser-widget.c:812


### PR DESCRIPTION
Fixes #441.

This is a very easy fix, and the string is only used in this location so it should have zero side effect.