### PR TITLE
pluma-document: avoid garbarge value in 'file_with_bom' function

### DIFF
--- a/pluma/pluma-document.c
+++ b/pluma/pluma-document.c
@@ -655,6 +655,8 @@ file_with_bom (GFile *file)
 	gchar    bom[3];
 	gchar   *file_path;
 
+	bom[0] = bom[1] = bom[2] = 0;
+
 	file_path = g_file_get_path (file);
 
 	testfile = fopen (file_path, "r");


### PR DESCRIPTION
Fixes clang analyzer warning:

```
pluma-document.c:682:14: warning: The left operand of '==' is a garbage value
        if ((bom[0] == '\357') &&
             ~~~~~~ ^
```

In the tests, make sure you can't reproduce the issue https://github.com/mate-desktop/pluma/issues/301