### PR TITLE
window: Do not override GdkWindowState

### DIFF
--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -266,7 +266,7 @@ pluma_window_window_state_event (GtkWidget           *widget,
 
 	window->priv->window_state = event->new_window_state;
 
-	return FALSE;
+	return GTK_WIDGET_CLASS (pluma_window_parent_class)->window_state_event (widget, event);
 }
 
 static gboolean


### PR DESCRIPTION
When setting the custom pluma window state we override the class method,
but never defer back to the parent class method. This means that window
states like backdrop are never set on Pluma.