### PR TITLE
Fix misuse of full-width symbols

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,31 +1,31 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR MATE Desktop Environment team
+# This file is distributed under the same license as the pluma package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Christopher Meng <i@cicku.me>, 2018
+# Christopher M <i@cicku.me>, 2018
 # Dianjin Wang <1132321739qq@gmail.com>, 2018
 # 玉堂白鹤 <yjwork@qq.com>, 2018
 # Martin Wimpress <code@flexion.org>, 2018
-# nyanyh <rebuilty@gmail.com>, 2018
-# Wylmer Wang, 2018
-# Stefano Karapetsas <stefano@karapetsas.com>, 2018
+# gtrslower, 2018
 # Mingcong Bai <jeffbai@aosc.xyz>, 2018
 # Mingye Wang <arthur200126@gmail.com>, 2018
-# shuyu liu <liushuyu011@gmail.com>, 2018
-# Wolfgang Ulbrich <mate@raveit.de>, 2019
+# liushuyu011 <liushuyu011@gmail.com>, 2018
 # CNAmira <forucial@icloud.com>, 2019
 # Wenbin Lv <wenbin816@gmail.com>, 2019
+# Wylmer Wang, 2019
+# Wolfgang Ulbrich <mate@raveit.de>, 2019
+# Stefano Karapetsas <stefano@karapetsas.com>, 2019
+# Mingtian Yang <i@skylee.xyz>, 2020
 # 
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-17 20:56+0200\n"
+"Project-Id-Version: pluma 1.23.2\n"
+"Report-Msgid-Bugs-To: https://github.com/mate-desktop/pluma/issues\n"
+"POT-Creation-Date: 2019-12-03 17:49+0100\n"
 "PO-Revision-Date: 2018-03-12 09:49+0000\n"
-"Last-Translator: Wenbin Lv <wenbin816@gmail.com>, 2019\n"
+"Last-Translator: Mingtian Yang <i@skylee.xyz>, 2020\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/mate/teams/13566/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -33,11 +33,11 @@ msgstr ""
 "Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:1
+#: data/org.mate.pluma.gschema.xml.in:11
 msgid "Use Default Font"
 msgstr "使用默认字体"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:2
+#: data/org.mate.pluma.gschema.xml.in:12
 msgid ""
 "Whether to use the system's default fixed width font for editing text "
 "instead of a font specific to pluma. If this option is turned off, then the "
@@ -45,111 +45,111 @@ msgid ""
 "font."
 msgstr "是否要为编辑文本指定不同于系统默认字体的字体。如果关闭了此选项，“编辑器字体”选项中的字体名称将会替代系统字体。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:3
+#: data/org.mate.pluma.gschema.xml.in:15
 msgctxt "editor-font"
 msgid "'Monospace 12'"
 msgstr "'等宽 12'"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:4
+#: data/org.mate.pluma.gschema.xml.in:16
 msgid "Editor Font"
 msgstr "编辑字体"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:5
+#: data/org.mate.pluma.gschema.xml.in:17
 msgid ""
 "A custom font that will be used for the editing area. This will only take "
 "effect if the \"Use Default Font\" option is turned off."
 msgstr "编辑区使用的自定义字体。只有当“使用默认字体”选项关掉时才有效。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:6
+#: data/org.mate.pluma.gschema.xml.in:21
 msgid "Switch tabs with [ctrl] + [tab]"
 msgstr "使用 [ctrl] + [tab] 切换标签页"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:7
+#: data/org.mate.pluma.gschema.xml.in:22
 msgid ""
 "If true, it enables the ability to switch tabs using [ctrl + tab] and [ctrl "
 "+ shift + tab]."
 msgstr "如果选中，您将可以使用 [ctrl + tab] 和 [ctrl + shift + tab] 切换标签页"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:8
+#: data/org.mate.pluma.gschema.xml.in:26
 msgid "Show the first tab if there is only one tab"
 msgstr "只有一个标签页时显示第一个标签页"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:9
+#: data/org.mate.pluma.gschema.xml.in:27
 msgid "If false, it hides the first tab if there is only one tab."
 msgstr "如果设置为 false，只有一个标签页时隐藏第一个标签页。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:10
+#: data/org.mate.pluma.gschema.xml.in:31
 msgid "Style Scheme"
 msgstr "风格大纲"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:11
+#: data/org.mate.pluma.gschema.xml.in:32
 msgid "The ID of a GtkSourceView Style Scheme used to color the text."
 msgstr "用于文本颜色的 GtkSourceView 样式主题 ID。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:12
+#: data/org.mate.pluma.gschema.xml.in:36
 msgid "Create Backup Copies"
 msgstr "生成备份文件"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:13
+#: data/org.mate.pluma.gschema.xml.in:37
 msgid ""
 "Whether pluma should create backup copies for the files it saves. You can "
 "set the backup file extension with the \"Backup Copy Extension\" option."
 msgstr "pluma 是否为保存的文件创建备份文件。您可以在“备份文件扩展名”选项中设置备份文件的扩展名。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:14
+#: data/org.mate.pluma.gschema.xml.in:41
 msgid "Autosave"
 msgstr "自动保存"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:15
+#: data/org.mate.pluma.gschema.xml.in:42
 msgid ""
 "Whether pluma should automatically save modified files after a time "
 "interval. You can set the time interval with the \"Autosave Interval\" "
 "option."
 msgstr "pluma 是否每隔一段时间自动保存已修改的文件。您可以在“自动保存时间间隔”选项中设置该时间间隔。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:16
+#: data/org.mate.pluma.gschema.xml.in:46
 msgid "Autosave Interval"
 msgstr "自动保存时间间隔"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:17
+#: data/org.mate.pluma.gschema.xml.in:47
 msgid ""
 "Number of minutes after which pluma will automatically save modified files. "
 "This will only take effect if the \"Autosave\" option is turned on."
 msgstr "文件修改后到自动保存的时间。只有当“自动保存”选项打开后才有效。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:18
+#: data/org.mate.pluma.gschema.xml.in:51
 msgid "Show save confirmation"
 msgstr "显示保存确认"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:19
+#: data/org.mate.pluma.gschema.xml.in:52
 msgid "Show save confirmation if the files have changes."
 msgstr "在文件更改后显示保存确认。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:20
+#: data/org.mate.pluma.gschema.xml.in:56
 msgid "Writable VFS schemes"
 msgstr "可写入的 VFS 大纲"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:21
+#: data/org.mate.pluma.gschema.xml.in:57
 msgid ""
 "List of VFS schemes pluma supports in write mode. The 'file' scheme is "
 "writable by default."
 msgstr "列出 pluma 在写入模式中支持的 VFS 大纲。“file”大纲默认可写。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:22
+#: data/org.mate.pluma.gschema.xml.in:61
 msgid "Maximum Number of Undo Actions"
 msgstr "撤消操作的最多数量"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:23
+#: data/org.mate.pluma.gschema.xml.in:62
 msgid ""
 "Maximum number of actions that pluma will be able to undo or redo. Use "
 "\"-1\" for unlimited number of actions."
 msgstr "pluma 撤消或重做操作的最多次数。使用“-1”代表无限制。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:24
+#: data/org.mate.pluma.gschema.xml.in:66
 msgid "Line Wrapping Mode"
 msgstr "自动换行模式"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:25
+#: data/org.mate.pluma.gschema.xml.in:67
 msgid ""
 "Specifies how to wrap long lines in the editing area. Use \"GTK_WRAP_NONE\" "
 "for no wrapping, \"GTK_WRAP_WORD\" for wrapping at word boundaries, and "
@@ -159,77 +159,77 @@ msgid ""
 msgstr ""
 "指定编辑区域中如何将长行折断。使用“GTK_WRAP_NONE”代表不换行，“GTK_WRAP_WORD”代表按单词换行，而“GTK_WRAP_CHAR”代表按字符换行。请注意，这些值是区分大小写的，所以请确定必须按照这里说明的大小写出现。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:26
+#: data/org.mate.pluma.gschema.xml.in:71
 msgid "Tab Size"
 msgstr "制表符长度"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:27
+#: data/org.mate.pluma.gschema.xml.in:72
 msgid ""
 "Specifies the number of spaces that should be displayed instead of Tab "
 "characters."
 msgstr "设定用于代替制表符的空格数。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:28
+#: data/org.mate.pluma.gschema.xml.in:76
 msgid "Insert spaces"
 msgstr "插入空格"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:29
+#: data/org.mate.pluma.gschema.xml.in:77
 msgid "Whether pluma should insert spaces instead of tabs."
 msgstr "pluma 是否要插入空格代替制表符。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:30
+#: data/org.mate.pluma.gschema.xml.in:81
 msgid "Automatic indent"
 msgstr "自动缩进"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:31
+#: data/org.mate.pluma.gschema.xml.in:82
 msgid "Whether pluma should enable automatic indentation."
 msgstr "pluma 是否启用自动缩进。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:32
+#: data/org.mate.pluma.gschema.xml.in:86
 msgid "Display Line Numbers"
 msgstr "显示行号"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:33
+#: data/org.mate.pluma.gschema.xml.in:87
 msgid "Whether pluma should display line numbers in the editing area."
 msgstr "pluma 是否在编辑区域显示行号。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:34
+#: data/org.mate.pluma.gschema.xml.in:91
 msgid "Highlight Current Line"
 msgstr "突出显示当前行"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:35
+#: data/org.mate.pluma.gschema.xml.in:92
 msgid "Whether pluma should highlight the current line."
 msgstr "pluma 是否应该突出显示当前行。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:36
+#: data/org.mate.pluma.gschema.xml.in:96
 msgid "Highlight Matching Bracket"
 msgstr "突出显示匹配的括号"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:37
+#: data/org.mate.pluma.gschema.xml.in:97
 msgid "Whether pluma should highlight the bracket matching the selected one."
 msgstr "pluma 是否应该突出显示和选择的括号所匹配的括号。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:38
+#: data/org.mate.pluma.gschema.xml.in:101
 msgid "Display Right Margin"
 msgstr "显示右边距"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:39
+#: data/org.mate.pluma.gschema.xml.in:102
 msgid "Whether pluma should display the right margin in the editing area."
 msgstr "pluma 是否在编辑区域显示右边距。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:40
+#: data/org.mate.pluma.gschema.xml.in:106
 msgid "Right Margin Position"
 msgstr "右边距位置"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:41
+#: data/org.mate.pluma.gschema.xml.in:107
 msgid "Specifies the position of the right margin."
 msgstr "指定右边距的位置。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:42
+#: data/org.mate.pluma.gschema.xml.in:111
 msgid "Smart Home End"
 msgstr "智能 Home End"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:43
+#: data/org.mate.pluma.gschema.xml.in:112
 msgid ""
 "Specifies how the cursor moves when the HOME and END keys are pressed. Use "
 "\"DISABLED\" to always move at the start/end of the line, \"AFTER\" to move "
@@ -242,46 +242,46 @@ msgstr ""
 "指定在按下 HOME 和 END "
 "键时光标如何移动。使用“DISABLED”以总是移动到行的开始/结尾，“AFTER”以在第一次按下键时移动到行的开始/结尾并在第二次按下键时忽略空白地移动到文本的开始/结尾，“BEFORE”以在移动到行的开始/结尾前先移动到文本的开始/结尾，“ALWAYS”以总是移动到文本的开始/结尾而不是行的开始/结尾。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:44
+#: data/org.mate.pluma.gschema.xml.in:116
 msgid "Restore Previous Cursor Position"
 msgstr "恢复上一次的光标位置"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:45
+#: data/org.mate.pluma.gschema.xml.in:117
 msgid ""
 "Whether pluma should restore the previous cursor position when a file is "
 "loaded."
 msgstr "在载入文件时 pluma 是否应恢复上次的光标位置。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:46
+#: data/org.mate.pluma.gschema.xml.in:121
 msgid "Enable Search Highlighting"
 msgstr "启用搜索突出显示"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:47
+#: data/org.mate.pluma.gschema.xml.in:122
 msgid ""
 "Whether pluma should highlight all the occurrences of the searched text."
 msgstr "pluma 是否应该突出显示被搜索文本的全部出现。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:48
+#: data/org.mate.pluma.gschema.xml.in:126
 msgid "Enable Syntax Highlighting"
 msgstr "启用语法突出显示"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:49
+#: data/org.mate.pluma.gschema.xml.in:127
 msgid "Whether pluma should enable syntax highlighting."
 msgstr "pluma 是否启用语法突出显示。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:50
+#: data/org.mate.pluma.gschema.xml.in:131
 msgid "Toolbar is Visible"
 msgstr "工具栏可见"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:51
+#: data/org.mate.pluma.gschema.xml.in:132
 msgid "Whether the toolbar should be visible in editing windows."
 msgstr "是否在编辑窗口中显示工具栏。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:52
+#: data/org.mate.pluma.gschema.xml.in:136
 msgid "Toolbar Buttons Style"
 msgstr "工具栏按钮风格"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:53
+#: data/org.mate.pluma.gschema.xml.in:137
 msgid ""
 "Style for the toolbar buttons. Possible values are \"PLUMA_TOOLBAR_SYSTEM\" "
 "to use the system's default style, \"PLUMA_TOOLBAR_ICONS\" to display icons "
@@ -292,75 +292,75 @@ msgid ""
 msgstr ""
 "工具栏按钮的风格。可供选择的值包括：“PLUMA_TOOLBAR_SYSTEM”代表使用系统默认风格，“PLUMA_TOOLBAR_ICONS”代表只显示图标，“PLUMA_TOOLBAR_AND_TEXT”代表同时显示图标和文字，而“PLUMA_TOOLBAR_ICONS_BOTH_HORIZ”代表在图标旁边显示文字。请注意，这些值是区分大小写的，所以请确定必须按照这里说明的大小写出现。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:54
+#: data/org.mate.pluma.gschema.xml.in:141
 msgid "Status Bar is Visible"
 msgstr "状态栏可见"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:55
+#: data/org.mate.pluma.gschema.xml.in:142
 msgid ""
 "Whether the status bar at the bottom of editing windows should be visible."
 msgstr "是否显示编辑窗口底部的状态栏。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:56
+#: data/org.mate.pluma.gschema.xml.in:146
 msgid "Side Pane is Visible"
 msgstr "侧边栏可见"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:57
+#: data/org.mate.pluma.gschema.xml.in:147
 msgid ""
 "Whether the side pane at the left of editing windows should be visible."
 msgstr "是否显示编辑窗口左侧的侧边栏。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:58
+#: data/org.mate.pluma.gschema.xml.in:151
 msgid "Show tabs with side pane"
 msgstr "与侧边栏一同显示标签页"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:59
+#: data/org.mate.pluma.gschema.xml.in:152
 msgid ""
 "If false, pluma doesn't show tabs in the notebook with the side pane active."
 msgstr "如果为 False，Pluma 将在侧边栏激活时不在笔记本中显示标签页。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:60
+#: data/org.mate.pluma.gschema.xml.in:156
 msgid "Bottom Panel is Visible"
 msgstr "底部面板可见"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:61
+#: data/org.mate.pluma.gschema.xml.in:157
 msgid ""
 "Whether the bottom panel at the bottom of editing windows should be visible."
 msgstr "是否显示编辑窗口底部的面板。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:62
+#: data/org.mate.pluma.gschema.xml.in:161
 msgid "Maximum Recent Files"
 msgstr "最大当前文件数"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:63
+#: data/org.mate.pluma.gschema.xml.in:162
 msgid ""
 "Specifies the maximum number of recently opened files that will be displayed"
 " in the \"Recent Files\" submenu."
 msgstr "设定最近打开文件数的最大值，这个将在“最近打开过的文件”子菜单中显示。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:64
+#: data/org.mate.pluma.gschema.xml.in:166
 msgid "Print Syntax Highlighting"
 msgstr "打印语法突出显示"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:65
+#: data/org.mate.pluma.gschema.xml.in:167
 msgid ""
 "Whether pluma should print syntax highlighting when printing documents."
 msgstr "pluma 是否在打印文档时打印语法突出显示。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:66
+#: data/org.mate.pluma.gschema.xml.in:171
 msgid "Print Header"
 msgstr "打印页眉"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:67
+#: data/org.mate.pluma.gschema.xml.in:172
 msgid ""
 "Whether pluma should include a document header when printing documents."
 msgstr "pluma 是否在打印文档时包含文档头。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:68
+#: data/org.mate.pluma.gschema.xml.in:176
 msgid "Printing Line Wrapping Mode"
 msgstr "打印时换行模式"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:69
+#: data/org.mate.pluma.gschema.xml.in:177
 msgid ""
 "Specifies how to wrap long lines for printing. Use \"GTK_WRAP_NONE\" for no "
 "wrapping, \"GTK_WRAP_WORD\" for wrapping at word boundaries, and "
@@ -370,247 +370,262 @@ msgid ""
 msgstr ""
 "指定打印时如何将长行折断。使用“GTK_WRAP_NONE”代表不换行，“GTK_WRAP_WORD”代表按单词换行，而“GTK_WRAP_CHAR”代表按字符换行。请注意，这些值是区分大小写的，所以请确定必须按照这里说明的大小写出现。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:70
+#: data/org.mate.pluma.gschema.xml.in:181
 msgid "Print Line Numbers"
 msgstr "打印行号"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:71
+#: data/org.mate.pluma.gschema.xml.in:182
 msgid ""
 "If this value is 0, then no line numbers will be inserted when printing a "
 "document. Otherwise, pluma will print line numbers every such number of "
 "lines."
 msgstr "如果该值(N)为0，则在打印文档时不插入行号；否则，pluma 将每隔 N 行插入行号。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:72
+#: data/org.mate.pluma.gschema.xml.in:185
 msgctxt "print-font-body-pango"
 msgid "'Monospace 9'"
 msgstr "'等宽 9'"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:73
+#: data/org.mate.pluma.gschema.xml.in:186
 msgid "Body Font for Printing"
 msgstr "打印时文档主体所用字体"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:74
+#: data/org.mate.pluma.gschema.xml.in:187
 msgid ""
 "Specifies the font to use for a document's body when printing documents."
 msgstr "设定打印时文档主体所用的字体。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:75
+#: data/org.mate.pluma.gschema.xml.in:190
 msgctxt "print-font-header-pango"
 msgid "'Sans 11'"
 msgstr "'无衬线 11'"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:76
+#: data/org.mate.pluma.gschema.xml.in:191
 msgid "Header Font for Printing"
 msgstr "打印时页眉所用的字体"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:77
+#: data/org.mate.pluma.gschema.xml.in:192
 msgid ""
 "Specifies the font to use for page headers when printing a document. This "
 "will only take effect if the \"Print Header\" option is turned on."
 msgstr "设定打印时页眉所用的字体。只有当“打印页眉”选项打开时才有效。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:78
+#: data/org.mate.pluma.gschema.xml.in:195
 msgctxt "print-font-numbers-pango"
 msgid "'Sans 8'"
 msgstr "'无衬线 8'"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:79
+#: data/org.mate.pluma.gschema.xml.in:196
 msgid "Line Number Font for Printing"
 msgstr "打印时行号所用的字体"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:80
+#: data/org.mate.pluma.gschema.xml.in:197
 msgid ""
 "Specifies the font to use for line numbers when printing. This will only "
 "take effect if the \"Print Line Numbers\" option is non-zero."
 msgstr "设定打印时行号所用的字体。只有当“打印行号”选项打开时才有效。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:81
+#: data/org.mate.pluma.gschema.xml.in:200
 msgctxt "auto-detected"
 msgid "[ 'UTF-8', 'CURRENT', 'ISO-8859-15', 'UTF-16' ]"
 msgstr "[ 'UTF-8', 'CURRENT', 'ISO-8859-15', 'UTF-16' ]"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:82
+#: data/org.mate.pluma.gschema.xml.in:201
 msgid "Automatically Detected Encodings"
 msgstr "自动检测的编码"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:83
+#: data/org.mate.pluma.gschema.xml.in:202
 msgid ""
 "Sorted list of encodings used by pluma for automatically detecting the "
 "encoding of a file. \"CURRENT\" represents the current locale encoding. Only"
 " recognized encodings are used."
 msgstr "pluma 自动检测文件编码时所用的编码清单。“CURRENT”为当前区域编码。只能使用可识别的编码。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:84
+#: data/org.mate.pluma.gschema.xml.in:205
 msgctxt "shown-in-menu"
 msgid "[ 'ISO-8859-15' ]"
 msgstr "[ 'ISO-8859-15' ]"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:85
+#: data/org.mate.pluma.gschema.xml.in:206
 msgid "Encodings shown in menu"
 msgstr "菜单中显示的编码"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:86
+#: data/org.mate.pluma.gschema.xml.in:207
 msgid ""
 "List of encodings shown in the Character Encoding menu in open/save file "
 "selector. Only recognized encodings are used."
 msgstr "在打开/保存文件选择器中的字符代码菜单中显示的编码列表。只使用可识别的编码。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:87
+#: data/org.mate.pluma.gschema.xml.in:211
 msgid "History for \"search for\" entries"
 msgstr "查找历史记录"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:88
+#: data/org.mate.pluma.gschema.xml.in:212
 msgid "List of entries in \"search for\" textbox."
 msgstr "“搜索”文本框的记录列表。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:89
+#: data/org.mate.pluma.gschema.xml.in:216
 msgid "History for \"replace with\" entries"
 msgstr "替换历史记录"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:90
+#: data/org.mate.pluma.gschema.xml.in:217
 msgid "List of entries in \"replace with\" textbox."
 msgstr "“替换为”文本框的记录列表。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:91
+#: data/org.mate.pluma.gschema.xml.in:221
 msgid "Active plugins"
 msgstr "激活插件"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:92
+#: data/org.mate.pluma.gschema.xml.in:222
 msgid ""
 "List of active plugins. It contains the \"Location\" of the active plugins. "
 "See the .pluma-plugin file for obtaining the \"Location\" of a given plugin."
 msgstr "列出激活的插件。其中包含激活插件的“位置”。请参看 .pluma-plugin 文件以便获得给定插件的“位置”。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:93
-msgid "Draw newline"
-msgstr ""
+#: data/org.mate.pluma.gschema.xml.in:226
+msgid "Show newline"
+msgstr "显示换行符"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:94
-msgid "Whether pluma should draw newlines in the editor window."
-msgstr ""
+#: data/org.mate.pluma.gschema.xml.in:227
+msgid "Whether pluma should show newlines in the editor window."
+msgstr "pluma 是否应在编辑器窗口中显示换行符。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:95
-msgid "Draw nbsp"
-msgstr ""
+#: data/org.mate.pluma.gschema.xml.in:231
+msgid "Show nbsp"
+msgstr "显示不换行空格"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:96
+#: data/org.mate.pluma.gschema.xml.in:232
 msgid ""
-"Whether pluma should draw not breaking spaces in the editor window: 'draw-"
-"none' no drawing; 'draw-trailing' drawing only trailing spaces; 'draw-all' "
-"drawing all spaces."
+"Whether pluma should show not breaking spaces in the editor window: 'show-"
+"none' no showing; 'show-trailing' showing only trailing spaces; 'show-all' "
+"showing all spaces."
 msgstr ""
+"pluma 是否应在编辑器窗口中显示不换行空格：'show-none'不显示； 'show-trailing'仅显示尾随空格； 'show-"
+"all'显示所有空格。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:97
-msgid "Draw tabs"
-msgstr ""
+#: data/org.mate.pluma.gschema.xml.in:236
+msgid "Show tabs"
+msgstr "显示制表符"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:98
+#: data/org.mate.pluma.gschema.xml.in:237
 msgid ""
-"Whether pluma should draw tabs in the editor window: 'draw-none' no drawing;"
-" 'draw-trailing' drawing only trailing spaces; 'draw-all' drawing all "
+"Whether pluma should show tabs in the editor window: 'show-none' no showing;"
+" 'show-trailing' showing only trailing spaces; 'show-all' showing all "
 "spaces."
 msgstr ""
+"pluma 是否应在编辑器窗口中显示制表符：'show-none'不显示； 'show-trailing'仅显示尾随空格； 'show-"
+"all'显示所有空格。"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:99
-msgid "Draw spaces"
-msgstr ""
+#: data/org.mate.pluma.gschema.xml.in:241
+msgid "Show spaces"
+msgstr "显示空格"
 
-#: ../data/org.mate.pluma.gschema.xml.in.h:100
+#: data/org.mate.pluma.gschema.xml.in:242
 msgid ""
-"Whether pluma should draw spaces in the editor window: 'draw-none' no "
-"drawing; 'draw-trailing' drawing only trailing spaces; 'draw-all' drawing "
+"Whether pluma should show spaces in the editor window: 'show-none' no "
+"showing; 'show-trailing' showing only trailing spaces; 'show-all' showing "
 "all spaces."
 msgstr ""
+"pluma 是否应在编辑器窗口中显示空格：'show-none'不显示； 'show-trailing'仅显示尾随空格； 'show-"
+"all'显示所有空格。"
 
-#: ../data/pluma.appdata.xml.in.h:1
-msgid "A Text Editor for the MATE desktop environment"
-msgstr "用于 MATE 桌面环境的文本编辑器"
-
-#: ../data/pluma.appdata.xml.in.h:2
-msgid ""
-"<p> Pluma is a small, but powerful text editor designed specifically for the"
-" MATE desktop. It has most standard text editor functions and fully supports"
-" international text in Unicode. Advanced features include syntax "
-"highlighting and automatic indentation of source code, printing and editing "
-"of multiple documents in one window. </p> <p> Pluma is extensible through a "
-"plugin system, which currently includes support for spell checking, "
-"comparing files, viewing CVS ChangeLogs, and adjusting indentation levels. "
-"</p>"
-msgstr ""
-"<p> Pluma 是为 MATE 桌面设计的，小而强大的文本编辑器。Pluma 带有基本的文本编辑功能，并完整支持 Unicode "
-"编码的国际文本。该文本编辑器还带有一些高级功能，比如语法高亮及用于源代码的自动缩进、打印以及在单窗口编辑多个文档。</p> <p> Pluma "
-"可通过扩展插件增强功能，当前包含提供语法检查、文本对比、查看 CVS 更改日志以及调整缩进级别功能的几个插件。</p>"
-
-#: ../data/pluma.desktop.in.in.h:1
+#: data/pluma.appdata.xml.in:7 data/pluma.desktop.in.in:3
 msgid "Pluma"
 msgstr "Pluma"
 
-#: ../data/pluma.desktop.in.in.h:2 ../pluma/pluma-print-job.c:754
+#: data/pluma.appdata.xml.in:8
+msgid "A Text Editor for the MATE desktop environment"
+msgstr "用于 MATE 桌面环境的文本编辑器"
+
+#: data/pluma.appdata.xml.in:10
+msgid ""
+"Pluma is a small, but powerful text editor designed specifically for the "
+"MATE desktop. It has most standard text editor functions and fully supports "
+"international text in Unicode. Advanced features include syntax highlighting"
+" and automatic indentation of source code, printing and editing of multiple "
+"documents in one window."
+msgstr ""
+"Pluma 是一个小型但功能强大的文本编辑器，专门为 MATE 桌面设计。它具有大多数标准的文本编辑器功能，并且完全支持 Unicode "
+"中的国际文本。高级功能包括语法高亮显示和源代码自动缩进，在一个窗口中打印和编辑多个文档。"
+
+#: data/pluma.appdata.xml.in:17
+msgid ""
+"Pluma is extensible through a plugin system, which currently includes "
+"support for spell checking, comparing files, viewing CVS ChangeLogs, and "
+"adjusting indentation levels."
+msgstr "Pluma 可通过插件系统扩展，该插件系统当前包括对拼写检查、比较文件、查看CVS更改日志以及调整缩进级别的支持。"
+
+#: data/pluma.desktop.in.in:4 pluma/pluma-print-job.c:754
 msgid "Text Editor"
 msgstr "文本编辑器"
 
-#: ../data/pluma.desktop.in.in.h:3
+#: data/pluma.desktop.in.in:5
 msgid "Edit text files"
 msgstr "编辑文本文件"
 
-#: ../data/pluma.desktop.in.in.h:4
-msgid "Pluma Text Editor"
-msgstr "Pluma 文本编辑器"
+#. Translators: Do NOT translate or transliterate this text (this is an icon
+#. file name)!
+#: data/pluma.desktop.in.in:12
+msgid "accessories-text-editor"
+msgstr ""
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:136
+#. Translators: Search terms to find this application. Do NOT translate or
+#. localize the semicolons! The list MUST also end with a semicolon!
+#: data/pluma.desktop.in.in:15
+msgid "text;editor;MATE;tabs;highlighting;code;multiple;files;pluggable;"
+msgstr ""
+
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:136
 msgid "Log Out _without Saving"
 msgstr "注销而不保存(_W)"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:140
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:140
 msgid "_Cancel Logout"
 msgstr "取消注销(_C)"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:147
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:147
 msgid "Close _without Saving"
 msgstr "关闭且不保存(_W)"
 
-#. Add a cancel button
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:151
-#: ../pluma/dialogs/pluma-encodings-dialog.c:306
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:3
-#: ../pluma/dialogs/pluma-preferences-dialog.c:975
-#: ../pluma/pluma-commands-file.c:583 ../pluma/pluma-commands-file.c:1223
-#: ../pluma/pluma-file-chooser-dialog.c:435
-#: ../pluma/pluma-io-error-message-area.c:168
-#: ../pluma/pluma-io-error-message-area.c:507
-#: ../pluma/pluma-io-error-message-area.c:1190
-#: ../pluma/pluma-progress-message-area.c:63
-#: ../plugins/filebrowser/pluma-file-browser-utils.c:171
-#: ../plugins/quickopen/quickopen/popup.py:36
-#: ../plugins/snippets/snippets/Manager.py:795
-#: ../plugins/snippets/snippets/Manager.py:881
-#: ../plugins/snippets/snippets/Manager.py:920 ../plugins/sort/sort.ui.h:2
-#: ../plugins/spell/pluma-spell-language-dialog.c:132
-#: ../plugins/spell/languages-dialog.ui.h:3
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:3
-#: ../plugins/time/pluma-time-dialog.ui.h:3
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:3
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:151
+#: pluma/dialogs/pluma-encodings-dialog.c:306
+#: pluma/dialogs/pluma-encodings-dialog.ui:56
+#: pluma/dialogs/pluma-preferences-dialog.c:975
+#: pluma/pluma-commands-file.c:583 pluma/pluma-commands-file.c:1223
+#: pluma/pluma-file-chooser-dialog.c:435
+#: pluma/pluma-io-error-message-area.c:168
+#: pluma/pluma-io-error-message-area.c:507
+#: pluma/pluma-io-error-message-area.c:1190
+#: pluma/pluma-progress-message-area.c:63
+#: plugins/filebrowser/pluma-file-browser-utils.c:171
+#: plugins/quickopen/quickopen/popup.py:36
+#: plugins/snippets/snippets/Manager.py:795
+#: plugins/snippets/snippets/Manager.py:881
+#: plugins/snippets/snippets/Manager.py:920 plugins/sort/sort.ui:45
+#: plugins/spell/pluma-spell-language-dialog.c:132
+#: plugins/spell/languages-dialog.ui:56
+#: plugins/spell/pluma-spell-setup-dialog.ui:55
+#: plugins/time/pluma-time-dialog.ui:52
+#: plugins/time/pluma-time-setup-dialog.ui:55
 msgid "_Cancel"
 msgstr "取消(_C)"
 
-#. File menu
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:178
-#: ../pluma/pluma-file-chooser-dialog.c:439 ../pluma/pluma-ui.h:80
-#: ../plugins/snippets/snippets/Manager.py:882
-#: ../plugins/snippets/snippets/Manager.py:921
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:178
+#: pluma/pluma-file-chooser-dialog.c:439 pluma/pluma-ui.h:80
+#: plugins/snippets/snippets/Manager.py:882
+#: plugins/snippets/snippets/Manager.py:921
 msgid "_Save"
 msgstr "保存(_S)"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:183
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:183
 msgid "Save _As"
 msgstr "另存为(_A)"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:216
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:216
 msgid "Question"
 msgstr "问题"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:414
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:414
 #, c-format
 msgid ""
 "If you don't save, changes from the last %ld second will be permanently "
@@ -620,12 +635,12 @@ msgid_plural ""
 "lost."
 msgstr[0] "如果您不保存，前 %ld 秒所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:423
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:423
 msgid ""
 "If you don't save, changes from the last minute will be permanently lost."
 msgstr "如果您不保存，上一分钟所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:429
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:429
 #, c-format
 msgid ""
 "If you don't save, changes from the last minute and %ld second will be "
@@ -635,7 +650,7 @@ msgid_plural ""
 "permanently lost."
 msgstr[0] "如果您不保存，前一分钟零 %ld 秒所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:439
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:439
 #, c-format
 msgid ""
 "If you don't save, changes from the last %ld minute will be permanently "
@@ -645,12 +660,12 @@ msgid_plural ""
 "lost."
 msgstr[0] "如果您不保存，前 %ld 分钟所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:454
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:454
 msgid ""
 "If you don't save, changes from the last hour will be permanently lost."
 msgstr "如果您不保存，上 %d 小时所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:460
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:460
 #, c-format
 msgid ""
 "If you don't save, changes from the last hour and %d minute will be "
@@ -660,7 +675,7 @@ msgid_plural ""
 "permanently lost."
 msgstr[0] "如果您不保存，上一小时零 %d 分钟所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:475
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:475
 #, c-format
 msgid ""
 "If you don't save, changes from the last %d hour will be permanently lost."
@@ -668,28 +683,28 @@ msgid_plural ""
 "If you don't save, changes from the last %d hours will be permanently lost."
 msgstr[0] "如果您不保存，上 %d 小时所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:521
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:521
 #, c-format
 msgid "Changes to document \"%s\" will be permanently lost."
 msgstr "对文档“%s”所作的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:526
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:526
 #, c-format
 msgid "Save changes to document \"%s\" before closing?"
 msgstr "在关闭前先将更改保存到文档 \"%s\" 吗？"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:540
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:765
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:540
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:765
 msgid "Saving has been disabled by the system administrator."
 msgstr "保存已经被系统管理员禁用。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:716
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:716
 #, c-format
 msgid "Changes to %d document will be permanently lost."
 msgid_plural "Changes to %d documents will be permanently lost."
 msgstr[0] "对 %d 个文档所做的更改将永久丢失。"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:722
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:722
 #, c-format
 msgid ""
 "There is %d document with unsaved changes. Save changes before closing?"
@@ -697,383 +712,397 @@ msgid_plural ""
 "There are %d documents with unsaved changes. Save changes before closing?"
 msgstr[0] "还有 %d 个文档已做更改但尚未保存。关闭前先保存吗？"
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:740
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:740
 msgid "Docum_ents with unsaved changes:"
 msgstr "有未保存更改的文档(_E)："
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:742
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:742
 msgid "S_elect the documents you want to save:"
 msgstr "选择您想要保存的文档(_E)："
 
-#: ../pluma/dialogs/pluma-close-confirmation-dialog.c:767
+#: pluma/dialogs/pluma-close-confirmation-dialog.c:767
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr "如果您不保存，您所做的全部更改都将永久丢失。"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.c:307
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:4
-#: ../plugins/spell/pluma-spell-language-dialog.c:133
-#: ../plugins/spell/languages-dialog.ui.h:4
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:4
-#: ../plugins/time/pluma-time-plugin.c:920
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:4
+#: pluma/dialogs/pluma-encodings-dialog.c:307
+#: pluma/dialogs/pluma-encodings-dialog.ui:72
+#: plugins/spell/pluma-spell-language-dialog.c:133
+#: plugins/spell/languages-dialog.ui:72
+#: plugins/spell/pluma-spell-setup-dialog.ui:71
+#: plugins/time/pluma-time-plugin.c:920
+#: plugins/time/pluma-time-setup-dialog.ui:71
 msgid "_OK"
 msgstr "确定 (_O)"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.c:308
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:2
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1292
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:2 ../pluma/pluma-ui.h:53
-#: ../plugins/sort/sort.ui.h:4
-#: ../plugins/spell/pluma-spell-language-dialog.c:134
-#: ../plugins/spell/languages-dialog.ui.h:2
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:2
-#: ../plugins/time/pluma-time-dialog.ui.h:2
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:2
+#: pluma/dialogs/pluma-encodings-dialog.c:308
+#: pluma/dialogs/pluma-encodings-dialog.ui:40
+#: pluma/dialogs/pluma-preferences-dialog.c:1292
+#: pluma/dialogs/pluma-preferences-dialog.ui:58 pluma/pluma-ui.h:53
+#: plugins/sort/sort.ui:77 plugins/spell/pluma-spell-language-dialog.c:134
+#: plugins/spell/languages-dialog.ui:40
+#: plugins/spell/pluma-spell-setup-dialog.ui:39
+#: plugins/time/pluma-time-dialog.ui:36
+#: plugins/time/pluma-time-setup-dialog.ui:39
 msgid "_Help"
-msgstr "帮助（_H）"
+msgstr "帮助(_H)"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.c:310
+#: pluma/dialogs/pluma-encodings-dialog.c:310
 msgid "Character Encodings"
 msgstr "字符编码"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.c:373
-#: ../pluma/dialogs/pluma-encodings-dialog.c:434
+#: pluma/dialogs/pluma-encodings-dialog.c:373
+#: pluma/dialogs/pluma-encodings-dialog.c:434
 msgid "_Description"
 msgstr "描述(_D)"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.c:382
-#: ../pluma/dialogs/pluma-encodings-dialog.c:443
+#: pluma/dialogs/pluma-encodings-dialog.c:382
+#: pluma/dialogs/pluma-encodings-dialog.c:443
 msgid "_Encoding"
 msgstr "编码(_E)"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:1
+#: pluma/dialogs/pluma-encodings-dialog.ui:25
 msgid "Character encodings"
 msgstr "字符编码"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:5
+#: pluma/dialogs/pluma-encodings-dialog.ui:112
 msgid "A_vailable encodings:"
 msgstr "可用的编码(_V)："
 
-#. + Add to Dictionary
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:6
-#: ../plugins/spell/pluma-automatic-spell-checker.c:514
+#: pluma/dialogs/pluma-encodings-dialog.ui:150
+#: plugins/spell/pluma-automatic-spell-checker.c:514
 msgid "_Add"
 msgstr "添加(_A)"
 
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:7
+#: pluma/dialogs/pluma-encodings-dialog.ui:190
 msgid "E_ncodings shown in menu:"
 msgstr "菜单中显示的编码(_N)："
 
-#: ../pluma/dialogs/pluma-encodings-dialog.ui.h:8
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:39
+#: pluma/dialogs/pluma-encodings-dialog.ui:228
+#: pluma/dialogs/pluma-preferences-dialog.ui:1405
 msgid "_Remove"
 msgstr "移除(_R)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:726
+#: pluma/dialogs/pluma-preferences-dialog.c:726
 msgid "Click on this button to select the font to be used by the editor"
 msgstr "按下此按钮可以选择编辑器所用的字体"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:736
+#: pluma/dialogs/pluma-preferences-dialog.c:736
 #, c-format
 msgid "_Use the system fixed width font (%s)"
 msgstr "使用系统等宽字体(_U)(%s)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:939
+#: pluma/dialogs/pluma-preferences-dialog.c:939
 msgid "The selected color scheme cannot be installed."
 msgstr "无法安装选中的配色方案。"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1017
+#: pluma/dialogs/pluma-preferences-dialog.c:1017
 msgid "Add Scheme"
 msgstr "添加方案"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1024
+#: pluma/dialogs/pluma-preferences-dialog.c:1024
 msgid "A_dd Scheme"
 msgstr "添加方案(_D)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1032
+#: pluma/dialogs/pluma-preferences-dialog.c:1032
 msgid "Color Scheme Files"
 msgstr "配色方案文件"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1039
-#: ../pluma/pluma-file-chooser-dialog.c:52
+#: pluma/dialogs/pluma-preferences-dialog.c:1039
+#: pluma/pluma-file-chooser-dialog.c:52
 msgid "All Files"
 msgstr "全部文件"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1084
+#: pluma/dialogs/pluma-preferences-dialog.c:1084
 #, c-format
 msgid "Could not remove color scheme \"%s\"."
 msgstr "无法删除配色方案“%s”。"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1291
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:3
-#: ../pluma/dialogs/pluma-search-dialog.c:327
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:2 ../pluma/pluma-ui.h:142
-#: ../plugins/docinfo/docinfo.ui.h:2 ../plugins/spell/spell-checker.ui.h:15
+#: pluma/dialogs/pluma-preferences-dialog.c:1291
+#: pluma/dialogs/pluma-preferences-dialog.ui:74
+#: pluma/dialogs/pluma-search-dialog.c:327
+#: pluma/dialogs/pluma-search-dialog.ui:60 pluma/pluma-ui.h:142
+#: plugins/docinfo/docinfo.ui:35 plugins/spell/spell-checker.ui:375
 msgid "_Close"
 msgstr "关闭(_C)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.c:1294
+#: pluma/dialogs/pluma-preferences-dialog.c:1294
 msgid "Pluma Preferences"
 msgstr "Pluma 首选项"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:1
+#: pluma/dialogs/pluma-preferences-dialog.ui:42
 msgid "Preferences"
 msgstr "首选项"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:4
-#: ../pluma/pluma-print-preferences.ui.h:9
+#: pluma/dialogs/pluma-preferences-dialog.ui:119
+#: pluma/pluma-print-preferences.ui:195
 msgid "Text Wrapping"
 msgstr "文字折行"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:5
-#: ../plugins/docinfo/docinfo.ui.h:5 ../plugins/time/pluma-time-dialog.ui.h:6
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:6
+#: pluma/dialogs/pluma-preferences-dialog.ui:138
+#: pluma/dialogs/pluma-preferences-dialog.ui:233
+#: pluma/dialogs/pluma-preferences-dialog.ui:313
+#: pluma/dialogs/pluma-preferences-dialog.ui:393
+#: pluma/dialogs/pluma-preferences-dialog.ui:515
+#: pluma/dialogs/pluma-preferences-dialog.ui:614
+#: pluma/dialogs/pluma-preferences-dialog.ui:735
+#: pluma/dialogs/pluma-preferences-dialog.ui:802
+#: pluma/dialogs/pluma-preferences-dialog.ui:943
+#: pluma/dialogs/pluma-preferences-dialog.ui:981
+#: pluma/dialogs/pluma-preferences-dialog.ui:993
+#: pluma/dialogs/pluma-preferences-dialog.ui:1031
+#: pluma/dialogs/pluma-preferences-dialog.ui:1072
+#: pluma/dialogs/pluma-preferences-dialog.ui:1110
+#: pluma/dialogs/pluma-preferences-dialog.ui:1122
+#: pluma/dialogs/pluma-preferences-dialog.ui:1219
+#: pluma/dialogs/pluma-preferences-dialog.ui:1342
+#: plugins/docinfo/docinfo.ui:106 plugins/time/pluma-time-dialog.ui:166
+#: plugins/time/pluma-time-setup-dialog.ui:125
+#: plugins/time/pluma-time-setup-dialog.ui:188
 msgid "    "
 msgstr "    "
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:6
-#: ../pluma/pluma-print-preferences.ui.h:10
+#: pluma/dialogs/pluma-preferences-dialog.ui:154
+#: pluma/pluma-print-preferences.ui:215
 msgid "Enable text _wrapping"
 msgstr "启用自动换行(_W)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:7
-#: ../pluma/pluma-print-preferences.ui.h:11
+#: pluma/dialogs/pluma-preferences-dialog.ui:169
+#: pluma/pluma-print-preferences.ui:235
 msgid "Do not _split words over two lines"
 msgstr "不将一个单词拆在两行(_S)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:8
-#: ../pluma/pluma-print-preferences.ui.h:3
+#: pluma/dialogs/pluma-preferences-dialog.ui:214
+#: pluma/pluma-print-preferences.ui:85
 msgid "Line Numbers"
 msgstr "行号"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:9 ../pluma/pluma-view.c:2191
+#: pluma/dialogs/pluma-preferences-dialog.ui:249 pluma/pluma-view.c:2191
 msgid "_Display line numbers"
 msgstr "显示行号(_D)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:10
+#: pluma/dialogs/pluma-preferences-dialog.ui:294
 msgid "Current Line"
 msgstr "当前行"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:11
+#: pluma/dialogs/pluma-preferences-dialog.ui:329
 msgid "Highlight current _line"
 msgstr "突出显示当前行(_L)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:12
+#: pluma/dialogs/pluma-preferences-dialog.ui:374
 msgid "Right Margin"
 msgstr "右边距"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:13
+#: pluma/dialogs/pluma-preferences-dialog.ui:409
 msgid "Display right _margin"
 msgstr "显示右边距(_M)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:14
+#: pluma/dialogs/pluma-preferences-dialog.ui:432
 msgid "_Right margin at column:"
 msgstr "右边距于列(_R)："
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:15
+#: pluma/dialogs/pluma-preferences-dialog.ui:496
 msgid "Bracket Matching"
 msgstr "括号匹配"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:16
+#: pluma/dialogs/pluma-preferences-dialog.ui:531
 msgid "Highlight matching _bracket"
 msgstr "突出显示匹配的括号(_B)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:17
+#: pluma/dialogs/pluma-preferences-dialog.ui:571
 msgid "View"
 msgstr "查看"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:18
+#: pluma/dialogs/pluma-preferences-dialog.ui:595
 msgid "Tab Stops"
 msgstr "制表位"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:19
+#: pluma/dialogs/pluma-preferences-dialog.ui:637
 msgid "_Tab width:"
 msgstr "跳格宽度(_T)："
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:20
+#: pluma/dialogs/pluma-preferences-dialog.ui:671
 msgid "Insert _spaces instead of tabs"
 msgstr "插入空格代替制表符(_S)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:21
+#: pluma/dialogs/pluma-preferences-dialog.ui:716
 msgid "Automatic Indentation"
 msgstr "自动缩进"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:22
+#: pluma/dialogs/pluma-preferences-dialog.ui:745
 msgid "_Enable automatic indentation"
 msgstr "启用自动缩进(_E)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:23
+#: pluma/dialogs/pluma-preferences-dialog.ui:783
 msgid "File Saving"
 msgstr "文件保存"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:24
+#: pluma/dialogs/pluma-preferences-dialog.ui:818
 msgid "Create a _backup copy of files before saving"
 msgstr "在保存之前创建一个备份文件(_B)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:25
+#: pluma/dialogs/pluma-preferences-dialog.ui:838
 msgid "_Autosave files every"
 msgstr "自动保存文件，每隔(_A)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:26
+#: pluma/dialogs/pluma-preferences-dialog.ui:869
 msgid "_minutes"
 msgstr "分钟(_M)"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:27
-msgid "Draw spaces, tabs, newlines"
+#: pluma/dialogs/pluma-preferences-dialog.ui:919
+msgid "Show spaces, tabs, newlines"
 msgstr ""
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:28
-msgid "Draw _tabs"
+#: pluma/dialogs/pluma-preferences-dialog.ui:953
+msgid "Show _tabs"
 msgstr ""
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:29
-msgid "Draw _trailing tabs only"
+#: pluma/dialogs/pluma-preferences-dialog.ui:1003
+msgid "Show _trailing tabs only"
 msgstr ""
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:30
-msgid "Draw _newlines"
+#: pluma/dialogs/pluma-preferences-dialog.ui:1041
+msgid "Show _newlines"
 msgstr ""
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:31
-msgid "Draw _spaces"
+#: pluma/dialogs/pluma-preferences-dialog.ui:1082
+msgid "Show _spaces"
 msgstr ""
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:32
-msgid "Draw _trailing spaces only"
+#: pluma/dialogs/pluma-preferences-dialog.ui:1132
+msgid "Show _trailing spaces only"
 msgstr ""
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:33
+#: pluma/dialogs/pluma-preferences-dialog.ui:1175
 msgid "Editor"
 msgstr "编辑器"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:34
+#: pluma/dialogs/pluma-preferences-dialog.ui:1200
 msgid "Font"
 msgstr "字体"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:35
+#: pluma/dialogs/pluma-preferences-dialog.ui:1258
 msgid "Editor _font: "
 msgstr "编辑器字体(_F)："
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:36
+#: pluma/dialogs/pluma-preferences-dialog.ui:1275
 msgid "Pick the editor font"
 msgstr "选择编辑器字体"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:37
+#: pluma/dialogs/pluma-preferences-dialog.ui:1323
 msgid "Color Scheme"
 msgstr "配色方案"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:38
+#: pluma/dialogs/pluma-preferences-dialog.ui:1390
 msgid "_Add..."
 msgstr "添加(_A)..."
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:40
+#: pluma/dialogs/pluma-preferences-dialog.ui:1454
 msgid "Font & Colors"
 msgstr "字体和颜色"
 
-#: ../pluma/dialogs/pluma-preferences-dialog.ui.h:41
+#: pluma/dialogs/pluma-preferences-dialog.ui:1479
 msgid "Plugins"
 msgstr "插件"
 
-#: ../pluma/dialogs/pluma-search-dialog.c:295
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:1 ../pluma/pluma-window.c:1531
+#: pluma/dialogs/pluma-search-dialog.c:295
+#: pluma/dialogs/pluma-search-dialog.ui:44
+#: pluma/dialogs/pluma-search-dialog.ui:91 pluma/pluma-window.c:1531
 msgid "Replace"
 msgstr "替换"
 
-#: ../pluma/dialogs/pluma-search-dialog.c:304 ../pluma/pluma-window.c:1529
+#: pluma/dialogs/pluma-search-dialog.c:304 pluma/pluma-window.c:1529
 msgid "Find"
 msgstr "查找"
 
-#: ../pluma/dialogs/pluma-search-dialog.c:407
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:4
+#: pluma/dialogs/pluma-search-dialog.c:407
+#: pluma/dialogs/pluma-search-dialog.ui:106
 msgid "_Find"
 msgstr "查找(_F)"
 
-#: ../pluma/dialogs/pluma-search-dialog.c:410
+#: pluma/dialogs/pluma-search-dialog.c:410
 msgid "Replace _All"
 msgstr "全部替换 (_A)"
 
-#: ../pluma/dialogs/pluma-search-dialog.c:411
-#: ../pluma/pluma-commands-file.c:588
+#: pluma/dialogs/pluma-search-dialog.c:411 pluma/pluma-commands-file.c:588
 msgid "_Replace"
 msgstr "替换 (_R)"
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:3
+#: pluma/dialogs/pluma-search-dialog.ui:76
 msgid "Replace All"
 msgstr "全部替换"
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:5
+#: pluma/dialogs/pluma-search-dialog.ui:146
 msgid "_Search for: "
 msgstr "搜索(_S)："
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:6
+#: pluma/dialogs/pluma-search-dialog.ui:158
 msgid "Replace _with: "
 msgstr "替换为(_W)："
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:7
+#: pluma/dialogs/pluma-search-dialog.ui:181
 msgid "_Match case"
 msgstr "区分大小写(_M)"
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:8
+#: pluma/dialogs/pluma-search-dialog.ui:197
 msgid "Match _regular expression"
 msgstr "使用正则表达式匹配(_R)"
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:9
+#: pluma/dialogs/pluma-search-dialog.ui:213
 msgid "Match _entire word only"
 msgstr "匹配整个单词(_E)"
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:10
+#: pluma/dialogs/pluma-search-dialog.ui:229
 msgid "Search _backwards"
 msgstr "反向搜索(_B)"
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:11
+#: pluma/dialogs/pluma-search-dialog.ui:245
 msgid "_Wrap around"
 msgstr "回到文档头部继续搜索(_W)"
 
-#: ../pluma/dialogs/pluma-search-dialog.ui.h:12
+#: pluma/dialogs/pluma-search-dialog.ui:262
 msgid "_Parse escape sequences (e.g. \\n)"
 msgstr "解析转义字符(如 \\n)(_P)"
 
-#: ../pluma/pluma.c:108
+#: pluma/pluma.c:108
 msgid "Show the application's version"
 msgstr "显示应用程序版本"
 
-#: ../pluma/pluma.c:111
+#: pluma/pluma.c:111
 msgid ""
 "Set the character encoding to be used to open the files listed on the "
 "command line"
 msgstr "设置打开在命令行中列出的文件时所用的字符编码"
 
-#: ../pluma/pluma.c:111
+#: pluma/pluma.c:111
 msgid "ENCODING"
 msgstr "编码"
 
-#: ../pluma/pluma.c:114
+#: pluma/pluma.c:114
 msgid "Display list of possible values for the encoding option"
 msgstr "显示可使用的编码选项列表"
 
-#: ../pluma/pluma.c:117
+#: pluma/pluma.c:117
 msgid "Create a new top-level window in an existing instance of pluma"
 msgstr "在已存在的 pluma 实例中创建一个最上层窗口"
 
-#: ../pluma/pluma.c:120
+#: pluma/pluma.c:120
 msgid "Create a new document in an existing instance of pluma"
 msgstr "在已存在的 pluma 实例中创建一个新文档"
 
-#: ../pluma/pluma.c:123
+#: pluma/pluma.c:123
 msgid "[FILE...]"
 msgstr "[文件...]"
 
-#: ../pluma/pluma.c:178
+#: pluma/pluma.c:178
 #, c-format
 msgid "%s: invalid encoding.\n"
 msgstr "%s：无效的编码。\n"
 
-#. Setup command line options
-#: ../pluma/pluma.c:524
+#: pluma/pluma.c:524
 msgid "- Edit text files"
 msgstr "- 编辑文本文件"
 
-#: ../pluma/pluma.c:535
+#: pluma/pluma.c:535
 #, c-format
 msgid ""
 "%s\n"
@@ -1082,51 +1111,51 @@ msgstr ""
 "%s\n"
 "运行“%s --help”可查看可用的命令行选项的完整列表。\n"
 
-#: ../pluma/pluma-commands-file.c:250
+#: pluma/pluma-commands-file.c:250
 #, c-format
 msgid "Loading file '%s'…"
 msgstr "正在载入文件“%s”..."
 
-#: ../pluma/pluma-commands-file.c:259
+#: pluma/pluma-commands-file.c:259
 #, c-format
 msgid "Loading %d file…"
 msgid_plural "Loading %d files…"
 msgstr[0] "正在载入 %d 个文件..."
 
 #. Translators: "Open Files" is the title of the file chooser window
-#: ../pluma/pluma-commands-file.c:463
+#: pluma/pluma-commands-file.c:463
 msgid "Open Files"
 msgstr "打开的文件"
 
-#: ../pluma/pluma-commands-file.c:574
+#: pluma/pluma-commands-file.c:574
 #, c-format
 msgid "The file \"%s\" is read-only."
 msgstr "文件“%s”为只读。"
 
-#: ../pluma/pluma-commands-file.c:579
+#: pluma/pluma-commands-file.c:579
 msgid "Do you want to try to replace it with the one you are saving?"
 msgstr "您想要试着将其替换为您正在保存的文件吗？"
 
-#: ../pluma/pluma-commands-file.c:649 ../pluma/pluma-commands-file.c:872
+#: pluma/pluma-commands-file.c:649 pluma/pluma-commands-file.c:872
 #, c-format
 msgid "Saving file '%s'…"
 msgstr "正在保存文件“%s”..."
 
-#: ../pluma/pluma-commands-file.c:757
+#: pluma/pluma-commands-file.c:757
 msgid "Save As…"
 msgstr "另存为..."
 
-#: ../pluma/pluma-commands-file.c:1086
+#: pluma/pluma-commands-file.c:1086
 #, c-format
 msgid "Reverting the document '%s'…"
 msgstr "正在还原文档“%s”..."
 
-#: ../pluma/pluma-commands-file.c:1131
+#: pluma/pluma-commands-file.c:1131
 #, c-format
 msgid "Revert unsaved changes to document '%s'?"
 msgstr "还原对文档“%s”未保存的更改吗？"
 
-#: ../pluma/pluma-commands-file.c:1140
+#: pluma/pluma-commands-file.c:1140
 #, c-format
 msgid ""
 "Changes made to the document in the last %ld second will be permanently "
@@ -1136,12 +1165,12 @@ msgid_plural ""
 "lost."
 msgstr[0] "前 %ld 秒内对文档所做的更改将永久丢失。"
 
-#: ../pluma/pluma-commands-file.c:1149
+#: pluma/pluma-commands-file.c:1149
 msgid ""
 "Changes made to the document in the last minute will be permanently lost."
 msgstr "上一分钟内对文档所做的更改将永久丢失。"
 
-#: ../pluma/pluma-commands-file.c:1155
+#: pluma/pluma-commands-file.c:1155
 #, c-format
 msgid ""
 "Changes made to the document in the last minute and %ld second will be "
@@ -1151,7 +1180,7 @@ msgid_plural ""
 "permanently lost."
 msgstr[0] "上一分钟零 %ld 秒内对文档所做的更改将永久丢失。"
 
-#: ../pluma/pluma-commands-file.c:1165
+#: pluma/pluma-commands-file.c:1165
 #, c-format
 msgid ""
 "Changes made to the document in the last %ld minute will be permanently "
@@ -1161,12 +1190,12 @@ msgid_plural ""
 "lost."
 msgstr[0] "前 %ld 分钟内对文档所做的更改将永久丢失。"
 
-#: ../pluma/pluma-commands-file.c:1180
+#: pluma/pluma-commands-file.c:1180
 msgid ""
 "Changes made to the document in the last hour will be permanently lost."
 msgstr "上 %d 小时内对文档所做的更改将永久丢失。"
 
-#: ../pluma/pluma-commands-file.c:1186
+#: pluma/pluma-commands-file.c:1186
 #, c-format
 msgid ""
 "Changes made to the document in the last hour and %d minute will be "
@@ -1176,7 +1205,7 @@ msgid_plural ""
 "permanently lost."
 msgstr[0] "上一小时零 %d 分钟内对文档所做的更改将永久丢失。"
 
-#: ../pluma/pluma-commands-file.c:1201
+#: pluma/pluma-commands-file.c:1201
 #, c-format
 msgid ""
 "Changes made to the document in the last %d hour will be permanently lost."
@@ -1184,27 +1213,27 @@ msgid_plural ""
 "Changes made to the document in the last %d hours will be permanently lost."
 msgstr[0] "上 %d 小时内对文档所做的更改将永久丢失。"
 
-#: ../pluma/pluma-commands-file.c:1228 ../pluma/pluma-ui.h:84
+#: pluma/pluma-commands-file.c:1228 pluma/pluma-ui.h:84
 msgid "_Revert"
 msgstr "还原(_R)"
 
-#: ../pluma/pluma-commands-help.c:60
+#: pluma/pluma-commands-help.c:60
 msgid "MATE Documentation Team"
 msgstr "MATE 文档团队"
 
-#: ../pluma/pluma-commands-help.c:61
+#: pluma/pluma-commands-help.c:61
 msgid "GNOME Documentation Team"
 msgstr "GNOME 文档团队"
 
-#: ../pluma/pluma-commands-help.c:62
+#: pluma/pluma-commands-help.c:62
 msgid "Sun Microsystems"
 msgstr "Sun Microsystems"
 
-#: ../pluma/pluma-commands-help.c:67
+#: pluma/pluma-commands-help.c:67
 msgid "Pluma is a small and lightweight text editor for the MATE Desktop"
 msgstr "Pluma 是 MATE 桌面的小型文本编辑器"
 
-#: ../pluma/pluma-commands-help.c:70
+#: pluma/pluma-commands-help.c:70
 msgid ""
 "Pluma is free software; you can redistribute it and/or modify it under the "
 "terms of the GNU General Public License as published by the Free Software "
@@ -1213,7 +1242,7 @@ msgid ""
 msgstr ""
 "Pluma 是自由软件；您可以按照自由软件基金会所发表的 GNU GPL 协议自由发放和/或修改它；GPL 协议应该采用第二版或以后的任何版本。"
 
-#: ../pluma/pluma-commands-help.c:74
+#: pluma/pluma-commands-help.c:74
 msgid ""
 "Pluma is distributed in the hope that it will be useful, but WITHOUT ANY "
 "WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS "
@@ -1223,7 +1252,7 @@ msgstr ""
 "Pluma 发表的目的是希望它能够对您有用，但我们没有任何保证；对于以任何用途使用它所造成的任何直接或间接后果都不承担任何责任。请参看GNU GPL "
 "协议中的细节。"
 
-#: ../pluma/pluma-commands-help.c:78
+#: pluma/pluma-commands-help.c:78
 msgid ""
 "You should have received a copy of the GNU General Public License along with"
 " Pluma; if not, write to the Free Software Foundation, Inc., 51 Franklin "
@@ -1232,11 +1261,11 @@ msgstr ""
 "您应该在收到 Pluma 的同时收到了 GNU GPL 协议的副本；如果您没有收到的话，请给自由软件基金会写信，地址是 51 Franklin "
 "Street, Fifth Floor, Boston, MA 02110-1301 USA"
 
-#: ../pluma/pluma-commands-help.c:113
+#: pluma/pluma-commands-help.c:113
 msgid "About Pluma"
 msgstr "关于 Pluma"
 
-#: ../pluma/pluma-commands-help.c:116
+#: pluma/pluma-commands-help.c:116
 msgid ""
 "Copyright © 1998-2000 Evan Lawrence, Alex Robert\n"
 "Copyright © 2000-2002 Chema Celorio, Paolo Maggi\n"
@@ -1254,7 +1283,7 @@ msgstr ""
 "版权所有 © 2011 Perberos\n"
 "版权所有 © 2012-2019 MATE 开发者"
 
-#: ../pluma/pluma-commands-help.c:126
+#: pluma/pluma-commands-help.c:126
 msgid "translator-credits"
 msgstr ""
 "Christopher Meng <i@cicku.me>, 2012-2013\n"
@@ -1266,418 +1295,412 @@ msgstr ""
 "玉堂白鹤 <yjwork@qq.com>, 2015\n"
 "Mingye Wang <arthur200126@gmail.com>, 2015-2016\n"
 "白铭骢 <jeffbai@aosc.xyz>, 2015-2016\n"
-"刘子兴 <liushuyu@aosc.xyz>, 2015-2016"
+"刘子兴 <liushuyu@aosc.xyz>, 2015-2016\n"
+"Mingtian Yang <i@skylee.xyz>, 2020"
 
-#: ../pluma/pluma-commands-search.c:112
+#: pluma/pluma-commands-search.c:112
 #, c-format
 msgid "Found and replaced %d occurrence"
 msgid_plural "Found and replaced %d occurrences"
 msgstr[0] "找到并替换了 %d 处"
 
-#: ../pluma/pluma-commands-search.c:122
+#: pluma/pluma-commands-search.c:122
 msgid "Found and replaced one occurrence"
 msgstr "找到并替换了一处"
 
 #. Translators: %s is replaced by the text
 #. entered by the user in the search box
-#: ../pluma/pluma-commands-search.c:143
+#: pluma/pluma-commands-search.c:143
 #, c-format
 msgid "\"%s\" not found"
 msgstr "“%s”未找到"
 
-#: ../pluma/pluma-document.c:1137 ../pluma/pluma-document.c:1157
+#: pluma/pluma-document.c:1139 pluma/pluma-document.c:1159
 #, c-format
 msgid "Unsaved Document %d"
 msgstr "未保存文档 %d"
 
-#: ../pluma/pluma-documents-panel.c:93 ../pluma/pluma-documents-panel.c:107
-#: ../pluma/pluma-window.c:2258 ../pluma/pluma-window.c:2263
+#: pluma/pluma-documents-panel.c:93 pluma/pluma-documents-panel.c:107
+#: pluma/pluma-window.c:2258 pluma/pluma-window.c:2263
 msgid "Read-Only"
 msgstr "只读"
 
-#: ../pluma/pluma-documents-panel.c:703 ../pluma/pluma-window.c:3684
+#: pluma/pluma-documents-panel.c:703 pluma/pluma-window.c:3684
 msgid "Documents"
 msgstr "文档"
 
-#: ../pluma/pluma-encodings.c:138 ../pluma/pluma-encodings.c:180
-#: ../pluma/pluma-encodings.c:182 ../pluma/pluma-encodings.c:184
-#: ../pluma/pluma-encodings.c:186 ../pluma/pluma-encodings.c:188
-#: ../pluma/pluma-encodings.c:190 ../pluma/pluma-encodings.c:192
+#: pluma/pluma-encodings.c:138 pluma/pluma-encodings.c:180
+#: pluma/pluma-encodings.c:182 pluma/pluma-encodings.c:184
+#: pluma/pluma-encodings.c:186 pluma/pluma-encodings.c:188
+#: pluma/pluma-encodings.c:190 pluma/pluma-encodings.c:192
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../pluma/pluma-encodings.c:151 ../pluma/pluma-encodings.c:175
-#: ../pluma/pluma-encodings.c:225 ../pluma/pluma-encodings.c:268
+#: pluma/pluma-encodings.c:151 pluma/pluma-encodings.c:175
+#: pluma/pluma-encodings.c:225 pluma/pluma-encodings.c:268
 msgid "Western"
 msgstr "西欧"
 
-#: ../pluma/pluma-encodings.c:153 ../pluma/pluma-encodings.c:227
-#: ../pluma/pluma-encodings.c:264
+#: pluma/pluma-encodings.c:153 pluma/pluma-encodings.c:227
+#: pluma/pluma-encodings.c:264
 msgid "Central European"
 msgstr "中欧"
 
-#: ../pluma/pluma-encodings.c:155
+#: pluma/pluma-encodings.c:155
 msgid "South European"
 msgstr "南欧"
 
-#: ../pluma/pluma-encodings.c:157 ../pluma/pluma-encodings.c:171
-#: ../pluma/pluma-encodings.c:278
+#: pluma/pluma-encodings.c:157 pluma/pluma-encodings.c:171
+#: pluma/pluma-encodings.c:278
 msgid "Baltic"
 msgstr "波罗的语"
 
-#: ../pluma/pluma-encodings.c:159 ../pluma/pluma-encodings.c:229
-#: ../pluma/pluma-encodings.c:242 ../pluma/pluma-encodings.c:246
-#: ../pluma/pluma-encodings.c:248 ../pluma/pluma-encodings.c:266
+#: pluma/pluma-encodings.c:159 pluma/pluma-encodings.c:229
+#: pluma/pluma-encodings.c:242 pluma/pluma-encodings.c:246
+#: pluma/pluma-encodings.c:248 pluma/pluma-encodings.c:266
 msgid "Cyrillic"
 msgstr "西里尔文"
 
-#: ../pluma/pluma-encodings.c:161 ../pluma/pluma-encodings.c:235
-#: ../pluma/pluma-encodings.c:276
+#: pluma/pluma-encodings.c:161 pluma/pluma-encodings.c:235
+#: pluma/pluma-encodings.c:276
 msgid "Arabic"
 msgstr "阿拉伯文"
 
-#: ../pluma/pluma-encodings.c:163 ../pluma/pluma-encodings.c:270
+#: pluma/pluma-encodings.c:163 pluma/pluma-encodings.c:270
 msgid "Greek"
 msgstr "希腊语"
 
-#: ../pluma/pluma-encodings.c:165
+#: pluma/pluma-encodings.c:165
 msgid "Hebrew Visual"
 msgstr "可视希伯来语"
 
-#: ../pluma/pluma-encodings.c:167 ../pluma/pluma-encodings.c:231
-#: ../pluma/pluma-encodings.c:272
+#: pluma/pluma-encodings.c:167 pluma/pluma-encodings.c:231
+#: pluma/pluma-encodings.c:272
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: ../pluma/pluma-encodings.c:169
+#: pluma/pluma-encodings.c:169
 msgid "Nordic"
 msgstr "北欧"
 
-#: ../pluma/pluma-encodings.c:173
+#: pluma/pluma-encodings.c:173
 msgid "Celtic"
 msgstr "凯尔特语"
 
-#: ../pluma/pluma-encodings.c:177
+#: pluma/pluma-encodings.c:177
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: ../pluma/pluma-encodings.c:195
+#: pluma/pluma-encodings.c:195
 msgid "Armenian"
 msgstr "亚美尼亚文"
 
-#: ../pluma/pluma-encodings.c:197 ../pluma/pluma-encodings.c:199
-#: ../pluma/pluma-encodings.c:213
+#: pluma/pluma-encodings.c:197 pluma/pluma-encodings.c:199
+#: pluma/pluma-encodings.c:213
 msgid "Chinese Traditional"
 msgstr "繁体中文"
 
-#: ../pluma/pluma-encodings.c:201
+#: pluma/pluma-encodings.c:201
 msgid "Cyrillic/Russian"
 msgstr "西里尔语/俄语"
 
-#: ../pluma/pluma-encodings.c:204 ../pluma/pluma-encodings.c:206
-#: ../pluma/pluma-encodings.c:208 ../pluma/pluma-encodings.c:238
-#: ../pluma/pluma-encodings.c:253
+#: pluma/pluma-encodings.c:204 pluma/pluma-encodings.c:206
+#: pluma/pluma-encodings.c:208 pluma/pluma-encodings.c:238
+#: pluma/pluma-encodings.c:253
 msgid "Japanese"
 msgstr "日语"
 
-#: ../pluma/pluma-encodings.c:211 ../pluma/pluma-encodings.c:240
-#: ../pluma/pluma-encodings.c:244 ../pluma/pluma-encodings.c:259
+#: pluma/pluma-encodings.c:211 pluma/pluma-encodings.c:240
+#: pluma/pluma-encodings.c:244 pluma/pluma-encodings.c:259
 msgid "Korean"
 msgstr "朝鲜语"
 
-#: ../pluma/pluma-encodings.c:216 ../pluma/pluma-encodings.c:218
-#: ../pluma/pluma-encodings.c:220
+#: pluma/pluma-encodings.c:216 pluma/pluma-encodings.c:218
+#: pluma/pluma-encodings.c:220
 msgid "Chinese Simplified"
 msgstr "简体中文"
 
-#: ../pluma/pluma-encodings.c:222
+#: pluma/pluma-encodings.c:222
 msgid "Georgian"
 msgstr "格鲁吉亚文"
 
-#: ../pluma/pluma-encodings.c:233 ../pluma/pluma-encodings.c:274
+#: pluma/pluma-encodings.c:233 pluma/pluma-encodings.c:274
 msgid "Hebrew"
 msgstr "希伯来文"
 
-#: ../pluma/pluma-encodings.c:250
+#: pluma/pluma-encodings.c:250
 msgid "Cyrillic/Ukrainian"
 msgstr "西里尔语/乌克兰语"
 
-#: ../pluma/pluma-encodings.c:255 ../pluma/pluma-encodings.c:261
-#: ../pluma/pluma-encodings.c:280
+#: pluma/pluma-encodings.c:255 pluma/pluma-encodings.c:261
+#: pluma/pluma-encodings.c:280
 msgid "Vietnamese"
 msgstr "越南语"
 
-#: ../pluma/pluma-encodings.c:257
+#: pluma/pluma-encodings.c:257
 msgid "Thai"
 msgstr "泰文"
 
-#: ../pluma/pluma-encodings.c:431
+#: pluma/pluma-encodings.c:431
 msgid "Unknown"
 msgstr "未知"
 
-#: ../pluma/pluma-encodings-combo-box.c:266
+#: pluma/pluma-encodings-combo-box.c:266
 msgid "Automatically Detected"
 msgstr "自动检测"
 
-#: ../pluma/pluma-encodings-combo-box.c:282
-#: ../pluma/pluma-encodings-combo-box.c:297
+#: pluma/pluma-encodings-combo-box.c:282 pluma/pluma-encodings-combo-box.c:297
 #, c-format
 msgid "Current Locale (%s)"
 msgstr "当前语系(%s)"
 
-#: ../pluma/pluma-encodings-combo-box.c:347
+#: pluma/pluma-encodings-combo-box.c:347
 msgid "Add or Remove..."
 msgstr "添加或删除..."
 
-#: ../pluma/pluma-file-chooser-dialog.c:53
+#: pluma/pluma-file-chooser-dialog.c:53
 msgid "All Text Files"
 msgstr "全部文本文件"
 
-#: ../pluma/pluma-file-chooser-dialog.c:78
+#: pluma/pluma-file-chooser-dialog.c:78
 msgid "C_haracter Encoding:"
 msgstr "字符编码(_H)："
 
-#: ../pluma/pluma-file-chooser-dialog.c:143
+#: pluma/pluma-file-chooser-dialog.c:143
 msgid "L_ine Ending:"
 msgstr "行尾(_I)"
 
-#: ../pluma/pluma-file-chooser-dialog.c:162
+#: pluma/pluma-file-chooser-dialog.c:162
 msgid "Unix/Linux"
 msgstr "Unix/Linux"
 
-#: ../pluma/pluma-file-chooser-dialog.c:168
+#: pluma/pluma-file-chooser-dialog.c:168
 msgid "Mac OS Classic"
 msgstr "Mac 操作系统风格"
 
-#: ../pluma/pluma-file-chooser-dialog.c:174
+#: pluma/pluma-file-chooser-dialog.c:174
 msgid "Windows"
 msgstr "窗口"
 
-#: ../pluma/pluma-file-chooser-dialog.c:437
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:808
-#: ../plugins/quickopen/quickopen/popup.py:37
-#: ../plugins/snippets/snippets/Manager.py:796
+#: pluma/pluma-file-chooser-dialog.c:437
+#: plugins/filebrowser/pluma-file-browser-widget.c:808
+#: plugins/quickopen/quickopen/popup.py:37
+#: plugins/snippets/snippets/Manager.py:796
 msgid "_Open"
 msgstr "打开(_O)"
 
-#: ../pluma/pluma-help.c:81
+#: pluma/pluma-help.c:81
 msgid "There was an error displaying the help."
 msgstr "显示帮助出错。"
 
-#: ../pluma/pluma-io-error-message-area.c:183
-#: ../pluma/pluma-io-error-message-area.c:485
+#: pluma/pluma-io-error-message-area.c:183
+#: pluma/pluma-io-error-message-area.c:485
 msgid "_Retry"
 msgstr "重试(_R)"
 
-#: ../pluma/pluma-io-error-message-area.c:204
+#: pluma/pluma-io-error-message-area.c:204
 #, c-format
 msgid "Could not find the file %s."
 msgstr "找不到文件 %s。"
 
-#: ../pluma/pluma-io-error-message-area.c:206
-#: ../pluma/pluma-io-error-message-area.c:245
-#: ../pluma/pluma-io-error-message-area.c:252
+#: pluma/pluma-io-error-message-area.c:206
+#: pluma/pluma-io-error-message-area.c:245
+#: pluma/pluma-io-error-message-area.c:252
 msgid "Please check that you typed the location correctly and try again."
 msgstr "请检查键入的位置是否正确，然后重试。"
 
 #. Translators: %s is a URI scheme (like for example http:, ftp:, etc.)
-#: ../pluma/pluma-io-error-message-area.c:221
+#: pluma/pluma-io-error-message-area.c:221
 #, c-format
 msgid "pluma cannot handle %s locations."
 msgstr "pluma 无法处理 %s 位置。"
 
-#: ../pluma/pluma-io-error-message-area.c:227
+#: pluma/pluma-io-error-message-area.c:227
 msgid "pluma cannot handle this location."
 msgstr "pluma 无法处理此位置。"
 
-#: ../pluma/pluma-io-error-message-area.c:235
+#: pluma/pluma-io-error-message-area.c:235
 msgid "The location of the file cannot be mounted."
 msgstr "文件的位置无法挂载。"
 
-#: ../pluma/pluma-io-error-message-area.c:239
+#: pluma/pluma-io-error-message-area.c:239
 msgid "The location of the file cannot be accessed because it is not mounted."
 msgstr "文件的位置无法访问，原因是未挂载。"
 
-#: ../pluma/pluma-io-error-message-area.c:243
+#: pluma/pluma-io-error-message-area.c:243
 #, c-format
 msgid "%s is a directory."
 msgstr "%s 是目录。"
 
-#: ../pluma/pluma-io-error-message-area.c:250
+#: pluma/pluma-io-error-message-area.c:250
 #, c-format
 msgid "%s is not a valid location."
 msgstr "%s 不是有效的位置"
 
-#: ../pluma/pluma-io-error-message-area.c:280
+#: pluma/pluma-io-error-message-area.c:280
 #, c-format
 msgid ""
 "Host %s could not be found. Please check that your proxy settings are "
 "correct and try again."
 msgstr "找不到主机 %s。请检查您的代理服务器设置是否正确，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:293
-#, c-format
+#: pluma/pluma-io-error-message-area.c:293
 msgid ""
 "Hostname was invalid. Please check that you typed the location correctly and"
 " try again."
 msgstr "主机名无效。请检查键入的位置是否正确，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:301
+#: pluma/pluma-io-error-message-area.c:301
 #, c-format
 msgid "%s is not a regular file."
 msgstr "%s 不是普通文件。"
 
-#: ../pluma/pluma-io-error-message-area.c:306
+#: pluma/pluma-io-error-message-area.c:306
 msgid "Connection timed out. Please try again."
 msgstr "连接超时。请再试一次。"
 
-#: ../pluma/pluma-io-error-message-area.c:329
+#: pluma/pluma-io-error-message-area.c:329
 msgid "The file is too big."
 msgstr "文件太大。"
 
-#: ../pluma/pluma-io-error-message-area.c:370
+#: pluma/pluma-io-error-message-area.c:370
 #, c-format
 msgid "Unexpected error: %s"
 msgstr "意外错误：%s"
 
-#: ../pluma/pluma-io-error-message-area.c:406
+#: pluma/pluma-io-error-message-area.c:406
 msgid "pluma cannot find the file. Perhaps it has recently been deleted."
 msgstr "pluma 找不到文件。可能它已被删除。"
 
-#: ../pluma/pluma-io-error-message-area.c:416
+#: pluma/pluma-io-error-message-area.c:416
 #, c-format
 msgid "Could not revert the file %s."
 msgstr "无法还原文件 %s。"
 
-#: ../pluma/pluma-io-error-message-area.c:442
+#: pluma/pluma-io-error-message-area.c:442
 msgid "Ch_aracter Encoding:"
 msgstr "字符编码(_A)："
 
 #. Translators: the access key chosen for this string should be
 #. different from other main menu access keys (Open, Edit, View...)
-#: ../pluma/pluma-io-error-message-area.c:494
-#: ../pluma/pluma-io-error-message-area.c:771
+#: pluma/pluma-io-error-message-area.c:494
+#: pluma/pluma-io-error-message-area.c:771
 msgid "Edit Any_way"
 msgstr "仍然编辑(_W)"
 
 #. Translators: the access key chosen for this string should be
 #. different from other main menu access keys (Open, Edit, View...)
-#: ../pluma/pluma-io-error-message-area.c:499
-#: ../pluma/pluma-io-error-message-area.c:776
+#: pluma/pluma-io-error-message-area.c:499
+#: pluma/pluma-io-error-message-area.c:776
 msgid "D_on't Edit"
 msgstr "放弃编辑(_O)"
 
-#: ../pluma/pluma-io-error-message-area.c:597
+#: pluma/pluma-io-error-message-area.c:597
 msgid ""
 "The number of followed links is limited and the actual file could not be "
 "found within this limit."
 msgstr "达到了跟随链接的层数极限，在此极限内找不到真实文件。"
 
-#: ../pluma/pluma-io-error-message-area.c:601
+#: pluma/pluma-io-error-message-area.c:601
 msgid "You do not have the permissions necessary to open the file."
 msgstr "您没有打开文件所需的权限。"
 
-#: ../pluma/pluma-io-error-message-area.c:607
+#: pluma/pluma-io-error-message-area.c:607
 msgid "pluma has not been able to detect the character encoding."
 msgstr "pluma 无法检测字符编码。"
 
-#: ../pluma/pluma-io-error-message-area.c:609
-#: ../pluma/pluma-io-error-message-area.c:631
+#: pluma/pluma-io-error-message-area.c:609
+#: pluma/pluma-io-error-message-area.c:631
 msgid "Please check that you are not trying to open a binary file."
 msgstr "请检查您是否正在尝试打开一个二进制文件。"
 
-#: ../pluma/pluma-io-error-message-area.c:610
+#: pluma/pluma-io-error-message-area.c:610
 msgid "Select a character encoding from the menu and try again."
 msgstr "从菜单中选择一种字符编码，然后再试一次。"
 
-#: ../pluma/pluma-io-error-message-area.c:616
+#: pluma/pluma-io-error-message-area.c:616
 #, c-format
 msgid "There was a problem opening the file %s."
 msgstr "在打开文件 %s 的时候出现问题。"
 
-#: ../pluma/pluma-io-error-message-area.c:618
+#: pluma/pluma-io-error-message-area.c:618
 msgid ""
 "The file you opened has some invalid characters. If you continue editing "
 "this file you could make this document useless."
 msgstr "您打开的文件有一些非法字符。如果您继续编辑这个文件，这个文件有可能不能使用。"
 
-#: ../pluma/pluma-io-error-message-area.c:621
+#: pluma/pluma-io-error-message-area.c:621
 msgid "You can also choose another character encoding and try again."
 msgstr "您可以选择另外一种字符编码，然后再试一次。"
 
-#: ../pluma/pluma-io-error-message-area.c:628
+#: pluma/pluma-io-error-message-area.c:628
 #, c-format
 msgid "Could not open the file %s using the %s character encoding."
 msgstr "无法使用编码 %2$s 编码打开文件 %1$s。"
 
-#: ../pluma/pluma-io-error-message-area.c:632
-#: ../pluma/pluma-io-error-message-area.c:707
+#: pluma/pluma-io-error-message-area.c:632
+#: pluma/pluma-io-error-message-area.c:707
 msgid "Select a different character encoding from the menu and try again."
 msgstr "从菜单中选择一种不同的字符编码，然后再试一次。"
 
-#: ../pluma/pluma-io-error-message-area.c:642
+#: pluma/pluma-io-error-message-area.c:642
 #, c-format
 msgid "Could not open the file %s."
 msgstr "无法打开文件 %s。"
 
-#: ../pluma/pluma-io-error-message-area.c:702
+#: pluma/pluma-io-error-message-area.c:702
 #, c-format
 msgid "Could not save the file %s using the %s character encoding."
 msgstr "无法使用 %2$s 字符编码保存文件 %1$s。"
 
-#: ../pluma/pluma-io-error-message-area.c:705
+#: pluma/pluma-io-error-message-area.c:705
 msgid ""
 "The document contains one or more characters that cannot be encoded using "
 "the specified character encoding."
 msgstr "文档包含无法使用指定字符编码表示的一个或多个字符。"
 
-#: ../pluma/pluma-io-error-message-area.c:791
+#: pluma/pluma-io-error-message-area.c:791
 #, c-format
 msgid "This file (%s) is already open in another pluma window."
 msgstr "此文件(%s)已经在另外的 pluma 窗口中打开。"
 
-#: ../pluma/pluma-io-error-message-area.c:805
+#: pluma/pluma-io-error-message-area.c:805
 msgid ""
 "pluma opened this instance of the file in a non-editable way. Do you want to"
 " edit it anyway?"
 msgstr "pluma 已经在非编辑方式中打开了此文件的其它实例。您是否想要仍然编辑？"
 
-#: ../pluma/pluma-io-error-message-area.c:864
-#: ../pluma/pluma-io-error-message-area.c:960
+#: pluma/pluma-io-error-message-area.c:864
+#: pluma/pluma-io-error-message-area.c:960
 msgid "S_ave Anyway"
 msgstr "仍然保存(_A)"
 
-#: ../pluma/pluma-io-error-message-area.c:868
-#: ../pluma/pluma-io-error-message-area.c:964
+#: pluma/pluma-io-error-message-area.c:868
+#: pluma/pluma-io-error-message-area.c:964
 msgid "D_on't Save"
 msgstr "不保存(_O)"
 
-#. FIXME: review this message, it's not clear since for the user the
-#. "modification"
-#. could be interpreted as the changes he made in the document. beside
-#. "reading" is
-#. not accurate (since last load/save)
-#: ../pluma/pluma-io-error-message-area.c:886
+#: pluma/pluma-io-error-message-area.c:886
 #, c-format
 msgid "The file %s has been modified since reading it."
 msgstr "文件 %s 自上次读取之后发生了修改。"
 
-#: ../pluma/pluma-io-error-message-area.c:901
+#: pluma/pluma-io-error-message-area.c:901
 msgid ""
 "If you save it, all the external changes could be lost. Save it anyway?"
 msgstr "如果您保存的话，外部的所有更改都将丢失。仍然保存吗？"
 
-#: ../pluma/pluma-io-error-message-area.c:982
+#: pluma/pluma-io-error-message-area.c:982
 #, c-format
 msgid "Could not create a backup file while saving %s"
 msgstr "保存 %s 时无法创建备份文件"
 
-#: ../pluma/pluma-io-error-message-area.c:985
+#: pluma/pluma-io-error-message-area.c:985
 #, c-format
 msgid "Could not create a temporary backup file while saving %s"
 msgstr "保存 %s 时无法创建临时备份文件"
 
-#: ../pluma/pluma-io-error-message-area.c:1001
+#: pluma/pluma-io-error-message-area.c:1001
 msgid ""
 "pluma could not back up the old copy of the file before saving the new one. "
 "You can ignore this warning and save the file anyway, but if an error occurs"
@@ -1686,691 +1709,678 @@ msgstr ""
 "pluma 无法在保存新文件时备份文件的旧副本。您可以忽略此警告，仍然进行保存，但是如果是在保存中发生了错误，，您可能会丢失文件的旧副本。仍然保存吗？"
 
 #. Translators: %s is a URI scheme (like for example http:, ftp:, etc.)
-#: ../pluma/pluma-io-error-message-area.c:1061
+#: pluma/pluma-io-error-message-area.c:1061
 #, c-format
 msgid ""
 "pluma cannot handle %s locations in write mode. Please check that you typed "
 "the location correctly and try again."
 msgstr "pluma 无法以写入模式处理 %s 位置。请检查键入的位置是否正确，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:1069
+#: pluma/pluma-io-error-message-area.c:1069
 msgid ""
 "pluma cannot handle this location in write mode. Please check that you typed"
 " the location correctly and try again."
 msgstr "pluma 无法以写入模式处理此位置。请检查键入的位置是否正确，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:1078
+#: pluma/pluma-io-error-message-area.c:1078
 #, c-format
 msgid ""
 "%s is not a valid location. Please check that you typed the location "
 "correctly and try again."
 msgstr "%s 不是有效的位置。请检查键入的位置是否正确，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:1084
+#: pluma/pluma-io-error-message-area.c:1084
 msgid ""
 "You do not have the permissions necessary to save the file. Please check "
 "that you typed the location correctly and try again."
 msgstr "您没有权限保存文件。请检查键入的位置是否正确，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:1090
+#: pluma/pluma-io-error-message-area.c:1090
 msgid ""
 "There is not enough disk space to save the file. Please free some disk space"
 " and try again."
 msgstr "没有足够的磁盘空间用于保存文件。请释放一些磁盘空间，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:1095
+#: pluma/pluma-io-error-message-area.c:1095
 msgid ""
 "You are trying to save the file on a read-only disk. Please check that you "
 "typed the location correctly and try again."
 msgstr "您试图将文件保存至只读磁盘。请检查键入的位置是否正确，然后重试。"
 
-#: ../pluma/pluma-io-error-message-area.c:1101
+#: pluma/pluma-io-error-message-area.c:1101
 msgid "A file with the same name already exists. Please use a different name."
 msgstr "已经存在同名文件。请使用不同的名称。"
 
-#: ../pluma/pluma-io-error-message-area.c:1106
+#: pluma/pluma-io-error-message-area.c:1106
 msgid ""
 "The disk where you are trying to save the file has a limitation on length of"
 " the file names. Please use a shorter name."
 msgstr "您试图用来保存文件的磁盘有文件名长度的限制。请使用较短的名称。"
 
-#: ../pluma/pluma-io-error-message-area.c:1113
+#: pluma/pluma-io-error-message-area.c:1113
 msgid ""
 "The disk where you are trying to save the file has a limitation on file "
 "sizes. Please try saving a smaller file or saving it to a disk that does not"
 " have this limitation."
 msgstr "磁盘有文件大小的限制，请保存较小的文件或者将文件保存到没有此限制的磁盘上。"
 
-#: ../pluma/pluma-io-error-message-area.c:1129
+#: pluma/pluma-io-error-message-area.c:1129
 #, c-format
 msgid "Could not save the file %s."
 msgstr "无法保存文件 %s。"
 
-#. FIXME: review this message, it's not clear since for the user the
-#. "modification"
-#. could be interpreted as the changes he made in the document. beside
-#. "reading" is
-#. not accurate (since last load/save)
-#: ../pluma/pluma-io-error-message-area.c:1173
+#: pluma/pluma-io-error-message-area.c:1173
 #, c-format
 msgid "The file %s changed on disk."
 msgstr "文件 %s 已在磁盘上更改。"
 
-#: ../pluma/pluma-io-error-message-area.c:1178
+#: pluma/pluma-io-error-message-area.c:1178
 msgid "Do you want to drop your changes and reload the file?"
 msgstr "您是想要丢弃您的更改还是重新载入文件？"
 
-#: ../pluma/pluma-io-error-message-area.c:1180
+#: pluma/pluma-io-error-message-area.c:1180
 msgid "Do you want to reload the file?"
 msgstr "您是否想要重新载入文件？"
 
-#: ../pluma/pluma-io-error-message-area.c:1185
+#: pluma/pluma-io-error-message-area.c:1185
 msgid "_Reload"
 msgstr "重新载入(_R)"
 
-#: ../pluma/pluma-panel.c:316 ../pluma/pluma-panel.c:490
+#: pluma/pluma-panel.c:316 pluma/pluma-panel.c:490
 msgid "Empty"
 msgstr "空"
 
-#: ../pluma/pluma-panel.c:380
+#: pluma/pluma-panel.c:380
 msgid "Hide panel"
 msgstr "隐藏面板"
 
-#: ../pluma/pluma-print-job.c:538
+#: pluma/pluma-print-job.c:538
 #, c-format
 msgid "File: %s"
 msgstr "文件：%s"
 
-#: ../pluma/pluma-print-job.c:547
+#: pluma/pluma-print-job.c:547
 msgid "Page %N of %Q"
 msgstr "第 %N 页共 %Q 页"
 
-#: ../pluma/pluma-print-job.c:804
+#: pluma/pluma-print-job.c:804
 msgid "Preparing..."
 msgstr "正在准备..."
 
-#: ../pluma/pluma-print-preferences.ui.h:1
+#: pluma/pluma-print-preferences.ui:15
+msgid "window1"
+msgstr ""
+
+#: pluma/pluma-print-preferences.ui:39
 msgid "Syntax Highlighting"
 msgstr "语法高亮"
 
-#: ../pluma/pluma-print-preferences.ui.h:2
+#: pluma/pluma-print-preferences.ui:52
 msgid "Print synta_x highlighting"
 msgstr "打印语法突出显示(_X)"
 
-#: ../pluma/pluma-print-preferences.ui.h:4
+#: pluma/pluma-print-preferences.ui:105
 msgid "Print line nu_mbers"
 msgstr "打印行号(_M)"
 
-#: ../pluma/pluma-print-preferences.ui.h:6
+#. 'Number every' from 'Number every 3 lines' in the 'Text Editor' tab of the
+#. print preferences.
+#: pluma/pluma-print-preferences.ui:128
 msgid "_Number every"
 msgstr "每几行打印一次行号(_N)"
 
-#: ../pluma/pluma-print-preferences.ui.h:8
+#. 'lines' from 'Number every 3 lines' in the 'Text Editor' tab of the print
+#. preferences.
+#: pluma/pluma-print-preferences.ui:155
 msgid "lines"
 msgstr "行"
 
-#: ../pluma/pluma-print-preferences.ui.h:12
+#: pluma/pluma-print-preferences.ui:281
 msgid "Page header"
 msgstr "页眉"
 
-#: ../pluma/pluma-print-preferences.ui.h:13
+#: pluma/pluma-print-preferences.ui:294
 msgid "Print page _headers"
 msgstr "打印页眉(_H)"
 
-#: ../pluma/pluma-print-preferences.ui.h:14
+#: pluma/pluma-print-preferences.ui:340
 msgid "Fonts"
 msgstr "字体"
 
-#: ../pluma/pluma-print-preferences.ui.h:15
+#: pluma/pluma-print-preferences.ui:369
 msgid "_Body:"
 msgstr "主体(_B)："
 
-#: ../pluma/pluma-print-preferences.ui.h:16
+#: pluma/pluma-print-preferences.ui:425
 msgid "He_aders and footers:"
 msgstr "页眉和页脚(_A)："
 
-#: ../pluma/pluma-print-preferences.ui.h:17
+#: pluma/pluma-print-preferences.ui:439
 msgid "_Line numbers:"
 msgstr "行号(_L)："
 
-#: ../pluma/pluma-print-preferences.ui.h:18
+#: pluma/pluma-print-preferences.ui:463
 msgid "_Restore Default Fonts"
 msgstr "恢复为默认字体(_R)"
 
-#: ../pluma/pluma-print-preview.c:569
+#: pluma/pluma-print-preview.c:569
 msgid "Show the previous page"
 msgstr "显示上一页"
 
-#: ../pluma/pluma-print-preview.c:582
+#: pluma/pluma-print-preview.c:582
 msgid "Show the next page"
 msgstr "显示下一页"
 
-#: ../pluma/pluma-print-preview.c:598
+#: pluma/pluma-print-preview.c:598
 msgid "Current page (Alt+P)"
 msgstr "当前页面(Alt+P)"
 
 #. Translators: the "of" from "1 of 19" in print preview.
-#: ../pluma/pluma-print-preview.c:621
+#: pluma/pluma-print-preview.c:621
 msgid "of"
 msgstr "/"
 
-#: ../pluma/pluma-print-preview.c:629
+#: pluma/pluma-print-preview.c:629
 msgid "Page total"
 msgstr "总计页数"
 
-#: ../pluma/pluma-print-preview.c:630
+#: pluma/pluma-print-preview.c:630
 msgid "The total number of pages in the document"
 msgstr "文档的总页数"
 
-#: ../pluma/pluma-print-preview.c:648
+#: pluma/pluma-print-preview.c:648
 msgid "Show multiple pages"
 msgstr "显示多页"
 
-#: ../pluma/pluma-print-preview.c:662
+#: pluma/pluma-print-preview.c:662
 msgid "Zoom 1:1"
 msgstr "缩放至原大"
 
-#: ../pluma/pluma-print-preview.c:672
+#: pluma/pluma-print-preview.c:672
 msgid "Zoom to fit the whole page"
 msgstr "缩放至适合整个页面"
 
-#: ../pluma/pluma-print-preview.c:682
+#: pluma/pluma-print-preview.c:682
 msgid "Zoom the page in"
 msgstr "缩小页面"
 
-#: ../pluma/pluma-print-preview.c:692
+#: pluma/pluma-print-preview.c:692
 msgid "Zoom the page out"
 msgstr "缩小页面"
 
-#: ../pluma/pluma-print-preview.c:704
+#: pluma/pluma-print-preview.c:704
 msgid "_Close Preview"
 msgstr "关闭预览(_C)"
 
-#: ../pluma/pluma-print-preview.c:707
+#: pluma/pluma-print-preview.c:707
 msgid "Close print preview"
 msgstr "关闭打印预览"
 
-#: ../pluma/pluma-print-preview.c:782
+#: pluma/pluma-print-preview.c:782
 #, c-format
 msgid "Page %d of %d"
 msgstr "第 %d 页，共 %d 页"
 
-#: ../pluma/pluma-print-preview.c:963
+#: pluma/pluma-print-preview.c:963
 msgid "Page Preview"
 msgstr "页面预览"
 
-#: ../pluma/pluma-print-preview.c:964
+#: pluma/pluma-print-preview.c:964
 msgid "The preview of a page in the document to be printed"
 msgstr "要打印文档中页面的预览"
 
-#: ../pluma/pluma-smart-charset-converter.c:316
+#: pluma/pluma-smart-charset-converter.c:316
 msgid "It is not possible to detect the encoding automatically"
 msgstr "不能自动检测编码"
 
-#: ../pluma/pluma-statusbar.c:66 ../pluma/pluma-statusbar.c:72
+#: pluma/pluma-statusbar.c:66 pluma/pluma-statusbar.c:72
 msgid "OVR"
 msgstr "覆盖"
 
-#: ../pluma/pluma-statusbar.c:66 ../pluma/pluma-statusbar.c:72
+#: pluma/pluma-statusbar.c:66 pluma/pluma-statusbar.c:72
 msgid "INS"
 msgstr "插入"
 
 #. Translators: "Ln" is an abbreviation for "Line", Col is an abbreviation for
 #. "Column". Please,
 #. use abbreviations if possible to avoid space problems.
-#: ../pluma/pluma-statusbar.c:245
+#: pluma/pluma-statusbar.c:245
 #, c-format
 msgid "  Ln %d, Col %d"
 msgstr "  行 %d，列 %d"
 
-#: ../pluma/pluma-statusbar.c:346
+#: pluma/pluma-statusbar.c:346
 #, c-format
 msgid "There is a tab with errors"
 msgid_plural "There are %d tabs with errors"
 msgstr[0] "有%d个有错的标签"
 
-#: ../pluma/pluma-style-scheme-manager.c:213
+#: pluma/pluma-style-scheme-manager.c:213
 #, c-format
 msgid "Directory '%s' could not be created: g_mkdir_with_parents() failed: %s"
 msgstr "无法创建目录“%s”：g_mkdir_with_parents() 失败：%s"
 
 #. Translators: the first %s is a file name (e.g. test.txt) the second one
 #. is a directory (e.g. ssh://master.gnome.org/home/users/paolo)
-#: ../pluma/pluma-tab.c:668
+#: pluma/pluma-tab.c:668
 #, c-format
 msgid "Reverting %s from %s"
 msgstr "从 %2$s 还原 %1$s"
 
-#: ../pluma/pluma-tab.c:675
+#: pluma/pluma-tab.c:675
 #, c-format
 msgid "Reverting %s"
 msgstr "还原 %s"
 
 #. Translators: the first %s is a file name (e.g. test.txt) the second one
 #. is a directory (e.g. ssh://master.gnome.org/home/users/paolo)
-#: ../pluma/pluma-tab.c:691
+#: pluma/pluma-tab.c:691
 #, c-format
 msgid "Loading %s from %s"
 msgstr "从 %2$s 载入 %1$s"
 
-#: ../pluma/pluma-tab.c:698
+#: pluma/pluma-tab.c:698
 #, c-format
 msgid "Loading %s"
 msgstr "载入 %s"
 
 #. Translators: the first %s is a file name (e.g. test.txt) the second one
 #. is a directory (e.g. ssh://master.gnome.org/home/users/paolo)
-#: ../pluma/pluma-tab.c:781
+#: pluma/pluma-tab.c:781
 #, c-format
 msgid "Saving %s to %s"
 msgstr "将 %s 保存到 %s"
 
-#: ../pluma/pluma-tab.c:788
+#: pluma/pluma-tab.c:788
 #, c-format
 msgid "Saving %s"
 msgstr "保存 %s"
 
-#. Read only
-#: ../pluma/pluma-tab.c:1664
+#: pluma/pluma-tab.c:1664
 msgid "RO"
 msgstr "只读"
 
-#: ../pluma/pluma-tab.c:1711
+#: pluma/pluma-tab.c:1711
 #, c-format
 msgid "Error opening file %s"
 msgstr "打开文件 %s 出错"
 
-#: ../pluma/pluma-tab.c:1716
+#: pluma/pluma-tab.c:1716
 #, c-format
 msgid "Error reverting file %s"
 msgstr "还原文件 %s 出错"
 
-#: ../pluma/pluma-tab.c:1721
+#: pluma/pluma-tab.c:1721
 #, c-format
 msgid "Error saving file %s"
 msgstr "保存文件 %s 出错"
 
-#: ../pluma/pluma-tab.c:1742
+#: pluma/pluma-tab.c:1742
 msgid "Unicode (UTF-8)"
 msgstr "Unicode (UTF-8)"
 
-#: ../pluma/pluma-tab.c:1749
+#: pluma/pluma-tab.c:1749
 msgid "Name:"
 msgstr "名称："
 
-#: ../pluma/pluma-tab.c:1750
+#: pluma/pluma-tab.c:1750
 msgid "MIME Type:"
 msgstr "MIME 类型："
 
-#: ../pluma/pluma-tab.c:1751
+#: pluma/pluma-tab.c:1751
 msgid "Encoding:"
 msgstr "编码："
 
-#: ../pluma/pluma-tab-label.c:274
+#: pluma/pluma-tab-label.c:274
 msgid "Close document"
 msgstr "关闭文档"
 
-#. Toplevel
-#: ../pluma/pluma-ui.h:47
+#: pluma/pluma-ui.h:47
 msgid "_File"
 msgstr "文件 (_F)"
 
-#: ../pluma/pluma-ui.h:48
+#: pluma/pluma-ui.h:48
 msgid "_Edit"
-msgstr "编辑（_E）"
+msgstr "编辑(_E)"
 
-#: ../pluma/pluma-ui.h:49
+#: pluma/pluma-ui.h:49
 msgid "_View"
-msgstr "视图（_V）"
+msgstr "视图(_V)"
 
-#: ../pluma/pluma-ui.h:50
+#: pluma/pluma-ui.h:50
 msgid "_Search"
 msgstr "搜索(_S)"
 
-#: ../pluma/pluma-ui.h:51
+#: pluma/pluma-ui.h:51
 msgid "_Tools"
 msgstr "工具(_T)"
 
-#: ../pluma/pluma-ui.h:52
+#: pluma/pluma-ui.h:52
 msgid "_Documents"
 msgstr "文档(_D)"
 
-#. File menu
-#: ../pluma/pluma-ui.h:56
+#: pluma/pluma-ui.h:56
 msgid "_New"
 msgstr "新建(_N)"
 
-#: ../pluma/pluma-ui.h:57
+#: pluma/pluma-ui.h:57
 msgid "Create a new document"
 msgstr "新建一个文档"
 
-#: ../pluma/pluma-ui.h:58
+#: pluma/pluma-ui.h:58
 msgid "_Open..."
 msgstr "打开(_O)..."
 
-#: ../pluma/pluma-ui.h:59 ../pluma/pluma-window.c:1455
+#: pluma/pluma-ui.h:59 pluma/pluma-window.c:1455
 msgid "Open a file"
 msgstr "打开文件"
 
-#. Edit menu
-#: ../pluma/pluma-ui.h:62
+#: pluma/pluma-ui.h:62
 msgid "Pr_eferences"
 msgstr "首选项(_E)"
 
-#: ../pluma/pluma-ui.h:63
+#: pluma/pluma-ui.h:63
 msgid "Configure the application"
 msgstr "配置应用程序"
 
-#. Help menu
-#: ../pluma/pluma-ui.h:66
+#: pluma/pluma-ui.h:66
 msgid "_Contents"
 msgstr "目录(_C)"
 
-#: ../pluma/pluma-ui.h:67
+#: pluma/pluma-ui.h:67
 msgid "Open the pluma manual"
 msgstr "打开 pluma 手册"
 
-#: ../pluma/pluma-ui.h:68
+#: pluma/pluma-ui.h:68
 msgid "_About"
 msgstr "关于(_A)"
 
-#: ../pluma/pluma-ui.h:69
+#: pluma/pluma-ui.h:69
 msgid "About this application"
 msgstr "关于此应用程序"
 
-#. Fullscreen toolbar
-#: ../pluma/pluma-ui.h:72
+#: pluma/pluma-ui.h:72
 msgid "_Leave Fullscreen"
 msgstr "离开全屏(_L)"
 
-#: ../pluma/pluma-ui.h:73
+#: pluma/pluma-ui.h:73
 msgid "Leave fullscreen mode"
 msgstr "离开全屏模式"
 
-#: ../pluma/pluma-ui.h:81
+#: pluma/pluma-ui.h:81
 msgid "Save the current file"
 msgstr "保存当前的文件"
 
-#: ../pluma/pluma-ui.h:82
+#: pluma/pluma-ui.h:82
 msgid "Save _As..."
 msgstr "另存为(_A)..."
 
-#: ../pluma/pluma-ui.h:83
+#: pluma/pluma-ui.h:83
 msgid "Save the current file with a different name"
 msgstr "用不同的文件名保存当前的文件"
 
-#: ../pluma/pluma-ui.h:85
+#: pluma/pluma-ui.h:85
 msgid "Revert to a saved version of the file"
 msgstr "恢复为已保存的文件"
 
-#: ../pluma/pluma-ui.h:86
+#: pluma/pluma-ui.h:86
 msgid "Print Previe_w"
 msgstr "打印预览(_W)"
 
-#: ../pluma/pluma-ui.h:87
+#: pluma/pluma-ui.h:87
 msgid "Print preview"
 msgstr "打印预览"
 
-#: ../pluma/pluma-ui.h:88
+#: pluma/pluma-ui.h:88
 msgid "_Print..."
 msgstr "打印(_P)..."
 
-#: ../pluma/pluma-ui.h:89
+#: pluma/pluma-ui.h:89
 msgid "Print the current page"
 msgstr "打印当前文件"
 
-#. Edit menu
-#: ../pluma/pluma-ui.h:92
+#: pluma/pluma-ui.h:92
 msgid "_Undo"
 msgstr "撤消(_U)"
 
-#: ../pluma/pluma-ui.h:93
+#: pluma/pluma-ui.h:93
 msgid "Undo the last action"
 msgstr "撤消上次操作"
 
-#: ../pluma/pluma-ui.h:94
+#: pluma/pluma-ui.h:94
 msgid "_Redo"
 msgstr "重做(_R)"
 
-#: ../pluma/pluma-ui.h:95
+#: pluma/pluma-ui.h:95
 msgid "Redo the last undone action"
 msgstr "重做上次撤消的操作"
 
-#: ../pluma/pluma-ui.h:96
+#: pluma/pluma-ui.h:96
 msgid "Cu_t"
 msgstr "剪切(_T)"
 
-#: ../pluma/pluma-ui.h:97
+#: pluma/pluma-ui.h:97
 msgid "Cut the selection"
 msgstr "剪切选中内容"
 
-#: ../pluma/pluma-ui.h:98
+#: pluma/pluma-ui.h:98
 msgid "_Copy"
 msgstr "复制(_C)"
 
-#: ../pluma/pluma-ui.h:99
+#: pluma/pluma-ui.h:99
 msgid "Copy the selection"
 msgstr "复制选中内容"
 
-#: ../pluma/pluma-ui.h:100
+#: pluma/pluma-ui.h:100
 msgid "_Paste"
 msgstr "粘贴(_P)"
 
-#: ../pluma/pluma-ui.h:101
+#: pluma/pluma-ui.h:101
 msgid "Paste the clipboard"
 msgstr "粘贴剪贴板中的内容"
 
-#. Add delete button
-#: ../pluma/pluma-ui.h:102
-#: ../plugins/filebrowser/pluma-file-browser-utils.c:182
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:801
+#: pluma/pluma-ui.h:102 plugins/filebrowser/pluma-file-browser-utils.c:182
+#: plugins/filebrowser/pluma-file-browser-widget.c:801
 msgid "_Delete"
 msgstr "删除(_D)"
 
-#: ../pluma/pluma-ui.h:103
+#: pluma/pluma-ui.h:103
 msgid "Delete the selected text"
 msgstr "删除选中的文本"
 
-#: ../pluma/pluma-ui.h:104
+#: pluma/pluma-ui.h:104
 msgid "Select _All"
 msgstr "全选(_A)"
 
-#: ../pluma/pluma-ui.h:105
+#: pluma/pluma-ui.h:105
 msgid "Select the entire document"
 msgstr "选中整个文档"
 
-#. View menu
-#: ../pluma/pluma-ui.h:108
+#: pluma/pluma-ui.h:108
 msgid "_Highlight Mode"
 msgstr "突出显示模式(_H)"
 
-#. Search menu
-#: ../pluma/pluma-ui.h:111
+#: pluma/pluma-ui.h:111
 msgid "_Find..."
 msgstr "查找(_F)..."
 
-#: ../pluma/pluma-ui.h:112
+#: pluma/pluma-ui.h:112
 msgid "Search for text"
 msgstr "搜索文字"
 
-#: ../pluma/pluma-ui.h:113
+#: pluma/pluma-ui.h:113
 msgid "Find Ne_xt"
 msgstr "查找下一个(_X)"
 
-#: ../pluma/pluma-ui.h:114
+#: pluma/pluma-ui.h:114
 msgid "Search forwards for the same text"
 msgstr "正向搜索相同的文字"
 
-#: ../pluma/pluma-ui.h:115
+#: pluma/pluma-ui.h:115
 msgid "Find Pre_vious"
 msgstr "查找上一个(_V)"
 
-#: ../pluma/pluma-ui.h:116
+#: pluma/pluma-ui.h:116
 msgid "Search backwards for the same text"
 msgstr "反向搜索相同的文字"
 
-#: ../pluma/pluma-ui.h:117
+#: pluma/pluma-ui.h:117
 msgid "_Replace..."
 msgstr "替换(_R)..."
 
-#: ../pluma/pluma-ui.h:118
+#: pluma/pluma-ui.h:118
 msgid "Search for and replace text"
 msgstr "搜索并替换文字"
 
-#: ../pluma/pluma-ui.h:119
+#: pluma/pluma-ui.h:119
 msgid "_Clear Highlight"
 msgstr "清除高亮(_C)"
 
-#: ../pluma/pluma-ui.h:120
+#: pluma/pluma-ui.h:120
 msgid "Clear highlighting of search matches"
 msgstr "清除搜索匹配项的突出显示"
 
-#: ../pluma/pluma-ui.h:121
+#: pluma/pluma-ui.h:121
 msgid "Go to _Line..."
 msgstr "跳转到指定行(_L)..."
 
-#: ../pluma/pluma-ui.h:122
+#: pluma/pluma-ui.h:122
 msgid "Go to a specific line"
 msgstr "跳转到指定的行"
 
-#: ../pluma/pluma-ui.h:123
+#: pluma/pluma-ui.h:123
 msgid "_Incremental Search..."
 msgstr "增量搜索(_I)..."
 
-#: ../pluma/pluma-ui.h:124
+#: pluma/pluma-ui.h:124
 msgid "Incrementally search for text"
 msgstr "增量搜索文字"
 
-#. Documents menu
-#: ../pluma/pluma-ui.h:127
+#: pluma/pluma-ui.h:127
 msgid "_Save All"
 msgstr "全部保存(_S)"
 
-#: ../pluma/pluma-ui.h:128
+#: pluma/pluma-ui.h:128
 msgid "Save all open files"
 msgstr "保存所有已打开的文件"
 
-#: ../pluma/pluma-ui.h:129
+#: pluma/pluma-ui.h:129
 msgid "_Close All"
 msgstr "全部关闭(_C)"
 
-#: ../pluma/pluma-ui.h:130
+#: pluma/pluma-ui.h:130
 msgid "Close all open files"
 msgstr "关闭所有已打开的文件"
 
-#: ../pluma/pluma-ui.h:131
+#: pluma/pluma-ui.h:131
 msgid "_Previous Document"
 msgstr "上一个文档(_P)"
 
-#: ../pluma/pluma-ui.h:132
+#: pluma/pluma-ui.h:132
 msgid "Activate previous document"
 msgstr "激活上一个文档"
 
-#: ../pluma/pluma-ui.h:133
+#: pluma/pluma-ui.h:133
 msgid "_Next Document"
 msgstr "下一个文档(_N)"
 
-#: ../pluma/pluma-ui.h:134
+#: pluma/pluma-ui.h:134
 msgid "Activate next document"
 msgstr "激活下一个文档"
 
-#: ../pluma/pluma-ui.h:135
+#: pluma/pluma-ui.h:135
 msgid "_Move to New Window"
 msgstr "移动到新窗口(_M)"
 
-#: ../pluma/pluma-ui.h:136
+#: pluma/pluma-ui.h:136
 msgid "Move the current document to a new window"
 msgstr "将当前文档移动到新窗口"
 
-#: ../pluma/pluma-ui.h:143
+#: pluma/pluma-ui.h:143
 msgid "Close the current file"
 msgstr "关闭当前的文件"
 
-#: ../pluma/pluma-ui.h:149
+#: pluma/pluma-ui.h:149
 msgid "_Quit"
 msgstr "退出(_Q)"
 
-#: ../pluma/pluma-ui.h:150
+#: pluma/pluma-ui.h:150
 msgid "Quit the program"
 msgstr "退出程序"
 
-#: ../pluma/pluma-ui.h:155
+#: pluma/pluma-ui.h:155
 msgid "_Toolbar"
 msgstr "工具栏(_T)"
 
-#: ../pluma/pluma-ui.h:156
+#: pluma/pluma-ui.h:156
 msgid "Show or hide the toolbar in the current window"
 msgstr "当前窗口中显示或隐藏工具栏"
 
-#: ../pluma/pluma-ui.h:158
+#: pluma/pluma-ui.h:158
 msgid "_Statusbar"
 msgstr "状态栏(_S)"
 
-#: ../pluma/pluma-ui.h:159
+#: pluma/pluma-ui.h:159
 msgid "Show or hide the statusbar in the current window"
 msgstr "在当前窗口中显示或隐藏显示状态栏"
 
-#: ../pluma/pluma-ui.h:161
+#: pluma/pluma-ui.h:161
 msgid "_Fullscreen"
 msgstr "全屏(_F)"
 
-#: ../pluma/pluma-ui.h:162
+#: pluma/pluma-ui.h:162
 msgid "Edit text in fullscreen"
 msgstr "全屏编辑文本文件"
 
-#: ../pluma/pluma-ui.h:169
+#: pluma/pluma-ui.h:169
 msgid "Side _Pane"
 msgstr "侧边栏(_P)"
 
-#: ../pluma/pluma-ui.h:170
+#: pluma/pluma-ui.h:170
 msgid "Show or hide the side pane in the current window"
 msgstr "在当前窗口中显示或隐藏侧边栏"
 
-#: ../pluma/pluma-ui.h:172
+#: pluma/pluma-ui.h:172
 msgid "_Bottom Pane"
 msgstr "底部面板(_B)"
 
-#: ../pluma/pluma-ui.h:173
+#: pluma/pluma-ui.h:173
 msgid "Show or hide the bottom pane in the current window"
 msgstr "在当前窗口中显示或隐藏底部面板"
 
-#: ../pluma/pluma-utils.c:1074
+#: pluma/pluma-utils.c:1074
 msgid "Please check your installation."
 msgstr "请检查您的安装。"
 
-#: ../pluma/pluma-utils.c:1147
+#: pluma/pluma-utils.c:1147
 #, c-format
 msgid "Unable to open UI file %s. Error: %s"
 msgstr "无法打开界面文件 %s。错误：%s"
 
-#: ../pluma/pluma-utils.c:1167
+#: pluma/pluma-utils.c:1167
 #, c-format
 msgid "Unable to find the object '%s' inside file %s."
 msgstr "在文件 %s 中找不到所需的对象“%s”。"
 
 #. Translators: '/ on <remote-share>'
-#: ../pluma/pluma-utils.c:1327
+#: pluma/pluma-utils.c:1327
 #, c-format
 msgid "/ on %s"
 msgstr "%s 上的 /"
 
-#. create "Wrap Around" menu item.
-#: ../pluma/pluma-view.c:1429
+#: pluma/pluma-view.c:1429
 msgid "_Wrap Around"
 msgstr "回到文档头部继续搜索(_W)"
 
-#. create "Match Entire Word Only" menu item.
-#: ../pluma/pluma-view.c:1439
+#: pluma/pluma-view.c:1439
 msgid "Match _Entire Word Only"
 msgstr "只匹配整个单词(_E)"
 
-#. create "Match Case" menu item.
-#: ../pluma/pluma-view.c:1449
+#: pluma/pluma-view.c:1449
 msgid "_Match Case"
 msgstr "区分大小写(_M)"
 
-#. create "Parse escapes" menu item.
-#: ../pluma/pluma-view.c:1459
+#: pluma/pluma-view.c:1459
 msgid ""
 "_Parse escape sequences (e.g. \n"
 ")"
@@ -2378,405 +2388,412 @@ msgstr ""
 "解析转义序列(如\n"
 ")(_P)"
 
-#: ../pluma/pluma-view.c:1573
+#: pluma/pluma-view.c:1573
 msgid "String you want to search for"
 msgstr "您想要搜索的字符串"
 
-#: ../pluma/pluma-view.c:1582
+#: pluma/pluma-view.c:1582
 msgid "Line you want to move the cursor to"
 msgstr "您想要将光标移动到的行"
 
-#: ../pluma/pluma-window.c:1014
+#: pluma/pluma-window.c:1014
 #, c-format
 msgid "Use %s highlight mode"
 msgstr "使用 %s 突出显示模式"
 
-#. add the "Plain Text" item before all the others
 #. Translators: "Plain Text" means that no highlight mode is selected in the
 #. * "View->Highlight Mode" submenu and so syntax highlighting is disabled
-#: ../pluma/pluma-window.c:1071 ../pluma/pluma-window.c:1959
-#: ../plugins/externaltools/tools/manager.py:108
-#: ../plugins/externaltools/tools/manager.py:308
-#: ../plugins/externaltools/tools/manager.py:424
-#: ../plugins/externaltools/tools/manager.py:746
+#: pluma/pluma-window.c:1071 pluma/pluma-window.c:1959
+#: plugins/externaltools/tools/manager.py:108
+#: plugins/externaltools/tools/manager.py:308
+#: plugins/externaltools/tools/manager.py:424
+#: plugins/externaltools/tools/manager.py:746
 msgid "Plain Text"
 msgstr "纯文本"
 
-#: ../pluma/pluma-window.c:1072
+#: pluma/pluma-window.c:1072
 msgid "Disable syntax highlighting"
 msgstr "禁用语法突出显示"
 
 #. Translators: %s is a URI
-#: ../pluma/pluma-window.c:1354
+#: pluma/pluma-window.c:1354
 #, c-format
 msgid "Open '%s'"
 msgstr "打开“%s”"
 
-#: ../pluma/pluma-window.c:1461
+#: pluma/pluma-window.c:1461
 msgid "Open a recently used file"
 msgstr "打开最近用过的文件"
 
-#: ../pluma/pluma-window.c:1467
+#: pluma/pluma-window.c:1467
 msgid "Open"
 msgstr "打开"
 
-#: ../pluma/pluma-window.c:1525
+#: pluma/pluma-window.c:1525
 msgid "Save"
 msgstr "保存"
 
-#: ../pluma/pluma-window.c:1527
+#: pluma/pluma-window.c:1527
 msgid "Print"
 msgstr "打印"
 
 #. Translators: %s is a URI
-#: ../pluma/pluma-window.c:1684
+#: pluma/pluma-window.c:1684
 #, c-format
 msgid "Activate '%s'"
 msgstr "激活“%s”"
 
-#: ../pluma/pluma-window.c:1937
+#: pluma/pluma-window.c:1937
 msgid "Use Spaces"
 msgstr "使用空格"
 
-#: ../pluma/pluma-window.c:2008
+#: pluma/pluma-window.c:2008
 msgid "Tab Width"
 msgstr "跳格宽度"
 
-#: ../plugins/changecase/changecase.plugin.desktop.in.h:1
+#: plugins/changecase/changecase.plugin.desktop.in:5
 msgid "Change Case"
 msgstr "更改大小写"
 
-#: ../plugins/changecase/changecase.plugin.desktop.in.h:2
+#: plugins/changecase/changecase.plugin.desktop.in:6
 msgid "Changes the case of selected text."
 msgstr "更改选中文本的大小写。"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:243
+#: plugins/changecase/pluma-changecase-plugin.c:243
 msgid "C_hange Case"
 msgstr "更改大小写(_H)"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:244
+#: plugins/changecase/pluma-changecase-plugin.c:244
 msgid "All _Upper Case"
 msgstr "全部大写(_U)"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:245
+#: plugins/changecase/pluma-changecase-plugin.c:245
 msgid "Change selected text to upper case"
 msgstr "将选中文本更改为大写"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:247
+#: plugins/changecase/pluma-changecase-plugin.c:247
 msgid "All _Lower Case"
 msgstr "全部小写(_L)"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:248
+#: plugins/changecase/pluma-changecase-plugin.c:248
 msgid "Change selected text to lower case"
 msgstr "将选中文本更改为小写"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:250
+#: plugins/changecase/pluma-changecase-plugin.c:250
 msgid "_Invert Case"
 msgstr "反转大小写(_I)"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:251
+#: plugins/changecase/pluma-changecase-plugin.c:251
 msgid "Invert the case of selected text"
 msgstr "反转选中文本的大小写"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:253
+#: plugins/changecase/pluma-changecase-plugin.c:253
 msgid "_Title Case"
 msgstr "字首大写(_T)"
 
-#: ../plugins/changecase/pluma-changecase-plugin.c:254
+#: plugins/changecase/pluma-changecase-plugin.c:254
 msgid "Capitalize the first letter of each selected word"
 msgstr "将选中的每个单词的第一个字母变成大写"
 
-#: ../plugins/docinfo/docinfo.plugin.desktop.in.h:1
-#: ../plugins/docinfo/docinfo.ui.h:1
+#: plugins/docinfo/docinfo.plugin.desktop.in:5 plugins/docinfo/docinfo.ui:19
 msgid "Document Statistics"
 msgstr "文档统计"
 
-#: ../plugins/docinfo/docinfo.plugin.desktop.in.h:2
+#: plugins/docinfo/docinfo.plugin.desktop.in:6
 msgid ""
 "Analyzes the current document and reports the number of words, lines, "
 "characters and non-space characters in it."
 msgstr "分析当前文档，并报告文档中的单词数、行数、字符数和非空格字符数。"
 
-#: ../plugins/docinfo/docinfo.ui.h:3
+#: plugins/docinfo/docinfo.ui:51
 msgid "_Update"
 msgstr "更新(_U)"
 
-#: ../plugins/docinfo/docinfo.ui.h:4
+#: plugins/docinfo/docinfo.ui:84
 msgid "File Name"
 msgstr "文件名"
 
-#: ../plugins/docinfo/docinfo.ui.h:6
+#: plugins/docinfo/docinfo.ui:127
 msgid "Bytes"
 msgstr "字节数"
 
-#: ../plugins/docinfo/docinfo.ui.h:7
+#: plugins/docinfo/docinfo.ui:153
 msgid "Characters (no spaces)"
 msgstr "字符数(不含空格)"
 
-#: ../plugins/docinfo/docinfo.ui.h:8
+#: plugins/docinfo/docinfo.ui:179
 msgid "Characters (with spaces)"
 msgstr "字符数(含空格)"
 
-#: ../plugins/docinfo/docinfo.ui.h:9
+#: plugins/docinfo/docinfo.ui:218
 msgid "Words"
 msgstr "单词数"
 
-#: ../plugins/docinfo/docinfo.ui.h:10
+#: plugins/docinfo/docinfo.ui:231
 msgid "Lines"
 msgstr "行数"
 
-#: ../plugins/docinfo/docinfo.ui.h:11
+#: plugins/docinfo/docinfo.ui:257
 msgid "Document"
 msgstr "文档"
 
-#: ../plugins/docinfo/docinfo.ui.h:12
+#: plugins/docinfo/docinfo.ui:290
 msgid "Selection"
 msgstr "选择"
 
-#: ../plugins/docinfo/pluma-docinfo-plugin.c:440
+#: plugins/docinfo/pluma-docinfo-plugin.c:440
 msgid "_Document Statistics"
 msgstr "文档统计(_D)"
 
-#: ../plugins/docinfo/pluma-docinfo-plugin.c:442
+#: plugins/docinfo/pluma-docinfo-plugin.c:442
 msgid "Get statistical information on the current document"
 msgstr "获取当前文档的统计信息"
 
-#: ../plugins/externaltools/externaltools.plugin.desktop.in.h:1
+#: plugins/externaltools/externaltools.plugin.desktop.in:6
 msgid "External Tools"
 msgstr "外部工具"
 
-#: ../plugins/externaltools/externaltools.plugin.desktop.in.h:2
+#: plugins/externaltools/externaltools.plugin.desktop.in:7
 msgid "Execute external commands and shell scripts."
 msgstr "执行外部命令和 Shell 脚本。"
 
-#: ../plugins/externaltools/tools/__init__.py:174
+#: plugins/externaltools/tools/__init__.py:174
 msgid "Manage _External Tools..."
 msgstr "管理外部工具(_E)…"
 
-#: ../plugins/externaltools/tools/__init__.py:176
+#: plugins/externaltools/tools/__init__.py:176
 msgid "Opens the External Tools Manager"
 msgstr "打开外部工具管理器"
 
-#: ../plugins/externaltools/tools/__init__.py:180
+#: plugins/externaltools/tools/__init__.py:180
 msgid "External _Tools"
 msgstr "外部工具(_T)"
 
-#: ../plugins/externaltools/tools/__init__.py:182
+#: plugins/externaltools/tools/__init__.py:182
 msgid "External tools"
 msgstr "外部工具"
 
-#: ../plugins/externaltools/tools/__init__.py:215
+#: plugins/externaltools/tools/__init__.py:215
 msgid "Shell Output"
 msgstr "Shell 输出"
 
-#: ../plugins/externaltools/tools/capture.py:96
+#: plugins/externaltools/tools/capture.py:96
 #, python-format
 msgid "Could not execute command: %s"
 msgstr "无法执行命令：%s"
 
-#: ../plugins/externaltools/tools/functions.py:155
+#: plugins/externaltools/tools/functions.py:155
 msgid "You must be inside a word to run this command"
 msgstr "您必须位于单词内才能运行此命令"
 
-#: ../plugins/externaltools/tools/functions.py:261
+#: plugins/externaltools/tools/functions.py:261
 msgid "Running tool:"
 msgstr "正在运行工具："
 
-#: ../plugins/externaltools/tools/functions.py:285
+#: plugins/externaltools/tools/functions.py:285
 msgid "Done."
 msgstr "完成。"
 
-#: ../plugins/externaltools/tools/functions.py:287
+#: plugins/externaltools/tools/functions.py:287
 msgid "Exited"
 msgstr "已退出"
 
-#: ../plugins/externaltools/tools/manager.py:106
+#: plugins/externaltools/tools/manager.py:106
 msgid "All languages"
 msgstr "全部语言"
 
-#: ../plugins/externaltools/tools/manager.py:413
-#: ../plugins/externaltools/tools/manager.py:417
-#: ../plugins/externaltools/tools/manager.py:744
-#: ../plugins/externaltools/tools/tools.ui.h:25
+#: plugins/externaltools/tools/manager.py:413
+#: plugins/externaltools/tools/manager.py:417
+#: plugins/externaltools/tools/manager.py:744
+#: plugins/externaltools/tools/tools.ui:525
 msgid "All Languages"
 msgstr "全部语言"
 
-#: ../plugins/externaltools/tools/manager.py:526
+#: plugins/externaltools/tools/manager.py:526
 msgid "New tool"
 msgstr "新建工具"
 
-#: ../plugins/externaltools/tools/manager.py:659
+#: plugins/externaltools/tools/manager.py:659
 #, python-format
 msgid "This accelerator is already bound to %s"
 msgstr "此快捷键已绑定到 %s"
 
-#: ../plugins/externaltools/tools/manager.py:710
+#: plugins/externaltools/tools/manager.py:710
 msgid "Type a new accelerator, or press Backspace to clear"
 msgstr "键入新的快捷键，或按 Backspace 清空"
 
-#: ../plugins/externaltools/tools/manager.py:712
+#: plugins/externaltools/tools/manager.py:712
 msgid "Type a new accelerator"
 msgstr "键入新的快捷键"
 
-#: ../plugins/externaltools/tools/outputpanel.py:102
+#: plugins/externaltools/tools/outputpanel.py:102
 msgid "Stopped."
 msgstr "已停止。"
 
-#. ex:ts=4:et:
-#: ../plugins/externaltools/tools/tools.ui.h:1
+#: plugins/externaltools/tools/tools.ui:17
+#: plugins/externaltools/tools/tools.ui:127
 msgid "All documents"
 msgstr "全部文档"
 
-#: ../plugins/externaltools/tools/tools.ui.h:2
+#: plugins/externaltools/tools/tools.ui:21
 msgid "All documents except untitled ones"
 msgstr "除无标题文档外的全部文档"
 
-#: ../plugins/externaltools/tools/tools.ui.h:3
+#: plugins/externaltools/tools/tools.ui:25
 msgid "Local files only"
 msgstr "仅本地文件"
 
-#: ../plugins/externaltools/tools/tools.ui.h:4
+#: plugins/externaltools/tools/tools.ui:29
 msgid "Remote files only"
 msgstr "仅远程文件"
 
-#: ../plugins/externaltools/tools/tools.ui.h:5
+#: plugins/externaltools/tools/tools.ui:33
 msgid "Untitled documents only"
 msgstr "仅无标题文档"
 
-#: ../plugins/externaltools/tools/tools.ui.h:6
+#: plugins/externaltools/tools/tools.ui:47
+#: plugins/externaltools/tools/tools.ui:81
+#: plugins/externaltools/tools/tools.ui:119
 msgid "Nothing"
 msgstr "无"
 
-#: ../plugins/externaltools/tools/tools.ui.h:7
+#: plugins/externaltools/tools/tools.ui:51
+#: plugins/externaltools/tools/tools.ui:123
 msgid "Current document"
 msgstr "当前文档"
 
-#: ../plugins/externaltools/tools/tools.ui.h:8
+#: plugins/externaltools/tools/tools.ui:55
 msgid "Current selection"
 msgstr "当前选中"
 
-#: ../plugins/externaltools/tools/tools.ui.h:9
+#: plugins/externaltools/tools/tools.ui:59
 msgid "Current selection (default to document)"
 msgstr "当前选中（默认为整个文档）"
 
-#: ../plugins/externaltools/tools/tools.ui.h:10
+#: plugins/externaltools/tools/tools.ui:63
 msgid "Current line"
 msgstr "当前行"
 
-#: ../plugins/externaltools/tools/tools.ui.h:11
+#: plugins/externaltools/tools/tools.ui:67
 msgid "Current word"
 msgstr "当前单词"
 
-#: ../plugins/externaltools/tools/tools.ui.h:12
+#: plugins/externaltools/tools/tools.ui:85
 msgid "Display in bottom pane"
 msgstr "在底部面板显示"
 
-#: ../plugins/externaltools/tools/tools.ui.h:13
+#: plugins/externaltools/tools/tools.ui:89
 msgid "Create new document"
 msgstr "创建新文档"
 
-#: ../plugins/externaltools/tools/tools.ui.h:14
+#: plugins/externaltools/tools/tools.ui:93
 msgid "Append to current document"
 msgstr "追加到当前文档"
 
-#: ../plugins/externaltools/tools/tools.ui.h:15
+#: plugins/externaltools/tools/tools.ui:97
 msgid "Replace current document"
 msgstr "替换当前文档"
 
-#: ../plugins/externaltools/tools/tools.ui.h:16
+#: plugins/externaltools/tools/tools.ui:101
 msgid "Replace current selection"
 msgstr "替换当前选中"
 
-#: ../plugins/externaltools/tools/tools.ui.h:17
+#: plugins/externaltools/tools/tools.ui:105
 msgid "Insert at cursor position"
 msgstr "在光标处插入"
 
-#: ../plugins/externaltools/tools/tools.ui.h:18
+#: plugins/externaltools/tools/tools.ui:134
 msgid "External Tools Manager"
 msgstr "外部工具管理器"
 
-#: ../plugins/externaltools/tools/tools.ui.h:19
+#: plugins/externaltools/tools/tools.ui:240
 msgid "_Tools:"
 msgstr "工具(_T)："
 
-#: ../plugins/externaltools/tools/tools.ui.h:20
+#: plugins/externaltools/tools/tools.ui:355
 msgid "_Applicability:"
 msgstr "适用性(_A)："
 
-#: ../plugins/externaltools/tools/tools.ui.h:21
+#: plugins/externaltools/tools/tools.ui:368
 msgid "_Output:"
 msgstr "输出(_O)："
 
-#: ../plugins/externaltools/tools/tools.ui.h:22
+#: plugins/externaltools/tools/tools.ui:381
 msgid "_Input:"
 msgstr "输入(_I)："
 
-#: ../plugins/externaltools/tools/tools.ui.h:23
+#: plugins/externaltools/tools/tools.ui:394
 msgid "_Save:"
 msgstr "保存(_S)："
 
-#: ../plugins/externaltools/tools/tools.ui.h:24
+#: plugins/externaltools/tools/tools.ui:407
 msgid "_Shortcut Key:"
 msgstr "快捷键(_S)："
 
-#: ../plugins/externaltools/tools/tools.ui.h:26
-#: ../plugins/snippets/snippets/snippets.ui.h:7
+#: plugins/externaltools/tools/tools.ui:572
+#: plugins/snippets/snippets/snippets.ui:308
 msgid "_Edit:"
 msgstr "编辑(_E)："
 
-#: ../plugins/externaltools/data/build.desktop.in.h:1
+#: plugins/externaltools/data/build.desktop.in:3
 msgid "Build"
 msgstr "构建"
 
-#: ../plugins/externaltools/data/build.desktop.in.h:2
+#: plugins/externaltools/data/build.desktop.in:4
 msgid "Run \"make\" in the document directory"
 msgstr "在文档所在的目录运行“make”"
 
-#: ../plugins/externaltools/data/open-terminal-here.desktop.in.h:1
+#: plugins/externaltools/data/open-terminal-here.desktop.in:3
 msgid "Open terminal here"
 msgstr "在此处打开终端"
 
-#: ../plugins/externaltools/data/open-terminal-here.desktop.in.h:2
+#: plugins/externaltools/data/open-terminal-here.desktop.in:4
 msgid "Open a terminal in the document location"
 msgstr "在文档所在位置打开终端"
 
-#: ../plugins/externaltools/data/remove-trailing-spaces.desktop.in.h:1
+#: plugins/externaltools/data/remove-trailing-spaces.desktop.in:3
 msgid "Remove trailing spaces"
 msgstr "移除尾随空白"
 
-#: ../plugins/externaltools/data/remove-trailing-spaces.desktop.in.h:2
+#: plugins/externaltools/data/remove-trailing-spaces.desktop.in:4
 msgid "Remove useless trailing spaces in your file"
 msgstr "删除文件中无用的尾随空白"
 
-#: ../plugins/externaltools/data/run-command.desktop.in.h:1
+#: plugins/externaltools/data/run-command.desktop.in:3
 msgid "Run command"
 msgstr "运行命令"
 
-#: ../plugins/externaltools/data/run-command.desktop.in.h:2
+#: plugins/externaltools/data/run-command.desktop.in:4
 msgid "Execute a custom command and put its output in a new document"
 msgstr "执行自定义命令并将其输出写入到新文档"
 
-#: ../plugins/externaltools/data/search-recursive.desktop.in.h:1
+#: plugins/externaltools/data/search-recursive.desktop.in:3
 msgid "Search"
 msgstr "查找"
 
-#: ../plugins/externaltools/data/switch-c.desktop.in.h:1
+#: plugins/externaltools/data/switch-c.desktop.in:3
 msgid "Switch onto a file .c and .h"
 msgstr "切换到一个 .c 或 .h 文件"
 
-#: ../plugins/filebrowser/filebrowser.plugin.desktop.in.h:1
+#: plugins/filebrowser/filebrowser.plugin.desktop.in:6
 msgid "File Browser Pane"
 msgstr "文件浏览器面板"
 
-#: ../plugins/filebrowser/filebrowser.plugin.desktop.in.h:2
+#: plugins/filebrowser/filebrowser.plugin.desktop.in:7
 msgid "Easy file access from the side pane"
 msgstr "从侧边栏轻松访问文件"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:1
+#. Translators: Do NOT translate or transliterate this text (this is an icon
+#. file name)!
+#: plugins/filebrowser/filebrowser.plugin.desktop.in:9
+msgid "system-file-manager"
+msgstr ""
+
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:6
 msgid "Set Location to First Document"
 msgstr "将位置设定为第一个文档"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:2
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:7
 msgid ""
 "If TRUE the file browser plugin will view the directory of the first opened "
 "document given that the file browser hasn't been used yet. (Thus this "
@@ -2785,11 +2802,11 @@ msgid ""
 msgstr ""
 "如果为 TRUE，则文件浏览器插件将查看第一个打开的文件所在目录，如果文件浏览器没有使用过的话。(这种情况通常出现在从命令行或者 Caja 打开文档)"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:3
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:11
 msgid "File Browser Filter Mode"
 msgstr "文件浏览器过滤方式"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:4
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:12
 msgid ""
 "This value determines what files get filtered from the file browser. Valid "
 "values are: none (filter nothing), hidden (filter hidden files), binary "
@@ -2799,41 +2816,41 @@ msgstr ""
 "此值决定了文件浏览器过滤文件的方式。可供选择的值有：none (不进行过滤)，hidden (过滤隐藏文件)，binary (过滤二进制文件)和 "
 "hidden_and_binary (过滤隐藏文件和二进制文件)"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:5
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:16
 msgid "File Browser Filter Pattern"
 msgstr "文件浏览器过滤模式"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:6
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:17
 msgid ""
 "The filter pattern to filter the file browser with. This filter works on top"
 " of the filter_mode."
 msgstr "文件浏览器进行过滤的模式。此过滤器取决于 filter_mode。"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:7
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:24
 msgid "Open With Tree View"
 msgstr "以树视图打开"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:8
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:25
 msgid ""
 "Open the tree view when the file browser plugin gets loaded instead of the "
 "bookmarks view"
 msgstr "文件浏览器插件载入时以树视图而不是书签视图打开"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:9
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:29
 msgid "File Browser Root Directory"
 msgstr "文件浏览器根目录"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:10
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:30
 msgid ""
 "The file browser root directory to use when loading the file browser plugin "
 "and onload/tree_view is TRUE."
 msgstr "当 onload/tree_view 为 TRUE 时，文件浏览器插件载入将使用此值作为文件浏览器的根目录。"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:11
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:34
 msgid "File Browser Virtual Root Directory"
 msgstr "文件浏览器虚拟根目录"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:12
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:35
 msgid ""
 "The file browser virtual root directory to use when loading the file browser"
 " plugin when onload/tree_view is TRUE. The virtual root must always be below"
@@ -2841,103 +2858,103 @@ msgid ""
 msgstr ""
 "当 onload/tree_view 为 TRUE 时，文件浏览器插件载入将使用此值作为文件浏览器的虚拟根目录。虚拟根目录必须位于实际根目录之下。"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:13
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:39
 msgid "Enable Restore of Remote Locations"
 msgstr "启用恢复远程位置"
 
-#: ../plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in.h:14
+#: plugins/filebrowser/org.mate.pluma.plugins.filebrowser.gschema.xml.in:40
 msgid "Sets whether to enable restoring of remote locations."
 msgstr "设定是否允许恢复远程位置。"
 
-#: ../plugins/filebrowser/pluma-file-bookmarks-store.c:238
+#: plugins/filebrowser/pluma-file-bookmarks-store.c:238
 msgid "File System"
 msgstr "文件系统"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:576
+#: plugins/filebrowser/pluma-file-browser-plugin.c:576
 msgid "_Set root to active document"
 msgstr "将根设定为当前文档(_S)"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:578
+#: plugins/filebrowser/pluma-file-browser-plugin.c:578
 msgid "Set the root to the active document location"
 msgstr "将根设定为当前文档的位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:583
+#: plugins/filebrowser/pluma-file-browser-plugin.c:583
 msgid "_Open terminal here"
 msgstr "在此打开终端(_O)"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:585
+#: plugins/filebrowser/pluma-file-browser-plugin.c:585
 msgid "Open a terminal at the currently opened directory"
 msgstr "在目前打开的目录中打开终端"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:725
+#: plugins/filebrowser/pluma-file-browser-plugin.c:725
 msgid "File Browser"
 msgstr "文件浏览器"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:870
+#: plugins/filebrowser/pluma-file-browser-plugin.c:870
 msgid "An error occurred while creating a new directory"
 msgstr "创建新目录时发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:873
+#: plugins/filebrowser/pluma-file-browser-plugin.c:873
 msgid "An error occurred while creating a new file"
 msgstr "创建新文件时发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:878
+#: plugins/filebrowser/pluma-file-browser-plugin.c:878
 msgid "An error occurred while renaming a file or directory"
 msgstr "重命名文件或目录时发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:883
+#: plugins/filebrowser/pluma-file-browser-plugin.c:883
 msgid "An error occurred while deleting a file or directory"
 msgstr "删除文件或目录时发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:888
+#: plugins/filebrowser/pluma-file-browser-plugin.c:888
 msgid "An error occurred while opening a directory in the file manager"
 msgstr "在文件管理其中打开目录时发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:892
+#: plugins/filebrowser/pluma-file-browser-plugin.c:892
 msgid "An error occurred while setting a root directory"
 msgstr "设定根目录时发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:896
+#: plugins/filebrowser/pluma-file-browser-plugin.c:896
 msgid "An error occurred while loading a directory"
 msgstr "载入目录时发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:899
+#: plugins/filebrowser/pluma-file-browser-plugin.c:899
 msgid "An error occurred"
 msgstr "发生了错误"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:1126
+#: plugins/filebrowser/pluma-file-browser-plugin.c:1126
 msgid ""
 "Cannot move file to trash, do you\n"
 "want to delete permanently?"
 msgstr "无法将文件移动到回收站，您是否想要永久删除？"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:1130
+#: plugins/filebrowser/pluma-file-browser-plugin.c:1130
 #, c-format
 msgid "The file \"%s\" cannot be moved to the trash."
 msgstr "无法将文件“%s”移动到回收站。"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:1133
+#: plugins/filebrowser/pluma-file-browser-plugin.c:1133
 msgid "The selected files cannot be moved to the trash."
 msgstr "无法将选中文件移动到回收站。"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:1161
+#: plugins/filebrowser/pluma-file-browser-plugin.c:1161
 #, c-format
 msgid "Are you sure you want to permanently delete \"%s\"?"
 msgstr "您确定要永久删除“%s”吗？"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:1164
+#: plugins/filebrowser/pluma-file-browser-plugin.c:1164
 msgid "Are you sure you want to permanently delete the selected files?"
 msgstr "您确定想要永久删除选中文件吗？"
 
-#: ../plugins/filebrowser/pluma-file-browser-plugin.c:1167
+#: plugins/filebrowser/pluma-file-browser-plugin.c:1167
 msgid "If you delete an item, it is permanently lost."
 msgstr "如果您删除一项，它将永久丢失。"
 
-#: ../plugins/filebrowser/pluma-file-browser-store.c:1662
+#: plugins/filebrowser/pluma-file-browser-store.c:1662
 msgid "(Empty)"
 msgstr "(空)"
 
-#: ../plugins/filebrowser/pluma-file-browser-store.c:3218
+#: plugins/filebrowser/pluma-file-browser-store.c:3218
 msgid ""
 "The renamed file is currently filtered out. You need to adjust your filter "
 "settings to make the file visible"
@@ -2945,11 +2962,11 @@ msgstr "重命名的文件现在已被过滤掉。您需要调整您的过滤器
 
 #. Translators: This is the default name of new files created by the file
 #. browser pane.
-#: ../plugins/filebrowser/pluma-file-browser-store.c:3475
+#: plugins/filebrowser/pluma-file-browser-store.c:3475
 msgid "file"
 msgstr "文件"
 
-#: ../plugins/filebrowser/pluma-file-browser-store.c:3499
+#: plugins/filebrowser/pluma-file-browser-store.c:3499
 msgid ""
 "The new file is currently filtered out. You need to adjust your filter "
 "settings to make the file visible"
@@ -2957,483 +2974,494 @@ msgstr "新文件现在已被过滤掉。您需要调整您的过滤器设置才
 
 #. Translators: This is the default name of new directories created by the
 #. file browser pane.
-#: ../plugins/filebrowser/pluma-file-browser-store.c:3528
+#: plugins/filebrowser/pluma-file-browser-store.c:3528
 msgid "directory"
 msgstr "目录"
 
-#: ../plugins/filebrowser/pluma-file-browser-store.c:3548
+#: plugins/filebrowser/pluma-file-browser-store.c:3548
 msgid ""
 "The new directory is currently filtered out. You need to adjust your filter "
 "settings to make the directory visible"
 msgstr "新目录现在已被过滤掉。您需要调整您的过滤器设置才能看到文件"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:712
+#: plugins/filebrowser/pluma-file-browser-widget.c:712
 msgid "Bookmarks"
 msgstr "书签"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:793
+#: plugins/filebrowser/pluma-file-browser-widget.c:793
 msgid "_Filter"
 msgstr "过滤器(_F)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:798
+#: plugins/filebrowser/pluma-file-browser-widget.c:798
 msgid "_Move to Trash"
 msgstr "移动到回收站(_M)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:799
+#: plugins/filebrowser/pluma-file-browser-widget.c:799
 msgid "Move selected file or folder to trash"
 msgstr "将选中文件或文件夹移动到回收站"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:802
+#: plugins/filebrowser/pluma-file-browser-widget.c:802
 msgid "Delete selected file or folder"
 msgstr "删除选中的文件或文件夹"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:809
+#: plugins/filebrowser/pluma-file-browser-widget.c:809
 msgid "Open selected file"
 msgstr "打开选中文件"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:815
+#: plugins/filebrowser/pluma-file-browser-widget.c:815
 msgid "Up"
 msgstr "向上"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:816
+#: plugins/filebrowser/pluma-file-browser-widget.c:816
 msgid "Open the parent folder"
 msgstr "打开父文件夹"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:821
+#: plugins/filebrowser/pluma-file-browser-widget.c:821
 msgid "_New Folder"
 msgstr "新建文件夹(_N)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:822
+#: plugins/filebrowser/pluma-file-browser-widget.c:822
 msgid "Add new empty folder"
 msgstr "添加新的空文件夹"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:824
+#: plugins/filebrowser/pluma-file-browser-widget.c:824
 msgid "New F_ile"
 msgstr "新建文件(_I)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:825
+#: plugins/filebrowser/pluma-file-browser-widget.c:825
 msgid "Add new empty file"
 msgstr "添加新的空文件"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:830
+#: plugins/filebrowser/pluma-file-browser-widget.c:830
 msgid "_Rename"
 msgstr "重命名(_R)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:831
+#: plugins/filebrowser/pluma-file-browser-widget.c:831
 msgid "Rename selected file or folder"
 msgstr "重命名选中的文件或文件夹"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:837
+#: plugins/filebrowser/pluma-file-browser-widget.c:837
 msgid "_Previous Location"
 msgstr "上一个位置(_P)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:839
+#: plugins/filebrowser/pluma-file-browser-widget.c:839
 msgid "Go to the previous visited location"
 msgstr "转到上一次访问的位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:841
+#: plugins/filebrowser/pluma-file-browser-widget.c:841
 msgid "_Next Location"
 msgstr "下一个位置(_N)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:842
+#: plugins/filebrowser/pluma-file-browser-widget.c:842
 msgid "Go to the next visited location"
 msgstr "转到下一次访问的位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:843
+#: plugins/filebrowser/pluma-file-browser-widget.c:843
 msgid "Re_fresh View"
 msgstr "刷新视图(_F)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:844
+#: plugins/filebrowser/pluma-file-browser-widget.c:844
 msgid "Refresh the view"
 msgstr "刷新视图"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:845
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:863
+#: plugins/filebrowser/pluma-file-browser-widget.c:845
+#: plugins/filebrowser/pluma-file-browser-widget.c:863
 msgid "_View Folder"
 msgstr "查看文件夹(_V)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:846
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:864
+#: plugins/filebrowser/pluma-file-browser-widget.c:846
+#: plugins/filebrowser/pluma-file-browser-widget.c:864
 msgid "View folder in file manager"
 msgstr "在文件管理器中查看文件夹"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:853
+#: plugins/filebrowser/pluma-file-browser-widget.c:853
 msgid "Show _Hidden"
 msgstr "显示隐藏文件(_H)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:854
+#: plugins/filebrowser/pluma-file-browser-widget.c:854
 msgid "Show hidden files and folders"
 msgstr "显示隐藏的文件和文件夹"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:856
+#: plugins/filebrowser/pluma-file-browser-widget.c:856
 msgid "Show _Binary"
 msgstr "显示二进制(_B)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:857
+#: plugins/filebrowser/pluma-file-browser-widget.c:857
 msgid "Show binary files"
 msgstr "显示二进制文件"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:990
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:1003
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:1029
+#: plugins/filebrowser/pluma-file-browser-widget.c:990
+#: plugins/filebrowser/pluma-file-browser-widget.c:1003
+#: plugins/filebrowser/pluma-file-browser-widget.c:1029
 msgid "Previous location"
 msgstr "上一个位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:996
+#: plugins/filebrowser/pluma-file-browser-widget.c:996
 msgid "Go to previous location"
 msgstr "转到上一个位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:998
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:1024
+#: plugins/filebrowser/pluma-file-browser-widget.c:998
+#: plugins/filebrowser/pluma-file-browser-widget.c:1024
 msgid "Go to a previously opened location"
 msgstr "转到上一个打开的位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:1016
+#: plugins/filebrowser/pluma-file-browser-widget.c:1016
 msgid "Next location"
 msgstr "下一个位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:1022
+#: plugins/filebrowser/pluma-file-browser-widget.c:1022
 msgid "Go to next location"
 msgstr "转到下一个位置"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:1234
+#: plugins/filebrowser/pluma-file-browser-widget.c:1234
 msgid "_Match Filename"
 msgstr "匹配文件名(_M)"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:2135
+#: plugins/filebrowser/pluma-file-browser-widget.c:2135
 #, c-format
 msgid "No mount object for mounted volume: %s"
 msgstr "挂载的卷没有挂载对象：%s"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:2215
+#: plugins/filebrowser/pluma-file-browser-widget.c:2215
 #, c-format
 msgid "Could not open media: %s"
 msgstr "无法打开介质：%s。"
 
-#: ../plugins/filebrowser/pluma-file-browser-widget.c:2262
+#: plugins/filebrowser/pluma-file-browser-widget.c:2262
 #, c-format
 msgid "Could not mount volume: %s"
 msgstr "无法挂载卷：%s"
 
-#. ex:ts=8:noet:
-#: ../plugins/modelines/modelines.plugin.desktop.in.h:1
+#: plugins/modelines/modelines.plugin.desktop.in:5
 msgid "Modelines"
 msgstr "模式行"
 
-#: ../plugins/modelines/modelines.plugin.desktop.in.h:2
+#: plugins/modelines/modelines.plugin.desktop.in:6
 msgid "Emacs, Kate and Vim-style modelines support for pluma."
 msgstr "pluma 的 Emacs、Kate 和 Vim 风格的 modeline 支持。"
 
-#: ../plugins/pythonconsole/pythonconsole.plugin.desktop.in.h:1
-#: ../plugins/pythonconsole/pythonconsole/__init__.py:55
+#: plugins/pythonconsole/pythonconsole.plugin.desktop.in:6
+#: plugins/pythonconsole/pythonconsole/__init__.py:55
 msgid "Python Console"
 msgstr "Python 控制台"
 
-#: ../plugins/pythonconsole/pythonconsole.plugin.desktop.in.h:2
+#: plugins/pythonconsole/pythonconsole.plugin.desktop.in:7
 msgid "Interactive Python console standing in the bottom panel"
 msgstr "位于底部面板中的交互式 Python 控制台"
 
-#. ex:et:ts=4:
-#: ../plugins/pythonconsole/pythonconsole/config.ui.h:1
+#. Translators: Do NOT translate or transliterate this text (this is an icon
+#. file name)!
+#: plugins/pythonconsole/pythonconsole.plugin.desktop.in:9
+msgid "text-x-python"
+msgstr ""
+
+#: plugins/pythonconsole/pythonconsole/config.ui:20
 msgid "_Error color:"
 msgstr "错误颜色(_E)："
 
-#: ../plugins/pythonconsole/pythonconsole/config.ui.h:2
+#: plugins/pythonconsole/pythonconsole/config.ui:59
 msgid "C_ommand color:"
 msgstr "命令颜色(_O)："
 
-#: ../plugins/pythonconsole/pythonconsole/config.ui.h:3
+#: plugins/pythonconsole/pythonconsole/config.ui:82
 msgid "Use system fixed width font"
 msgstr ""
 
-#: ../plugins/pythonconsole/pythonconsole/config.ui.h:4
+#: plugins/pythonconsole/pythonconsole/config.ui:102
 msgid "Font:"
 msgstr ""
 
-#. ex:ts=4:et:
-#: ../plugins/quickopen/quickopen/popup.py:32
-#: ../plugins/quickopen/quickopen.plugin.desktop.in.h:1
+#: plugins/quickopen/quickopen/popup.py:32
+#: plugins/quickopen/quickopen.plugin.desktop.in:6
 msgid "Quick Open"
 msgstr "快速打开"
 
-#: ../plugins/quickopen/quickopen/windowhelper.py:65
+#: plugins/quickopen/quickopen/windowhelper.py:65
 msgid "Quick open"
 msgstr "快速打开"
 
-#: ../plugins/quickopen/quickopen/windowhelper.py:66
+#: plugins/quickopen/quickopen/windowhelper.py:66
 msgid "Quickly open documents"
 msgstr "快速地打开文档"
 
-#: ../plugins/quickopen/quickopen.plugin.desktop.in.h:2
+#: plugins/quickopen/quickopen.plugin.desktop.in:7
 msgid "Quickly open files"
 msgstr "快速地打开文件"
 
-#. Do the fancy completion dialog
-#: ../plugins/snippets/snippets.plugin.desktop.in.h:1
-#: ../plugins/snippets/snippets/Document.py:51
-#: ../plugins/snippets/snippets/Document.py:189
-#: ../plugins/snippets/snippets/Document.py:618
+#. Translators: Do NOT translate or transliterate this text (this is an icon
+#. file name)!
+#: plugins/quickopen/quickopen.plugin.desktop.in:9
+msgid "document-open"
+msgstr ""
+
+#: plugins/snippets/snippets.plugin.desktop.in:6
+#: plugins/snippets/snippets/Document.py:51
+#: plugins/snippets/snippets/Document.py:189
+#: plugins/snippets/snippets/Document.py:618
 msgid "Snippets"
 msgstr "片断"
 
-#: ../plugins/snippets/snippets.plugin.desktop.in.h:2
+#: plugins/snippets/snippets.plugin.desktop.in:7
 msgid "Insert often-used pieces of text in a fast way"
 msgstr "快速插入最常使用的文本片断"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:1
+#: plugins/snippets/snippets/snippets.ui:40
 msgid "Snippets Manager"
 msgstr "片断管理器"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:2
+#: plugins/snippets/snippets/snippets.ui:144
 msgid "_Snippets:"
 msgstr "片断(_S)："
 
-#: ../plugins/snippets/snippets/snippets.ui.h:3
+#: plugins/snippets/snippets/snippets.ui:165
 msgid "Create new snippet"
 msgstr "创建新片断"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:4
-#: ../plugins/snippets/snippets/Manager.py:792
+#: plugins/snippets/snippets/snippets.ui:186
+#: plugins/snippets/snippets/Manager.py:792
 msgid "Import snippets"
 msgstr "导入片断"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:5
+#: plugins/snippets/snippets/snippets.ui:207
 msgid "Export selected snippets"
 msgstr "导出选中片断"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:6
-#: ../plugins/snippets/snippets/Manager.py:400
+#: plugins/snippets/snippets/snippets.ui:229
+#: plugins/snippets/snippets/Manager.py:400
 msgid "Delete selected snippet"
 msgstr "删除选中的片断"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:8
+#: plugins/snippets/snippets/snippets.ui:335
 msgid "Activation"
 msgstr "激活"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:9
+#: plugins/snippets/snippets/snippets.ui:379
 msgid "_Drop targets:"
 msgstr "拖放目标(_D)："
 
-#: ../plugins/snippets/snippets/snippets.ui.h:10
+#: plugins/snippets/snippets/snippets.ui:392
 msgid "Shortcut key with which the snippet is activated"
 msgstr "此片断的快捷键已经激活"
 
-#: ../plugins/snippets/snippets/snippets.ui.h:11
+#: plugins/snippets/snippets/snippets.ui:411
 msgid "S_hortcut key:"
 msgstr "快捷键(_H)："
 
 #. "tab" here means the tab key, not the notebook tab!
-#: ../plugins/snippets/snippets/snippets.ui.h:13
+#: plugins/snippets/snippets/snippets.ui:424
 msgid "_Tab trigger:"
 msgstr "_Tab 触发器："
 
-#. self['hbox_tab_trigger'].set_spacing(0)
-#: ../plugins/snippets/snippets/snippets.ui.h:14
-#: ../plugins/snippets/snippets/Manager.py:681
+#: plugins/snippets/snippets/snippets.ui:446
+#: plugins/snippets/snippets/Manager.py:681
 msgid "Single word the snippet is activated with after pressing Tab"
 msgstr "按下 tab 键后和片断一起激活的单字"
 
-#: ../plugins/snippets/snippets/WindowHelper.py:72
+#: plugins/snippets/snippets/WindowHelper.py:72
 msgid "Manage _Snippets..."
 msgstr "管理片断(_S)..."
 
-#: ../plugins/snippets/snippets/WindowHelper.py:73
+#: plugins/snippets/snippets/WindowHelper.py:73
 msgid "Manage snippets"
 msgstr "管理片断"
 
-#: ../plugins/snippets/snippets/Manager.py:41
+#: plugins/snippets/snippets/Manager.py:41
 msgid "Snippets archive"
 msgstr "片断存档"
 
-#: ../plugins/snippets/snippets/Manager.py:66
+#: plugins/snippets/snippets/Manager.py:66
 msgid "Add a new snippet..."
 msgstr "添加新片断..."
 
-#: ../plugins/snippets/snippets/Manager.py:117
+#: plugins/snippets/snippets/Manager.py:117
 msgid "Global"
 msgstr "全局"
 
-#: ../plugins/snippets/snippets/Manager.py:397
+#: plugins/snippets/snippets/Manager.py:397
 msgid "Revert selected snippet"
 msgstr "还原选中的片断"
 
-#. self['hbox_tab_trigger'].set_spacing(3)
-#: ../plugins/snippets/snippets/Manager.py:674
+#: plugins/snippets/snippets/Manager.py:674
 msgid ""
 "This is not a valid Tab trigger. Triggers can either contain letters or a "
 "single (non-alphanumeric) character like: {, [, etc."
 msgstr "这不是有效的跳格触发器。触发器必须是包含包含字母或者单个非字母字符，比如 { 或 [ 等等。"
 
-#: ../plugins/snippets/snippets/Manager.py:771
+#: plugins/snippets/snippets/Manager.py:771
 #, python-format
 msgid "The following error occurred while importing: %s"
 msgstr "导入时发生了下列错误：%s"
 
-#: ../plugins/snippets/snippets/Manager.py:778
+#: plugins/snippets/snippets/Manager.py:778
 msgid "Import successfully completed"
 msgstr "导入成功完成"
 
-#: ../plugins/snippets/snippets/Manager.py:798
-#: ../plugins/snippets/snippets/Manager.py:885
-#: ../plugins/snippets/snippets/Manager.py:949
+#: plugins/snippets/snippets/Manager.py:798
+#: plugins/snippets/snippets/Manager.py:885
+#: plugins/snippets/snippets/Manager.py:949
 msgid "All supported archives"
 msgstr "支持的全部存档"
 
-#: ../plugins/snippets/snippets/Manager.py:799
-#: ../plugins/snippets/snippets/Manager.py:886
-#: ../plugins/snippets/snippets/Manager.py:950
+#: plugins/snippets/snippets/Manager.py:799
+#: plugins/snippets/snippets/Manager.py:886
+#: plugins/snippets/snippets/Manager.py:950
 msgid "Gzip compressed archive"
 msgstr "Gzip 压缩的归档"
 
-#: ../plugins/snippets/snippets/Manager.py:800
-#: ../plugins/snippets/snippets/Manager.py:887
-#: ../plugins/snippets/snippets/Manager.py:951
+#: plugins/snippets/snippets/Manager.py:800
+#: plugins/snippets/snippets/Manager.py:887
+#: plugins/snippets/snippets/Manager.py:951
 msgid "Bzip2 compressed archive"
 msgstr "Bzip2 压缩的归档"
 
-#: ../plugins/snippets/snippets/Manager.py:801
+#: plugins/snippets/snippets/Manager.py:801
 msgid "Single snippets file"
 msgstr "单个片断文件"
 
-#: ../plugins/snippets/snippets/Manager.py:802
-#: ../plugins/snippets/snippets/Manager.py:889
-#: ../plugins/snippets/snippets/Manager.py:953
+#: plugins/snippets/snippets/Manager.py:802
+#: plugins/snippets/snippets/Manager.py:889
+#: plugins/snippets/snippets/Manager.py:953
 msgid "All files"
 msgstr "全部文件"
 
-#: ../plugins/snippets/snippets/Manager.py:814
+#: plugins/snippets/snippets/Manager.py:814
 #, python-format
 msgid "The following error occurred while exporting: %s"
 msgstr "导出时发生了下列错误：%s"
 
-#: ../plugins/snippets/snippets/Manager.py:818
+#: plugins/snippets/snippets/Manager.py:818
 msgid "Export successfully completed"
 msgstr "导出成功完成"
 
-#. Ask if system snippets should also be exported
-#: ../plugins/snippets/snippets/Manager.py:858
-#: ../plugins/snippets/snippets/Manager.py:927
+#: plugins/snippets/snippets/Manager.py:858
+#: plugins/snippets/snippets/Manager.py:927
 msgid "Do you want to include selected <b>system</b> snippets in your export?"
 msgstr "您是否想要在导出时包含选中的<b>系统</b>片断？"
 
-#: ../plugins/snippets/snippets/Manager.py:873
-#: ../plugins/snippets/snippets/Manager.py:945
+#: plugins/snippets/snippets/Manager.py:873
+#: plugins/snippets/snippets/Manager.py:945
 msgid "There are no snippets selected to be exported"
 msgstr "没有选中要导出的片断"
 
-#: ../plugins/snippets/snippets/Manager.py:878
-#: ../plugins/snippets/snippets/Manager.py:917
+#: plugins/snippets/snippets/Manager.py:878
+#: plugins/snippets/snippets/Manager.py:917
 msgid "Export snippets"
 msgstr "导出片断"
 
-#: ../plugins/snippets/snippets/Manager.py:1058
+#: plugins/snippets/snippets/Manager.py:1058
 msgid "Type a new shortcut, or press Backspace to clear"
 msgstr "输入新快捷键或按退格键 (Backspace) 清除"
 
-#: ../plugins/snippets/snippets/Manager.py:1060
+#: plugins/snippets/snippets/Manager.py:1060
 msgid "Type a new shortcut"
 msgstr "输入新快捷键"
 
-#: ../plugins/snippets/snippets/Exporter.py:65
+#: plugins/snippets/snippets/Exporter.py:65
 #, python-format
 msgid "The archive \"%s\" could not be created"
 msgstr "无法创建归档“%s”"
 
-#: ../plugins/snippets/snippets/Exporter.py:82
+#: plugins/snippets/snippets/Exporter.py:82
 #, python-format
 msgid "Target directory \"%s\" does not exist"
 msgstr "目标目录“%s”不存在"
 
-#: ../plugins/snippets/snippets/Exporter.py:85
+#: plugins/snippets/snippets/Exporter.py:85
 #, python-format
 msgid "Target directory \"%s\" is not a valid directory"
 msgstr "目标目录“%s”不是有效的目录"
 
-#: ../plugins/snippets/snippets/Importer.py:29
-#: ../plugins/snippets/snippets/Importer.py:83
+#: plugins/snippets/snippets/Importer.py:29
+#: plugins/snippets/snippets/Importer.py:83
 #, python-format
 msgid "File \"%s\" does not exist"
 msgstr "文件“%s”不存在"
 
-#: ../plugins/snippets/snippets/Importer.py:32
+#: plugins/snippets/snippets/Importer.py:32
 #, python-format
 msgid "File \"%s\" is not a valid snippets file"
 msgstr "文件“%s”不是有效的片断文件"
 
-#: ../plugins/snippets/snippets/Importer.py:42
+#: plugins/snippets/snippets/Importer.py:42
 #, python-format
 msgid "Imported file \"%s\" is not a valid snippets file"
 msgstr "导入的文件“%s”不是有效的片断文件"
 
-#: ../plugins/snippets/snippets/Importer.py:52
+#: plugins/snippets/snippets/Importer.py:52
 #, python-format
 msgid "The archive \"%s\" could not be extracted"
 msgstr "无法解压缩归档 “%s”"
 
-#: ../plugins/snippets/snippets/Importer.py:70
+#: plugins/snippets/snippets/Importer.py:70
 #, python-format
 msgid "The following files could not be imported: %s"
 msgstr "无法导入下列文件：%s"
 
-#: ../plugins/snippets/snippets/Importer.py:86
-#: ../plugins/snippets/snippets/Importer.py:99
+#: plugins/snippets/snippets/Importer.py:86
+#: plugins/snippets/snippets/Importer.py:99
 #, python-format
 msgid "File \"%s\" is not a valid snippets archive"
 msgstr "文件“%s”不是有效的片断归档文件"
 
-#: ../plugins/snippets/snippets/Placeholder.py:601
+#: plugins/snippets/snippets/Placeholder.py:601
 #, python-format
 msgid ""
 "Execution of the Python command (%s) exceeds the maximum time, execution "
 "aborted."
 msgstr "执行 Python 命令(%s)超过最长时间，执行被中止。"
 
-#: ../plugins/snippets/snippets/Placeholder.py:609
+#: plugins/snippets/snippets/Placeholder.py:609
 #, python-format
 msgid "Execution of the Python command (%s) failed: %s"
 msgstr "执行 Python 命令(%s)失败：%s"
 
-#: ../plugins/sort/pluma-sort-plugin.c:93
+#: plugins/sort/pluma-sort-plugin.c:93
 msgid "S_ort..."
 msgstr "排序(_O)..."
 
-#: ../plugins/sort/pluma-sort-plugin.c:95
+#: plugins/sort/pluma-sort-plugin.c:95
 msgid "Sort the current document or selection"
 msgstr "将当前文档或选中的文字排序"
 
-#: ../plugins/sort/sort.plugin.desktop.in.h:1 ../plugins/sort/sort.ui.h:1
+#: plugins/sort/sort.plugin.desktop.in:5 plugins/sort/sort.ui:29
 msgid "Sort"
 msgstr "排序"
 
-#: ../plugins/sort/sort.plugin.desktop.in.h:2
+#: plugins/sort/sort.plugin.desktop.in:6
 msgid "Sorts a document or selected text."
 msgstr "将文档或选中的文字排序。"
 
-#: ../plugins/sort/sort.ui.h:3
+#. Translators: Do NOT translate or transliterate this text (this is an icon
+#. file name)!
+#: plugins/sort/sort.plugin.desktop.in:8
+msgid "view-sort-ascending"
+msgstr ""
+
+#: plugins/sort/sort.ui:61
 msgid "_Sort"
 msgstr "排序(_S)"
 
-#: ../plugins/sort/sort.ui.h:5
+#: plugins/sort/sort.ui:114
 msgid "_Reverse order"
 msgstr "逆序排序(_R)"
 
-#: ../plugins/sort/sort.ui.h:6
+#: plugins/sort/sort.ui:129
 msgid "R_emove duplicates"
 msgstr "删除重复内容(_E)"
 
-#: ../plugins/sort/sort.ui.h:7
+#: plugins/sort/sort.ui:144
 msgid "_Ignore case"
 msgstr "忽略大小写(_I)"
 
-#: ../plugins/sort/sort.ui.h:8
+#: plugins/sort/sort.ui:167
 msgid "S_tart at column:"
 msgstr "排序开始于列(_T)："
 
-#: ../plugins/sort/sort.ui.h:9
+#: plugins/sort/sort.ui:228
 msgid "You cannot undo a sort operation"
 msgstr "您无法撤消排序操作"
 
-#: ../plugins/spell/org.mate.pluma.plugins.spell.gschema.xml.in.h:1
+#: plugins/spell/org.mate.pluma.plugins.spell.gschema.xml.in:11
 msgid "Autocheck Type"
 msgstr "自动检查类型"
 
@@ -3442,47 +3470,46 @@ msgstr "自动检查类型"
 #. Translators: Displayed in the "Check Spelling" dialog if there are no
 #. suggestions
 #. * for the current misspelled word
-#: ../plugins/spell/pluma-automatic-spell-checker.c:420
-#: ../plugins/spell/pluma-spell-checker-dialog.c:458
+#: plugins/spell/pluma-automatic-spell-checker.c:420
+#: plugins/spell/pluma-spell-checker-dialog.c:458
 msgid "(no suggested words)"
 msgstr "(没有建议的单词)"
 
-#: ../plugins/spell/pluma-automatic-spell-checker.c:444
+#: plugins/spell/pluma-automatic-spell-checker.c:444
 msgid "_More..."
 msgstr "更多(_M)..."
 
-#. Ignore all
-#: ../plugins/spell/pluma-automatic-spell-checker.c:499
+#: plugins/spell/pluma-automatic-spell-checker.c:499
 msgid "_Ignore All"
 msgstr "全部忽略(_I)"
 
-#: ../plugins/spell/pluma-automatic-spell-checker.c:553
+#: plugins/spell/pluma-automatic-spell-checker.c:553
 msgid "_Spelling Suggestions..."
 msgstr "拼写建议(_S)..."
 
-#: ../plugins/spell/pluma-spell-checker-dialog.c:270
+#: plugins/spell/pluma-spell-checker-dialog.c:270
 msgid "Check Spelling"
 msgstr "检查拼写"
 
-#: ../plugins/spell/pluma-spell-checker-dialog.c:281
+#: plugins/spell/pluma-spell-checker-dialog.c:281
 msgid "Suggestions"
 msgstr "建议"
 
 #. Translators: Displayed in the "Check Spelling" dialog if the current word
 #. isn't misspelled
-#: ../plugins/spell/pluma-spell-checker-dialog.c:565
+#: plugins/spell/pluma-spell-checker-dialog.c:565
 msgid "(correct spelling)"
 msgstr "(正确的拼写)"
 
-#: ../plugins/spell/pluma-spell-checker-dialog.c:712
+#: plugins/spell/pluma-spell-checker-dialog.c:712
 msgid "Completed spell checking"
 msgstr "完成拼写检查"
 
 #. Translators: the first %s is the language name, and
 #. * the second %s is the locale name. Example:
 #. * "French (France)"
-#: ../plugins/spell/pluma-spell-checker-language.c:285
-#: ../plugins/spell/pluma-spell-checker-language.c:291
+#: plugins/spell/pluma-spell-checker-language.c:285
+#: plugins/spell/pluma-spell-checker-language.c:291
 #, c-format
 msgctxt "language"
 msgid "%s (%s)"
@@ -3490,7 +3517,7 @@ msgstr "%s (%s)"
 
 #. Translators: this refers to an unknown language code
 #. * (one which isn't in our built-in list).
-#: ../plugins/spell/pluma-spell-checker-language.c:300
+#: plugins/spell/pluma-spell-checker-language.c:300
 #, c-format
 msgctxt "language"
 msgid "Unknown (%s)"
@@ -3498,1780 +3525,2869 @@ msgstr "未知 (%s)"
 
 #. Translators: this refers the Default language used by the
 #. * spell checker
-#: ../plugins/spell/pluma-spell-checker-language.c:406
+#: plugins/spell/pluma-spell-checker-language.c:406
 msgctxt "language"
 msgid "Default"
 msgstr "默认"
 
-#: ../plugins/spell/pluma-spell-language-dialog.c:136
-#: ../plugins/spell/languages-dialog.ui.h:1
+#: plugins/spell/pluma-spell-language-dialog.c:136
+#: plugins/spell/languages-dialog.ui:24
 msgid "Set language"
 msgstr "设置语言"
 
-#: ../plugins/spell/pluma-spell-language-dialog.c:186
+#: plugins/spell/pluma-spell-language-dialog.c:186
 msgid "Languages"
 msgstr "语言"
 
-#: ../plugins/spell/pluma-spell-plugin.c:97
+#: plugins/spell/pluma-spell-plugin.c:97
 msgid "_Check Spelling..."
 msgstr "拼写检查(_C)..."
 
-#: ../plugins/spell/pluma-spell-plugin.c:99
+#: plugins/spell/pluma-spell-plugin.c:99
 msgid "Check the current document for incorrect spelling"
 msgstr "检查当前文档的拼写错误"
 
-#: ../plugins/spell/pluma-spell-plugin.c:105
+#: plugins/spell/pluma-spell-plugin.c:105
 msgid "Set _Language..."
 msgstr "设置语言(_L)..."
 
-#: ../plugins/spell/pluma-spell-plugin.c:107
+#: plugins/spell/pluma-spell-plugin.c:107
 msgid "Set the language of the current document"
 msgstr "设置当前文档的语言"
 
-#: ../plugins/spell/pluma-spell-plugin.c:116
+#: plugins/spell/pluma-spell-plugin.c:116
 msgid "_Autocheck Spelling"
 msgstr "自动检查拼写(_A)"
 
-#: ../plugins/spell/pluma-spell-plugin.c:118
+#: plugins/spell/pluma-spell-plugin.c:118
 msgid "Automatically spell-check the current document"
 msgstr "自动检查当前文档的拼写"
 
-#: ../plugins/spell/pluma-spell-plugin.c:918
+#: plugins/spell/pluma-spell-plugin.c:918
 msgid "The document is empty."
 msgstr "文档为空。"
 
-#: ../plugins/spell/pluma-spell-plugin.c:943
+#: plugins/spell/pluma-spell-plugin.c:943
 msgid "No misspelled words"
 msgstr "没有拼错的单词"
 
-#: ../plugins/spell/languages-dialog.ui.h:5
+#: plugins/spell/languages-dialog.ui:105
 msgid "Select the _language of the current document."
 msgstr "选择当前文档的语言(_L)。"
 
-#: ../plugins/spell/spell-checker.ui.h:1
+#: plugins/spell/spell-checker.ui:33
 msgid "Check spelling"
 msgstr "拼写检查"
 
-#: ../plugins/spell/spell-checker.ui.h:2
+#: plugins/spell/spell-checker.ui:52
 msgid "Misspelled word:"
 msgstr "拼错的单词："
 
-#: ../plugins/spell/spell-checker.ui.h:3
+#: plugins/spell/spell-checker.ui:66
 msgid "word"
 msgstr "单词"
 
-#: ../plugins/spell/spell-checker.ui.h:4
+#: plugins/spell/spell-checker.ui:84
 msgid "Change _to:"
 msgstr "更改为(_T)："
 
-#: ../plugins/spell/spell-checker.ui.h:5
+#: plugins/spell/spell-checker.ui:115
 msgid "Check _Word"
 msgstr "检查单词(_W)"
 
-#: ../plugins/spell/spell-checker.ui.h:6
+#: plugins/spell/spell-checker.ui:151
 msgid "_Suggestions:"
 msgstr "建议(_S)："
 
-#: ../plugins/spell/spell-checker.ui.h:7
+#: plugins/spell/spell-checker.ui:202
 msgid "_Ignore"
 msgstr "忽略(_I)"
 
-#: ../plugins/spell/spell-checker.ui.h:8
+#: plugins/spell/spell-checker.ui:216
 msgid "Cha_nge"
 msgstr "更改(_N)"
 
-#: ../plugins/spell/spell-checker.ui.h:9
+#: plugins/spell/spell-checker.ui:230
 msgid "Ignore _All"
 msgstr "全部忽略(_A)"
 
-#: ../plugins/spell/spell-checker.ui.h:10
+#: plugins/spell/spell-checker.ui:244
 msgid "Change A_ll"
 msgstr "全部更改(_L)"
 
-#: ../plugins/spell/spell-checker.ui.h:11
+#: plugins/spell/spell-checker.ui:273
 msgid "User dictionary:"
 msgstr "用户字典："
 
-#: ../plugins/spell/spell-checker.ui.h:12
+#: plugins/spell/spell-checker.ui:292
 msgid "Add w_ord"
 msgstr "添加单词(_O)"
 
-#: ../plugins/spell/spell-checker.ui.h:13
+#: plugins/spell/spell-checker.ui:334
 msgid "Language:"
 msgstr "语言："
 
-#: ../plugins/spell/spell-checker.ui.h:14
+#: plugins/spell/spell-checker.ui:348
 msgid "Language"
 msgstr "语言"
 
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:1
+#: plugins/spell/pluma-spell-setup-dialog.ui:23
 msgid "_Configure Spell Checker plugin..."
 msgstr "配置拼写检查器插件(_C)…"
 
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:5
+#: plugins/spell/pluma-spell-setup-dialog.ui:103
 msgid "Autocheck spelling on document load..."
 msgstr "载入文档时自动检查拼写…"
 
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:6
+#: plugins/spell/pluma-spell-setup-dialog.ui:116
 msgid "_Never autocheck"
 msgstr "从不自动检查(_N)"
 
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:7
+#: plugins/spell/pluma-spell-setup-dialog.ui:133
 msgid "_Remember autocheck by document"
 msgstr "根据文档记住自动检查设置(_R)"
 
-#: ../plugins/spell/pluma-spell-setup-dialog.ui.h:8
+#: plugins/spell/pluma-spell-setup-dialog.ui:151
 msgid "_Always autocheck"
 msgstr "总是自动检查(_A)"
 
-#: ../plugins/spell/spell.plugin.desktop.in.h:1
+#: plugins/spell/spell.plugin.desktop.in:5
 msgid "Spell Checker"
 msgstr "拼写检查器"
 
-#: ../plugins/spell/spell.plugin.desktop.in.h:2
+#: plugins/spell/spell.plugin.desktop.in:6
 msgid "Checks the spelling of the current document."
 msgstr "检查当前文档的拼写。"
 
-#: ../plugins/taglist/pluma-taglist-plugin.c:124
-#: ../plugins/taglist/pluma-taglist-plugin-panel.c:707
-#: ../plugins/taglist/pluma-taglist-plugin-panel.c:722
+#. Translators: Do NOT translate or transliterate this text (this is an icon
+#. file name)!
+#: plugins/spell/spell.plugin.desktop.in:8
+msgid "tools-check-spelling"
+msgstr ""
+
+#: plugins/taglist/pluma-taglist-plugin.c:124
+#: plugins/taglist/pluma-taglist-plugin-panel.c:707
+#: plugins/taglist/pluma-taglist-plugin-panel.c:722
 msgid "Tags"
 msgstr "标签"
 
-#: ../plugins/taglist/pluma-taglist-plugin-panel.c:611
+#: plugins/taglist/pluma-taglist-plugin-panel.c:611
 msgid "Select the group of tags you want to use"
 msgstr "选择您想使用的标记组"
 
-#: ../plugins/taglist/pluma-taglist-plugin-panel.c:630
+#: plugins/taglist/pluma-taglist-plugin-panel.c:630
 msgid "_Preview"
 msgstr "预览(_P)"
 
-#: ../plugins/taglist/pluma-taglist-plugin-panel.c:704
+#: plugins/taglist/pluma-taglist-plugin-panel.c:704
 msgid "Available Tag Lists"
 msgstr "可用的标记列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:1
+#: plugins/taglist/HTML.tags.xml.in:3
 msgid "XHTML 1.0 - Tags"
 msgstr "XHTML 1.0 - 标记"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:2
+#: plugins/taglist/HTML.tags.xml.in:5 plugins/taglist/HTML.tags.xml.in:1132
 msgid "Abbreviated form"
 msgstr "缩写格式"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:3
+#: plugins/taglist/HTML.tags.xml.in:10 plugins/taglist/HTML.tags.xml.in:1137
 msgid "Abbreviation"
 msgstr "缩写"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:4
+#: plugins/taglist/HTML.tags.xml.in:15 plugins/taglist/HTML.tags.xml.in:1145
 msgid "Accessibility key character"
 msgstr "辅助字符"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:5
+#: plugins/taglist/HTML.tags.xml.in:20 plugins/taglist/HTML.tags.xml.in:1149
 msgid "Acronym"
 msgstr "缩写"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:6
+#: plugins/taglist/HTML.tags.xml.in:25 plugins/taglist/HTML.tags.xml.in:1154
 msgid "Align"
 msgstr "对齐"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:7
+#: plugins/taglist/HTML.tags.xml.in:30 plugins/taglist/HTML.tags.xml.in:1158
 msgid "Alignment character"
 msgstr "对齐字符"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:8
+#: plugins/taglist/HTML.tags.xml.in:35 plugins/taglist/HTML.tags.xml.in:1162
 msgid "Alternative"
 msgstr "替代"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:9
+#: plugins/taglist/HTML.tags.xml.in:40 plugins/taglist/HTML.tags.xml.in:1166
 msgid "Anchor URI"
 msgstr "锚 URI"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:10
+#: plugins/taglist/HTML.tags.xml.in:45 plugins/taglist/HTML.tags.xml.in:1171
 msgid "Anchor"
 msgstr "锚点"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:12
+#: plugins/taglist/HTML.tags.xml.in:51
 msgid "Applet class file code (deprecated)"
 msgstr "小程序类文件代码(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:13
+#: plugins/taglist/HTML.tags.xml.in:56 plugins/taglist/HTML.tags.xml.in:1184
 msgid "Associated information"
 msgstr "关联的新ch"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:14
+#: plugins/taglist/HTML.tags.xml.in:61 plugins/taglist/HTML.tags.xml.in:1188
 msgid "Author info"
 msgstr "作者信息"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:15
+#: plugins/taglist/HTML.tags.xml.in:66 plugins/taglist/HTML.tags.xml.in:1193
 msgid "Axis related headers"
 msgstr "与轴相关的页眉"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:17
+#: plugins/taglist/HTML.tags.xml.in:72
 msgid "Background color (deprecated)"
 msgstr "背景颜色(已废弃)"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:19
+#: plugins/taglist/HTML.tags.xml.in:78
 msgid "Background texture tile (deprecated)"
 msgstr "背景纹理平铺(已废弃)"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:21
+#: plugins/taglist/HTML.tags.xml.in:84
 msgid "Base font (deprecated)"
 msgstr "基本字体(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:22
+#: plugins/taglist/HTML.tags.xml.in:88 plugins/taglist/HTML.tags.xml.in:1209
 msgid "Base URI"
 msgstr "基 URI"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:23
+#: plugins/taglist/HTML.tags.xml.in:93 plugins/taglist/HTML.tags.xml.in:1213
 msgid "Bold"
 msgstr "粗体"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:25
+#: plugins/taglist/HTML.tags.xml.in:99
 msgid "Border (deprecated)"
 msgstr "边框(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:26
+#: plugins/taglist/HTML.tags.xml.in:104 plugins/taglist/HTML.tags.xml.in:1226
 msgid "Cell rowspan"
 msgstr "单元格跨行"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:28
+#: plugins/taglist/HTML.tags.xml.in:110
 msgid "Center (deprecated)"
 msgstr "居中(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:29
+#: plugins/taglist/HTML.tags.xml.in:115 plugins/taglist/HTML.tags.xml.in:1235
 msgid "Character encoding of linked resource"
 msgstr "链接资源的字符编码"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:30
+#: plugins/taglist/HTML.tags.xml.in:120
 msgid "Checked state"
 msgstr "已选中状态"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:31
+#: plugins/taglist/HTML.tags.xml.in:124 plugins/taglist/HTML.tags.xml.in:1243
 msgid "Citation"
 msgstr "引用"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:32
+#: plugins/taglist/HTML.tags.xml.in:129 plugins/taglist/HTML.tags.xml.in:1248
 msgid "Cite reason for change"
 msgstr "更改的引用原因"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:33
+#: plugins/taglist/HTML.tags.xml.in:134 plugins/taglist/HTML.tags.xml.in:1252
 msgid "Class implementation ID"
 msgstr "类实现 ID"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:34
+#: plugins/taglist/HTML.tags.xml.in:139 plugins/taglist/HTML.tags.xml.in:1256
 msgid "Class list"
 msgstr "类列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:35
+#: plugins/taglist/HTML.tags.xml.in:144 plugins/taglist/HTML.tags.xml.in:1260
 msgid "Clear text flow control"
 msgstr "清除文本流控制"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:36
+#: plugins/taglist/HTML.tags.xml.in:149 plugins/taglist/HTML.tags.xml.in:1264
 msgid "Code content type"
 msgstr "代码内容类型"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:38
+#: plugins/taglist/HTML.tags.xml.in:155
 msgid "Color of selected links (deprecated)"
 msgstr "选中链接的颜色(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:39
+#: plugins/taglist/HTML.tags.xml.in:160 plugins/taglist/HTML.tags.xml.in:1272
 msgid "Column span"
 msgstr "跨列"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:40
+#: plugins/taglist/HTML.tags.xml.in:165 plugins/taglist/HTML.tags.xml.in:1276
 msgid "Columns"
 msgstr "列"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:41
+#: plugins/taglist/HTML.tags.xml.in:170 plugins/taglist/HTML.tags.xml.in:1280
+#: plugins/taglist/HTML.tags.xml.in:1285
 msgid "Comment"
 msgstr "评论"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:42
+#: plugins/taglist/HTML.tags.xml.in:175 plugins/taglist/HTML.tags.xml.in:1290
 msgid "Computer code fragment"
 msgstr "计算机代码段"
 
-#. The "type" attribute is deprecated for the "ol" tag only,
-#. since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:45
+#: plugins/taglist/HTML.tags.xml.in:182
 msgid "Content type (deprecated)"
 msgstr "内容类型(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:46
+#: plugins/taglist/HTML.tags.xml.in:187 plugins/taglist/HTML.tags.xml.in:1303
 msgid "Coordinates"
 msgstr "坐标"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:47
+#: plugins/taglist/HTML.tags.xml.in:192 plugins/taglist/HTML.tags.xml.in:1307
 msgid "Date and time of change"
 msgstr "更改日期和时间"
 
-#. NOTE: used in "object" tag
-#: ../plugins/taglist/HTML.tags.xml.in.h:49
+#: plugins/taglist/HTML.tags.xml.in:197 plugins/taglist/HTML.tags.xml.in:1311
 msgid "Declare flag"
 msgstr "声明标志"
 
-#. Translators: DEFER is an optional attribute of the <script> tag.
-#. It indicates that the script is not going to generate any document
-#. content. The browser can continue parsing and drawing the page.
-#: ../plugins/taglist/HTML.tags.xml.in.h:53
+#: plugins/taglist/HTML.tags.xml.in:204 plugins/taglist/HTML.tags.xml.in:1318
 msgid "Defer attribute"
 msgstr "延期属性"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:54
+#: plugins/taglist/HTML.tags.xml.in:208 plugins/taglist/HTML.tags.xml.in:1322
 msgid "Definition description"
 msgstr "定义描述"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:55
+#: plugins/taglist/HTML.tags.xml.in:213 plugins/taglist/HTML.tags.xml.in:1327
 msgid "Definition list"
 msgstr "定义列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:56
+#: plugins/taglist/HTML.tags.xml.in:218 plugins/taglist/HTML.tags.xml.in:1332
 msgid "Definition term"
 msgstr "定义条款"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:57
+#: plugins/taglist/HTML.tags.xml.in:223 plugins/taglist/HTML.tags.xml.in:1337
 msgid "Deleted text"
 msgstr "删除的文本"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:58
+#: plugins/taglist/HTML.tags.xml.in:228 plugins/taglist/HTML.tags.xml.in:1346
 msgid "Directionality"
 msgstr "方向性"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:60
+#: plugins/taglist/HTML.tags.xml.in:234
 msgid "Directionality (deprecated)"
 msgstr "方向性(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:61
+#: plugins/taglist/HTML.tags.xml.in:239 plugins/taglist/HTML.tags.xml.in:1355
 msgid "Disabled"
 msgstr "禁用"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:62
+#: plugins/taglist/HTML.tags.xml.in:243 plugins/taglist/HTML.tags.xml.in:1359
 msgid "DIV container"
 msgstr "DIV 容器"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:63
+#: plugins/taglist/HTML.tags.xml.in:248 plugins/taglist/HTML.tags.xml.in:1364
 msgid "DIV Style container"
 msgstr "DIV 样式容器"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:64
+#: plugins/taglist/HTML.tags.xml.in:253 plugins/taglist/HTML.tags.xml.in:1369
 msgid "Document base"
 msgstr "文档基础"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:65
+#: plugins/taglist/HTML.tags.xml.in:258 plugins/taglist/HTML.tags.xml.in:1373
 msgid "Document body"
 msgstr "文档主体"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:66
+#: plugins/taglist/HTML.tags.xml.in:263 plugins/taglist/HTML.tags.xml.in:1378
 msgid "Document head"
 msgstr "文档头"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:67
+#: plugins/taglist/HTML.tags.xml.in:268 plugins/taglist/HTML.tags.xml.in:1383
 msgid "Element ID"
 msgstr "元素 ID"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:68
+#: plugins/taglist/HTML.tags.xml.in:273 plugins/taglist/HTML.tags.xml.in:1387
 msgid "Document title"
 msgstr "文档标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:69
+#: plugins/taglist/HTML.tags.xml.in:278 plugins/taglist/HTML.tags.xml.in:1392
 msgid "Document type"
 msgstr "文档类型"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:70
-#: ../plugins/taglist/Latex.tags.xml.in.h:72
+#: plugins/taglist/HTML.tags.xml.in:282 plugins/taglist/HTML.tags.xml.in:1405
+#: plugins/taglist/Latex.tags.xml.in:328
 msgid "Emphasis"
 msgstr "强调"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:71
+#: plugins/taglist/HTML.tags.xml.in:287 plugins/taglist/HTML.tags.xml.in:1410
 msgid "Encode type"
 msgstr "编码类型"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:73
+#: plugins/taglist/HTML.tags.xml.in:293
 msgid "Font face (deprecated)"
 msgstr "字体族(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:74
+#: plugins/taglist/HTML.tags.xml.in:298 plugins/taglist/HTML.tags.xml.in:1423
 msgid "For label"
 msgstr "For 标签"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:75
+#: plugins/taglist/HTML.tags.xml.in:303 plugins/taglist/HTML.tags.xml.in:1427
 msgid "Forced line break"
 msgstr "强制换行"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:76
+#: plugins/taglist/HTML.tags.xml.in:307 plugins/taglist/HTML.tags.xml.in:1431
 msgid "Form action handler"
 msgstr "表单动作处理器"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:77
+#: plugins/taglist/HTML.tags.xml.in:312 plugins/taglist/HTML.tags.xml.in:1435
 msgid "Form control group"
 msgstr "表单控件组"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:78
+#: plugins/taglist/HTML.tags.xml.in:317 plugins/taglist/HTML.tags.xml.in:1440
 msgid "Form field label text"
 msgstr "表单域标签文字"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:79
+#: plugins/taglist/HTML.tags.xml.in:322 plugins/taglist/HTML.tags.xml.in:1445
 msgid "Form input type"
 msgstr "表单输入类型"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:80
+#: plugins/taglist/HTML.tags.xml.in:327 plugins/taglist/HTML.tags.xml.in:1449
 msgid "Form input"
 msgstr "表单输入"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:81
+#: plugins/taglist/HTML.tags.xml.in:331 plugins/taglist/HTML.tags.xml.in:336
+#: plugins/taglist/HTML.tags.xml.in:1453 plugins/taglist/HTML.tags.xml.in:1457
 msgid "Form method"
 msgstr "表单方式"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:82
+#: plugins/taglist/HTML.tags.xml.in:341 plugins/taglist/HTML.tags.xml.in:1461
 msgid "Form"
 msgstr "表单"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:83
+#: plugins/taglist/HTML.tags.xml.in:346 plugins/taglist/HTML.tags.xml.in:1466
 msgid "Forward link"
 msgstr "转发链接"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:84
+#: plugins/taglist/HTML.tags.xml.in:351 plugins/taglist/HTML.tags.xml.in:1470
 msgid "Frame render parts"
 msgstr "边框渲染部件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:85
+#: plugins/taglist/HTML.tags.xml.in:356 plugins/taglist/HTML.tags.xml.in:1474
 msgid "Frame source"
 msgstr "框架源"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:86
+#: plugins/taglist/HTML.tags.xml.in:361 plugins/taglist/HTML.tags.xml.in:1478
 msgid "Frame target"
 msgstr "框架目标"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:87
+#: plugins/taglist/HTML.tags.xml.in:366 plugins/taglist/HTML.tags.xml.in:1482
 msgid "Frame"
 msgstr "框架"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:88
+#: plugins/taglist/HTML.tags.xml.in:371
 msgid "Frame border"
 msgstr "框架边框"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:89
+#: plugins/taglist/HTML.tags.xml.in:376 plugins/taglist/HTML.tags.xml.in:1490
 msgid "Frameset columns"
 msgstr "框架集列"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:90
+#: plugins/taglist/HTML.tags.xml.in:381 plugins/taglist/HTML.tags.xml.in:1495
 msgid "Frameset rows"
 msgstr "框架集行"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:91
+#: plugins/taglist/HTML.tags.xml.in:386 plugins/taglist/HTML.tags.xml.in:1500
 msgid "Frameset"
 msgstr "框架集"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:92
+#: plugins/taglist/HTML.tags.xml.in:391
 msgid "Frame spacing"
 msgstr "框架间距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:93
+#: plugins/taglist/HTML.tags.xml.in:396 plugins/taglist/HTML.tags.xml.in:1509
 msgid "Generic embedded object"
 msgstr "通用嵌入对象"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:94
+#: plugins/taglist/HTML.tags.xml.in:401 plugins/taglist/HTML.tags.xml.in:1513
 msgid "Generic metainformation"
 msgstr "通用元信息"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:95
+#: plugins/taglist/HTML.tags.xml.in:406 plugins/taglist/HTML.tags.xml.in:1517
 msgid "Generic span"
 msgstr "通用 span"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:96
+#: plugins/taglist/HTML.tags.xml.in:411 plugins/taglist/HTML.tags.xml.in:1522
 msgid "Header cell IDs"
 msgstr "表头单元格 ID"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:97
+#: plugins/taglist/HTML.tags.xml.in:416 plugins/taglist/HTML.tags.xml.in:1526
 msgid "Heading 1"
 msgstr "一级标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:98
+#: plugins/taglist/HTML.tags.xml.in:421 plugins/taglist/HTML.tags.xml.in:1531
 msgid "Heading 2"
 msgstr "二级标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:99
+#: plugins/taglist/HTML.tags.xml.in:426 plugins/taglist/HTML.tags.xml.in:1536
 msgid "Heading 3"
 msgstr "三级标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:100
+#: plugins/taglist/HTML.tags.xml.in:431 plugins/taglist/HTML.tags.xml.in:1541
 msgid "Heading 4"
 msgstr "四级标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:101
+#: plugins/taglist/HTML.tags.xml.in:436 plugins/taglist/HTML.tags.xml.in:1546
 msgid "Heading 5"
 msgstr "五级标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:102
+#: plugins/taglist/HTML.tags.xml.in:441 plugins/taglist/HTML.tags.xml.in:1551
 msgid "Heading 6"
 msgstr "六级标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:103
+#: plugins/taglist/HTML.tags.xml.in:446 plugins/taglist/HTML.tags.xml.in:1561
 msgid "Height"
 msgstr "高度"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:104
+#: plugins/taglist/HTML.tags.xml.in:450 plugins/taglist/HTML.tags.xml.in:1565
 msgid "Horizontal rule"
 msgstr "水平线"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:106
+#: plugins/taglist/HTML.tags.xml.in:455
 msgid "Horizontal space (deprecated)"
 msgstr "水平间距(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:107
+#: plugins/taglist/HTML.tags.xml.in:460 plugins/taglist/HTML.tags.xml.in:1573
 msgid "HREF URI"
 msgstr "HREF URI"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:108
+#: plugins/taglist/HTML.tags.xml.in:465 plugins/taglist/HTML.tags.xml.in:1577
 msgid "HTML root element"
 msgstr "HTML 根元素"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:109
+#: plugins/taglist/HTML.tags.xml.in:470 plugins/taglist/HTML.tags.xml.in:1582
 msgid "HTTP header name"
 msgstr "HTTP 头名称"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:110
+#: plugins/taglist/HTML.tags.xml.in:475 plugins/taglist/HTML.tags.xml.in:1586
 msgid "I18N BiDi override"
 msgstr "I18N 双向文字覆盖"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:111
+#: plugins/taglist/HTML.tags.xml.in:480 plugins/taglist/HTML.tags.xml.in:1591
 msgid "Image map area"
 msgstr "图像映射区域"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:112
+#: plugins/taglist/HTML.tags.xml.in:485 plugins/taglist/HTML.tags.xml.in:1595
 msgid "Image map name"
 msgstr "图像映射名称"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:113
+#: plugins/taglist/HTML.tags.xml.in:490 plugins/taglist/HTML.tags.xml.in:1600
 msgid "Image map"
 msgstr "图像映射"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:114
+#: plugins/taglist/HTML.tags.xml.in:495 plugins/taglist/HTML.tags.xml.in:1609
 msgid "Image"
 msgstr "图像"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:115
+#: plugins/taglist/HTML.tags.xml.in:500 plugins/taglist/HTML.tags.xml.in:1613
 msgid "Inline frame"
 msgstr "内嵌框架"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:116
+#: plugins/taglist/HTML.tags.xml.in:505 plugins/taglist/HTML.tags.xml.in:1623
 msgid "Inserted text"
 msgstr "插入的文字"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:117
+#: plugins/taglist/HTML.tags.xml.in:510 plugins/taglist/HTML.tags.xml.in:1628
 msgid "Instance definition"
 msgstr "实例定义"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:118
+#: plugins/taglist/HTML.tags.xml.in:515 plugins/taglist/HTML.tags.xml.in:1633
 msgid "Italic text"
 msgstr "斜体文字"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:120
+#: plugins/taglist/HTML.tags.xml.in:521
 msgid "Java applet (deprecated)"
 msgstr "Java 小程序(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:121
+#: plugins/taglist/HTML.tags.xml.in:526 plugins/taglist/HTML.tags.xml.in:1643
 msgid "Label"
 msgstr "标签"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:122
+#: plugins/taglist/HTML.tags.xml.in:531 plugins/taglist/HTML.tags.xml.in:536
+#: plugins/taglist/HTML.tags.xml.in:1647 plugins/taglist/HTML.tags.xml.in:1651
 msgid "Language code"
 msgstr "语言代码"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:123
+#: plugins/taglist/HTML.tags.xml.in:541 plugins/taglist/HTML.tags.xml.in:1655
 msgid "Large text style"
 msgstr "大文本样式"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:125
+#: plugins/taglist/HTML.tags.xml.in:547
 msgid "Link color (deprecated)"
 msgstr "链接颜色(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:126
+#: plugins/taglist/HTML.tags.xml.in:552 plugins/taglist/HTML.tags.xml.in:1668
 msgid "List item"
 msgstr "列表项目"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:127
+#: plugins/taglist/HTML.tags.xml.in:557 plugins/taglist/HTML.tags.xml.in:1673
 msgid "List of MIME types for file upload"
 msgstr "列出上传文件的 MIME 类型"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:128
+#: plugins/taglist/HTML.tags.xml.in:562 plugins/taglist/HTML.tags.xml.in:1677
 msgid "List of supported character sets"
 msgstr "列出可接受的字符集"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:129
+#: plugins/taglist/HTML.tags.xml.in:567 plugins/taglist/HTML.tags.xml.in:1686
 msgid "Local change to font"
 msgstr "字体的本地更改"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:130
+#: plugins/taglist/HTML.tags.xml.in:572 plugins/taglist/HTML.tags.xml.in:1691
 msgid "Long description link"
 msgstr "长描述链接"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:131
+#: plugins/taglist/HTML.tags.xml.in:577 plugins/taglist/HTML.tags.xml.in:1695
 msgid "Long quotation"
 msgstr "长引用"
 
-#. Supported in XHTML 1.0 Frameset DTD only.
-#: ../plugins/taglist/HTML.tags.xml.in.h:133
+#: plugins/taglist/HTML.tags.xml.in:583 plugins/taglist/HTML.tags.xml.in:1704
 msgid "Margin pixel height"
 msgstr "边距像素高度"
 
-#. Supported in XHTML 1.0 Frameset DTD only.
-#: ../plugins/taglist/HTML.tags.xml.in.h:135
+#: plugins/taglist/HTML.tags.xml.in:589 plugins/taglist/HTML.tags.xml.in:1708
 msgid "Margin pixel width"
 msgstr "边距像素宽度"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:136
+#: plugins/taglist/HTML.tags.xml.in:594 plugins/taglist/HTML.tags.xml.in:1717
 msgid "Maximum length of text field"
 msgstr "文本框的最大长度"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:137
+#: plugins/taglist/HTML.tags.xml.in:599 plugins/taglist/HTML.tags.xml.in:1721
 msgid "Output media"
 msgstr "输出介质"
 
-#. Here I take some liberties: There's no mandatory attributes,
-#. but those are most common, and will likely be used.
-#: ../plugins/taglist/HTML.tags.xml.in.h:140
+#: plugins/taglist/HTML.tags.xml.in:606 plugins/taglist/HTML.tags.xml.in:1725
 msgid "Media-independent link"
 msgstr "独立于媒体的链接"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:142
+#: plugins/taglist/HTML.tags.xml.in:612
 msgid "Menu list (deprecated)"
 msgstr "菜单列表(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:143
+#: plugins/taglist/HTML.tags.xml.in:617 plugins/taglist/HTML.tags.xml.in:1739
 msgid "Multi-line text field"
 msgstr "多行文本框"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:144
+#: plugins/taglist/HTML.tags.xml.in:622 plugins/taglist/HTML.tags.xml.in:1744
 msgid "Multiple"
 msgstr "多个"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:145
+#: plugins/taglist/HTML.tags.xml.in:626 plugins/taglist/HTML.tags.xml.in:1748
 msgid "Name"
 msgstr "名称"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:146
+#: plugins/taglist/HTML.tags.xml.in:631 plugins/taglist/HTML.tags.xml.in:1752
 msgid "Named property value"
 msgstr "命名属性值"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:147
+#: plugins/taglist/HTML.tags.xml.in:636 plugins/taglist/HTML.tags.xml.in:1764
 msgid "No frames"
 msgstr "无框架"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:148
+#: plugins/taglist/HTML.tags.xml.in:641 plugins/taglist/HTML.tags.xml.in:1779
 msgid "No resize"
 msgstr "不更改大小"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:149
+#: plugins/taglist/HTML.tags.xml.in:645 plugins/taglist/HTML.tags.xml.in:1783
 msgid "No script"
 msgstr "无脚本"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:151
+#: plugins/taglist/HTML.tags.xml.in:651
 msgid "No shade (deprecated)"
 msgstr "无阴影(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:152
+#: plugins/taglist/HTML.tags.xml.in:655 plugins/taglist/HTML.tags.xml.in:1792
 msgid "No URI"
 msgstr "无 URI"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:154
+#: plugins/taglist/HTML.tags.xml.in:661
 msgid "No word wrap (deprecated)"
 msgstr "无换行(已废弃)"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:156
+#: plugins/taglist/HTML.tags.xml.in:666
 msgid "Object applet file (deprecated)"
 msgstr "对象小程序文件(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:157
+#: plugins/taglist/HTML.tags.xml.in:671 plugins/taglist/HTML.tags.xml.in:1809
 msgid "Object data reference"
 msgstr "对象数据引用"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:158
+#: plugins/taglist/HTML.tags.xml.in:676 plugins/taglist/HTML.tags.xml.in:1813
 msgid "Offset for alignment character"
 msgstr "对齐字符的偏移"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:159
+#: plugins/taglist/HTML.tags.xml.in:681 plugins/taglist/HTML.tags.xml.in:1817
 msgid "OnBlur event"
 msgstr "OnBlur 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:160
+#: plugins/taglist/HTML.tags.xml.in:686 plugins/taglist/HTML.tags.xml.in:1821
 msgid "OnChange event"
 msgstr "OnChange 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:161
+#: plugins/taglist/HTML.tags.xml.in:691 plugins/taglist/HTML.tags.xml.in:1825
 msgid "OnClick event"
 msgstr "OnClick 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:162
+#: plugins/taglist/HTML.tags.xml.in:696 plugins/taglist/HTML.tags.xml.in:1829
 msgid "OnDblClick event"
 msgstr "OnDblClick 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:163
+#: plugins/taglist/HTML.tags.xml.in:701 plugins/taglist/HTML.tags.xml.in:1833
 msgid "OnFocus event"
 msgstr "OnFocus 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:164
+#: plugins/taglist/HTML.tags.xml.in:706 plugins/taglist/HTML.tags.xml.in:1837
 msgid "OnKeyDown event"
 msgstr "OnKeyDown 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:165
+#: plugins/taglist/HTML.tags.xml.in:711 plugins/taglist/HTML.tags.xml.in:1841
 msgid "OnKeyPress event"
 msgstr "OnKeyPress 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:166
+#: plugins/taglist/HTML.tags.xml.in:716 plugins/taglist/HTML.tags.xml.in:1845
 msgid "OnKeyUp event"
 msgstr "OnKeyUp 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:167
+#: plugins/taglist/HTML.tags.xml.in:721 plugins/taglist/HTML.tags.xml.in:1849
 msgid "OnLoad event"
 msgstr "OnLoad 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:168
+#: plugins/taglist/HTML.tags.xml.in:726 plugins/taglist/HTML.tags.xml.in:1853
 msgid "OnMouseDown event"
 msgstr "OnMouseDown 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:169
+#: plugins/taglist/HTML.tags.xml.in:731 plugins/taglist/HTML.tags.xml.in:1857
 msgid "OnMouseMove event"
 msgstr "OnMouseMove 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:170
+#: plugins/taglist/HTML.tags.xml.in:736 plugins/taglist/HTML.tags.xml.in:1861
 msgid "OnMouseOut event"
 msgstr "OnMouseOut 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:171
+#: plugins/taglist/HTML.tags.xml.in:741 plugins/taglist/HTML.tags.xml.in:1865
 msgid "OnMouseOver event"
 msgstr "OnMouseOver 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:172
+#: plugins/taglist/HTML.tags.xml.in:746 plugins/taglist/HTML.tags.xml.in:1869
 msgid "OnMouseUp event"
 msgstr "OnMouseUp 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:173
+#: plugins/taglist/HTML.tags.xml.in:751 plugins/taglist/HTML.tags.xml.in:1873
 msgid "OnReset event"
 msgstr "OnReset 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:174
+#: plugins/taglist/HTML.tags.xml.in:756 plugins/taglist/HTML.tags.xml.in:1877
 msgid "OnSelect event"
 msgstr "OnSelect 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:175
+#: plugins/taglist/HTML.tags.xml.in:761 plugins/taglist/HTML.tags.xml.in:1881
 msgid "OnSubmit event"
 msgstr "OnSubmit 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:176
+#: plugins/taglist/HTML.tags.xml.in:766 plugins/taglist/HTML.tags.xml.in:1885
 msgid "OnUnload event"
 msgstr "OnUnload 事件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:177
+#: plugins/taglist/HTML.tags.xml.in:771 plugins/taglist/HTML.tags.xml.in:1889
 msgid "Option group"
 msgstr "选项组"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:178
+#: plugins/taglist/HTML.tags.xml.in:776 plugins/taglist/HTML.tags.xml.in:1894
 msgid "Option selector"
 msgstr "选择器"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:179
+#: plugins/taglist/HTML.tags.xml.in:781 plugins/taglist/HTML.tags.xml.in:1899
 msgid "Ordered list"
 msgstr "有序列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:180
+#: plugins/taglist/HTML.tags.xml.in:786 plugins/taglist/HTML.tags.xml.in:1904
 msgid "Paragraph class"
 msgstr "段落类"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:181
+#: plugins/taglist/HTML.tags.xml.in:791 plugins/taglist/HTML.tags.xml.in:1909
 msgid "Paragraph style"
 msgstr "段落样式"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:182
+#: plugins/taglist/HTML.tags.xml.in:796 plugins/taglist/HTML.tags.xml.in:1914
 msgid "Paragraph"
 msgstr "段落"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:183
+#: plugins/taglist/HTML.tags.xml.in:801 plugins/taglist/HTML.tags.xml.in:1924
 msgid "Preformatted text"
 msgstr "预格式化文本"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:184
+#: plugins/taglist/HTML.tags.xml.in:806 plugins/taglist/HTML.tags.xml.in:1929
 msgid "Profile metainfo dictionary"
 msgstr "配置文件元信息字典"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:185
+#: plugins/taglist/HTML.tags.xml.in:811 plugins/taglist/HTML.tags.xml.in:1937
 msgid "Push button"
 msgstr "按钮"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:186
+#: plugins/taglist/HTML.tags.xml.in:816 plugins/taglist/HTML.tags.xml.in:1950
 msgid "ReadOnly text and password"
 msgstr "只读文字和密码"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:188
+#: plugins/taglist/HTML.tags.xml.in:821
 msgid "Reduced spacing (deprecated)"
 msgstr "减少间距(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:189
+#: plugins/taglist/HTML.tags.xml.in:825 plugins/taglist/HTML.tags.xml.in:1958
 msgid "Reverse link"
 msgstr "保留链接"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:190
+#: plugins/taglist/HTML.tags.xml.in:830 plugins/taglist/HTML.tags.xml.in:1966
 msgid "Rows"
 msgstr "行"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:191
+#: plugins/taglist/HTML.tags.xml.in:835 plugins/taglist/HTML.tags.xml.in:1970
 msgid "Rulings between rows and columns"
 msgstr "行列刻度"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:192
+#: plugins/taglist/HTML.tags.xml.in:840 plugins/taglist/HTML.tags.xml.in:1974
 msgid "Sample program output, scripts"
 msgstr "示例程序输出，脚本"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:193
+#: plugins/taglist/HTML.tags.xml.in:845 plugins/taglist/HTML.tags.xml.in:1979
 msgid "Scope covered by header cells"
 msgstr "表头单元格覆盖的范围"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:195
+#: plugins/taglist/HTML.tags.xml.in:851 plugins/taglist/HTML.tags.xml.in:1983
 msgid "Script language name"
 msgstr "脚本语言名称"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:196
+#: plugins/taglist/HTML.tags.xml.in:856 plugins/taglist/HTML.tags.xml.in:1987
 msgid "Script statements"
 msgstr "脚本声明"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:197
+#: plugins/taglist/HTML.tags.xml.in:861 plugins/taglist/HTML.tags.xml.in:1992
 msgid "Scrollbar"
 msgstr "滚动条"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:198
+#: plugins/taglist/HTML.tags.xml.in:866 plugins/taglist/HTML.tags.xml.in:1996
 msgid "Selectable option"
 msgstr "可选项"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:199
+#: plugins/taglist/HTML.tags.xml.in:871 plugins/taglist/HTML.tags.xml.in:2000
 msgid "Selected"
 msgstr "选中"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:200
+#: plugins/taglist/HTML.tags.xml.in:875 plugins/taglist/HTML.tags.xml.in:2004
 msgid "Server-side image map"
 msgstr "服务器端图像映射"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:201
+#: plugins/taglist/HTML.tags.xml.in:880 plugins/taglist/HTML.tags.xml.in:2008
 msgid "Shape"
 msgstr "形状"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:202
+#: plugins/taglist/HTML.tags.xml.in:885 plugins/taglist/HTML.tags.xml.in:2012
 msgid "Short inline quotation"
 msgstr "短嵌入引用"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:204
+#: plugins/taglist/HTML.tags.xml.in:891
 msgid "Size (deprecated)"
 msgstr "大小(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:205
+#: plugins/taglist/HTML.tags.xml.in:896 plugins/taglist/HTML.tags.xml.in:2025
 msgid "Small text style"
 msgstr "小文本样式"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:206
+#: plugins/taglist/HTML.tags.xml.in:901 plugins/taglist/HTML.tags.xml.in:2038
 msgid "Source"
 msgstr "源"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:207
+#: plugins/taglist/HTML.tags.xml.in:906 plugins/taglist/HTML.tags.xml.in:2042
 msgid "Space-separated archive list"
 msgstr "以空格分隔的存档列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:208
+#: plugins/taglist/HTML.tags.xml.in:911 plugins/taglist/HTML.tags.xml.in:2050
 msgid "Spacing between cells"
 msgstr "单元格间距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:209
+#: plugins/taglist/HTML.tags.xml.in:916 plugins/taglist/HTML.tags.xml.in:2054
 msgid "Spacing within cells"
 msgstr "单元格内间距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:210
+#: plugins/taglist/HTML.tags.xml.in:921 plugins/taglist/HTML.tags.xml.in:2058
 msgid "Span"
 msgstr "适合宽度"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:211
+#: plugins/taglist/HTML.tags.xml.in:926 plugins/taglist/HTML.tags.xml.in:2066
 msgid "Standby load message"
 msgstr "等候载入信息"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:213
+#: plugins/taglist/HTML.tags.xml.in:932
 msgid "Starting sequence number (deprecated)"
 msgstr "起始序列号(已废弃)"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:215
+#: plugins/taglist/HTML.tags.xml.in:938
 msgid "Strike-through text style (deprecated)"
 msgstr "删除线文字样式(已废弃)"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:217
+#: plugins/taglist/HTML.tags.xml.in:944
 msgid "Strike-through text (deprecated)"
 msgstr "删除线文字(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:218
+#: plugins/taglist/HTML.tags.xml.in:949 plugins/taglist/HTML.tags.xml.in:2084
 msgid "Strong emphasis"
 msgstr "强调"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:219
+#: plugins/taglist/HTML.tags.xml.in:954 plugins/taglist/HTML.tags.xml.in:959
+#: plugins/taglist/HTML.tags.xml.in:2089 plugins/taglist/HTML.tags.xml.in:2094
 msgid "Style info"
 msgstr "样式信息"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:220
+#: plugins/taglist/HTML.tags.xml.in:964 plugins/taglist/HTML.tags.xml.in:2098
 msgid "Subscript"
 msgstr "下标"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:221
+#: plugins/taglist/HTML.tags.xml.in:969 plugins/taglist/HTML.tags.xml.in:2103
 msgid "Superscript"
 msgstr "上标"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:222
+#: plugins/taglist/HTML.tags.xml.in:974 plugins/taglist/HTML.tags.xml.in:2112
 msgid "Table body"
 msgstr "表体"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:223
+#: plugins/taglist/HTML.tags.xml.in:979 plugins/taglist/HTML.tags.xml.in:2117
 msgid "Table caption"
 msgstr "表格标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:224
+#: plugins/taglist/HTML.tags.xml.in:984 plugins/taglist/HTML.tags.xml.in:2122
 msgid "Table column group properties"
 msgstr "表列组属性"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:225
+#: plugins/taglist/HTML.tags.xml.in:989 plugins/taglist/HTML.tags.xml.in:2127
 msgid "Table column properties"
 msgstr "表列属性"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:226
+#: plugins/taglist/HTML.tags.xml.in:994 plugins/taglist/HTML.tags.xml.in:2132
 msgid "Table data cell"
 msgstr "表格数据单元格"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:227
+#: plugins/taglist/HTML.tags.xml.in:999 plugins/taglist/HTML.tags.xml.in:2137
 msgid "Table footer"
 msgstr "表脚"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:228
+#: plugins/taglist/HTML.tags.xml.in:1004 plugins/taglist/HTML.tags.xml.in:2142
 msgid "Table header cell"
 msgstr "表头元素"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:229
+#: plugins/taglist/HTML.tags.xml.in:1009 plugins/taglist/HTML.tags.xml.in:2147
 msgid "Table header"
 msgstr "表头"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:230
+#: plugins/taglist/HTML.tags.xml.in:1014 plugins/taglist/HTML.tags.xml.in:2152
 msgid "Table row"
 msgstr "表格行"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:231
+#: plugins/taglist/HTML.tags.xml.in:1019 plugins/taglist/HTML.tags.xml.in:2157
 msgid "Table summary"
 msgstr "表格概览"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:232
+#: plugins/taglist/HTML.tags.xml.in:1024 plugins/taglist/HTML.tags.xml.in:2161
 msgid "Table"
 msgstr "表格"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:233
+#: plugins/taglist/HTML.tags.xml.in:1029 plugins/taglist/HTML.tags.xml.in:2166
 msgid "Target - Blank"
 msgstr "目标 - Blank"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:234
+#: plugins/taglist/HTML.tags.xml.in:1034 plugins/taglist/HTML.tags.xml.in:2171
 msgid "Target - Parent"
 msgstr "目标 - Parent"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:235
+#: plugins/taglist/HTML.tags.xml.in:1039 plugins/taglist/HTML.tags.xml.in:2176
 msgid "Target - Self"
 msgstr "目标 - Self"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:236
+#: plugins/taglist/HTML.tags.xml.in:1044 plugins/taglist/HTML.tags.xml.in:2181
 msgid "Target - Top"
 msgstr "目标 - Top"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:237
+#: plugins/taglist/HTML.tags.xml.in:1049 plugins/taglist/HTML.tags.xml.in:2186
 msgid "Teletype or monospace text style"
 msgstr "电传或等宽文字样式"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:239
+#: plugins/taglist/HTML.tags.xml.in:1055 plugins/taglist/HTML.tags.xml.in:1061
 msgid "Text color (deprecated)"
 msgstr "文本颜色(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:240
+#: plugins/taglist/HTML.tags.xml.in:1066 plugins/taglist/HTML.tags.xml.in:2199
 msgid "Text entered by user"
 msgstr "用户输入的文字"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:241
+#: plugins/taglist/HTML.tags.xml.in:1071 plugins/taglist/HTML.tags.xml.in:2208
 msgid "Title"
 msgstr "标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:242
+#: plugins/taglist/HTML.tags.xml.in:1076 plugins/taglist/HTML.tags.xml.in:2216
 msgid "Underlined text style"
 msgstr "下划线文字样式"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:243
+#: plugins/taglist/HTML.tags.xml.in:1081 plugins/taglist/HTML.tags.xml.in:2221
 msgid "Unordered list"
 msgstr "无序列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:244
+#: plugins/taglist/HTML.tags.xml.in:1086 plugins/taglist/HTML.tags.xml.in:2230
 msgid "Use image map"
 msgstr "使用图像映射"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:245
+#: plugins/taglist/HTML.tags.xml.in:1091 plugins/taglist/HTML.tags.xml.in:2234
 msgid "Value interpretation"
 msgstr "值解释"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:246
+#: plugins/taglist/HTML.tags.xml.in:1096 plugins/taglist/HTML.tags.xml.in:2238
 msgid "Value"
 msgstr "值"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:247
+#: plugins/taglist/HTML.tags.xml.in:1101 plugins/taglist/HTML.tags.xml.in:2242
 msgid "Variable or program argument"
 msgstr "变量或程序参数"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:248
+#: plugins/taglist/HTML.tags.xml.in:1106 plugins/taglist/HTML.tags.xml.in:2247
 msgid "Vertical cell alignment"
 msgstr "单元格垂直对齐"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:250
+#: plugins/taglist/HTML.tags.xml.in:1112
 msgid "Vertical space (deprecated)"
 msgstr "垂直间距(已废弃)"
 
-#. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
-#: ../plugins/taglist/HTML.tags.xml.in.h:252
+#: plugins/taglist/HTML.tags.xml.in:1118
 msgid "Visited link color (deprecated)"
 msgstr "已浏览的链接颜色(已废弃)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:253
+#: plugins/taglist/HTML.tags.xml.in:1123 plugins/taglist/HTML.tags.xml.in:2259
 msgid "Width"
 msgstr "宽度"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:254
+#: plugins/taglist/HTML.tags.xml.in:1130
 msgid "HTML - Tags"
 msgstr "HTML - 标记"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:255
+#: plugins/taglist/HTML.tags.xml.in:1141
 msgid "Above"
 msgstr "以上"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:256
+#: plugins/taglist/HTML.tags.xml.in:1176
 msgid "Applet class file code"
 msgstr "小程序类文件代码"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:257
+#: plugins/taglist/HTML.tags.xml.in:1180
 msgid "Array"
 msgstr "数组"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:258
+#: plugins/taglist/HTML.tags.xml.in:1197
 msgid "Background color"
 msgstr "背景色"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:259
+#: plugins/taglist/HTML.tags.xml.in:1201
 msgid "Background texture tile"
 msgstr "背景纹理平铺"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:260
+#: plugins/taglist/HTML.tags.xml.in:1205
 msgid "Base font"
 msgstr "基本字体"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:261
+#: plugins/taglist/HTML.tags.xml.in:1218
 msgid "Border color"
 msgstr "边框颜色"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:262
+#: plugins/taglist/HTML.tags.xml.in:1222
 msgid "Border"
 msgstr "边框"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:263
+#: plugins/taglist/HTML.tags.xml.in:1230
 msgid "Center"
 msgstr "居中"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:264
+#: plugins/taglist/HTML.tags.xml.in:1239
 msgid "Checked (state)"
 msgstr "已选中(状态)"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:265
+#: plugins/taglist/HTML.tags.xml.in:1268
 msgid "Color of selected links"
 msgstr "选中链接的颜色"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:266
+#: plugins/taglist/HTML.tags.xml.in:1295
 msgid "Content scheme"
 msgstr "目录大纲"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:267
+#: plugins/taglist/HTML.tags.xml.in:1299
 msgid "Content type"
 msgstr "内容类型"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:268
+#: plugins/taglist/HTML.tags.xml.in:1342
 msgid "Direction"
 msgstr "方向"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:269
+#: plugins/taglist/HTML.tags.xml.in:1350
 msgid "Directory list"
 msgstr "目录列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:270
+#: plugins/taglist/HTML.tags.xml.in:1396
 msgid "HTML version"
 msgstr "HTML 版本"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:271
+#: plugins/taglist/HTML.tags.xml.in:1400
 msgid "Embedded object"
 msgstr "嵌入对象"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:272
+#: plugins/taglist/HTML.tags.xml.in:1414
 msgid "Figure"
 msgstr "图形"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:273
+#: plugins/taglist/HTML.tags.xml.in:1419
 msgid "Font face"
 msgstr "字体名"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:274
+#: plugins/taglist/HTML.tags.xml.in:1486
 msgid "Frameborder"
 msgstr "框架边框"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:275
+#: plugins/taglist/HTML.tags.xml.in:1505
 msgid "Framespacing"
 msgstr "框架间距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:276
+#: plugins/taglist/HTML.tags.xml.in:1556
 msgid "Heading"
 msgstr "标题"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:277
+#: plugins/taglist/HTML.tags.xml.in:1569
 msgid "Horizontal space"
 msgstr "水平间距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:278
+#: plugins/taglist/HTML.tags.xml.in:1605
 msgid "Image source"
 msgstr "图象源"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:279
+#: plugins/taglist/HTML.tags.xml.in:1618
 msgid "Inline layer"
 msgstr "内嵌层"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:280
+#: plugins/taglist/HTML.tags.xml.in:1638
 msgid "Java applet"
 msgstr "Java 小程序"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:281
+#: plugins/taglist/HTML.tags.xml.in:1660
 msgid "Layer"
 msgstr "层"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:282
+#: plugins/taglist/HTML.tags.xml.in:1664
 msgid "Link color"
 msgstr "链接颜色"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:283
+#: plugins/taglist/HTML.tags.xml.in:1681
 msgid "Listing"
 msgstr "列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:284
+#: plugins/taglist/HTML.tags.xml.in:1700
 msgid "Mail link"
 msgstr "邮寄链接"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:285
+#: plugins/taglist/HTML.tags.xml.in:1712
 msgid "Marquee"
 msgstr "字幕"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:286
+#: plugins/taglist/HTML.tags.xml.in:1729
 msgid "Menu list"
 msgstr "菜单列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:287
+#: plugins/taglist/HTML.tags.xml.in:1734
 msgid "Multicolumn"
 msgstr "多列"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:288
+#: plugins/taglist/HTML.tags.xml.in:1756
 msgid "Next ID"
 msgstr "下一 ID"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:289
+#: plugins/taglist/HTML.tags.xml.in:1760
 msgid "No embedded objects"
 msgstr "无嵌入对象"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:290
+#: plugins/taglist/HTML.tags.xml.in:1769
 msgid "No layers"
 msgstr "无层"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:291
+#: plugins/taglist/HTML.tags.xml.in:1774
 msgid "No line break"
 msgstr "无换行"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:292
+#: plugins/taglist/HTML.tags.xml.in:1788
 msgid "No shade"
 msgstr "无阴影"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:293
+#: plugins/taglist/HTML.tags.xml.in:1796
 msgid "No word wrap"
 msgstr "无换行"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:294
+#: plugins/taglist/HTML.tags.xml.in:1800
 msgid "Note"
 msgstr "笔记"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:295
+#: plugins/taglist/HTML.tags.xml.in:1805
 msgid "Object applet file"
 msgstr "对象小程序文件"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:296
+#: plugins/taglist/HTML.tags.xml.in:1919
 msgid "Preformatted listing"
 msgstr "预格式化列表"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:297
+#: plugins/taglist/HTML.tags.xml.in:1933
 msgid "Prompt message"
 msgstr "提示信息"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:298
+#: plugins/taglist/HTML.tags.xml.in:1942
 msgid "Quote"
 msgstr "引用"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:299
+#: plugins/taglist/HTML.tags.xml.in:1946
 msgid "Range"
 msgstr "范围"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:300
+#: plugins/taglist/HTML.tags.xml.in:1954
 msgid "Reduced spacing"
 msgstr "减少间距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:301
+#: plugins/taglist/HTML.tags.xml.in:1962
 msgid "Root"
 msgstr "根"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:302
+#: plugins/taglist/HTML.tags.xml.in:2017
 msgid "Single line prompt"
 msgstr "单行提示"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:303
+#: plugins/taglist/HTML.tags.xml.in:2021
 msgid "Size"
 msgstr "大小"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:304
+#: plugins/taglist/HTML.tags.xml.in:2030
 msgid "Soft line break"
 msgstr "软换行"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:305
+#: plugins/taglist/HTML.tags.xml.in:2034
 msgid "Sound"
 msgstr "声音"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:306
+#: plugins/taglist/HTML.tags.xml.in:2046
 msgid "Spacer"
 msgstr "间距符"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:307
+#: plugins/taglist/HTML.tags.xml.in:2062
 msgid "Square root"
 msgstr "平方根"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:308
+#: plugins/taglist/HTML.tags.xml.in:2070
 msgid "Starting sequence number"
 msgstr "起始序列号"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:309
+#: plugins/taglist/HTML.tags.xml.in:2074
 msgid "Strike-through text style"
 msgstr "删除线文字样式"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:310
+#: plugins/taglist/HTML.tags.xml.in:2079
 msgid "Strike-through text"
 msgstr "删除线文字"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:311
+#: plugins/taglist/HTML.tags.xml.in:2108
 msgid "Tab order position"
 msgstr "Tab 顺序位置"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:312
+#: plugins/taglist/HTML.tags.xml.in:2191 plugins/taglist/HTML.tags.xml.in:2195
 msgid "Text color"
 msgstr "文本颜色"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:313
+#: plugins/taglist/HTML.tags.xml.in:2204
 msgid "Text"
 msgstr "文本"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:314
+#: plugins/taglist/HTML.tags.xml.in:2212
 msgid "Top margin in pixels"
 msgstr "以像素计的上边距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:315
+#: plugins/taglist/HTML.tags.xml.in:2226
 msgid "URL"
 msgstr "URL"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:316
+#: plugins/taglist/HTML.tags.xml.in:2251
 msgid "Vertical space"
 msgstr "垂直间距"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:317
+#: plugins/taglist/HTML.tags.xml.in:2255
 msgid "Visited link color"
 msgstr "已浏览的链接颜色"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:318
+#: plugins/taglist/HTML.tags.xml.in:2265
 msgid "HTML - Special Characters"
 msgstr "HTML - 特殊字符"
 
-#: ../plugins/taglist/HTML.tags.xml.in.h:319
+#: plugins/taglist/HTML.tags.xml.in:2267
 msgid "Non-breaking space"
 msgstr "无间距空格"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:1
+#: plugins/taglist/HTML.tags.xml.in:2271
+msgid "Soft hyphen­"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2275
+msgid "&quot;"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2279
+msgid "&amp;"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2283
+msgid "¡"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2287
+msgid "¦"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2291
+msgid "¨"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2295
+msgid "¯"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2299
+msgid "´"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2303
+msgid "¸"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2307
+msgid "&lt;"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2311
+msgid "&gt;"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2315
+msgid "±"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2319
+msgid "«"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2323
+msgid "»"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2327
+msgid "×"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2331
+msgid "÷"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2335
+msgid "¢"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2339
+msgid "£"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2343
+msgid "€"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2347
+msgid "¤"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2351
+msgid "¥"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2355
+msgid "§"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2359
+msgid "©"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2363
+msgid "¬"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2367
+msgid "®"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2371
+msgid "™"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2375
+msgid "°"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2379
+msgid "µ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2383
+msgid "¶"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2387
+msgid "·"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2391
+msgid "¼"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2395
+msgid "½"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2399
+msgid "¾"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2403
+msgid "¹"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2407
+msgid "²"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2411
+msgid "³"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2415
+msgid "á"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2419
+msgid "Á"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2423
+msgid "â"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2427
+msgid "Â"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2431
+msgid "à"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2435
+msgid "À"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2439
+msgid "å"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2443
+msgid "Å"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2447
+msgid "ã"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2451
+msgid "Ã"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2455
+msgid "ä"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2459
+msgid "Ä"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2463
+msgid "ª"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2467
+msgid "æ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2471
+msgid "Æ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2475
+msgid "ç"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2479
+msgid "Ç"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2483
+msgid "Ð"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2487
+msgid "ð"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2491
+msgid "é"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2495
+msgid "É"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2499
+msgid "ê"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2503
+msgid "Ê"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2507
+msgid "è"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2511
+msgid "È"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2515
+msgid "ë"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2519
+msgid "Ë"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2523
+msgid "í"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2527
+msgid "Í"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2531
+msgid "î"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2535
+msgid "Î"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2539
+msgid "ì"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2543
+msgid "Ì"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2547
+msgid "ï"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2551
+msgid "Ï"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2555
+msgid "ñ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2559
+msgid "Ñ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2563
+msgid "ó"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2567
+msgid "Ó"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2571
+msgid "ô"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2575
+msgid "Ô"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2579
+msgid "ò"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2583
+msgid "Ò"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2587
+msgid "º"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2591
+msgid "ø"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2595
+msgid "Ø"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2599
+msgid "õ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2603
+msgid "Õ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2607
+msgid "ö"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2611
+msgid "Ö"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2615
+msgid "ß"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2619
+msgid "þ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2623
+msgid "Þ"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2627
+msgid "ú"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2631
+msgid "Ú"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2635
+msgid "û"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2639
+msgid "Û"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2643
+msgid "ù"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2647
+msgid "Ù"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2651
+msgid "ü"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2655
+msgid "Ü"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2659
+msgid "ý"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2663
+msgid "Ý"
+msgstr ""
+
+#: plugins/taglist/HTML.tags.xml.in:2667
+msgid "ÿ"
+msgstr ""
+
+#: plugins/taglist/Latex.tags.xml.in:3
 msgid "Latex - Tags"
 msgstr "Latex - 标记"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:2
+#: plugins/taglist/Latex.tags.xml.in:4
 msgid "Bibliography (cite)"
 msgstr "文献引用(cite)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:3
+#: plugins/taglist/Latex.tags.xml.in:9
 msgid "Bibliography (item)"
 msgstr "文献项目(item)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:4
+#: plugins/taglist/Latex.tags.xml.in:14
 msgid "Bibliography (shortcite)"
 msgstr "文献短引(shortcite)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:5
+#: plugins/taglist/Latex.tags.xml.in:19
 msgid "Bibliography (thebibliography)"
 msgstr "文献嵌套引用(thebibliography)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:6
+#: plugins/taglist/Latex.tags.xml.in:24
 msgid "Brackets ()"
 msgstr "圆括号 ()"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:7
+#: plugins/taglist/Latex.tags.xml.in:29
 msgid "Brackets []"
 msgstr "方括号 []"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:8
+#: plugins/taglist/Latex.tags.xml.in:34
 msgid "Brackets {}"
 msgstr "大括号 {}"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:9
-msgid "Brackets <>"
-msgstr "尖括号 <>"
+#: plugins/taglist/Latex.tags.xml.in:39
+msgid "Brackets &lt;&gt;"
+msgstr ""
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:10
+#: plugins/taglist/Latex.tags.xml.in:44
 msgid "File input"
 msgstr "文件输入"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:11
+#: plugins/taglist/Latex.tags.xml.in:49
 msgid "Function cosine"
 msgstr "余弦函数"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:12
+#: plugins/taglist/Latex.tags.xml.in:54
 msgid "Function e^"
 msgstr "e^ 函数"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:13
+#: plugins/taglist/Latex.tags.xml.in:59
 msgid "Function exp"
 msgstr "exp 函数"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:14
+#: plugins/taglist/Latex.tags.xml.in:64
 msgid "Function log"
 msgstr "log 函数"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:15
+#: plugins/taglist/Latex.tags.xml.in:69
 msgid "Function log10"
 msgstr "log10 函数"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:16
+#: plugins/taglist/Latex.tags.xml.in:74
 msgid "Function sine"
 msgstr "sin 函数"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:17
+#: plugins/taglist/Latex.tags.xml.in:79
 msgid "Greek alpha"
 msgstr "α"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:18
+#: plugins/taglist/Latex.tags.xml.in:83
 msgid "Greek beta"
 msgstr "β"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:19
+#: plugins/taglist/Latex.tags.xml.in:87
 msgid "Greek epsilon"
 msgstr "ε"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:20
+#: plugins/taglist/Latex.tags.xml.in:91
 msgid "Greek gamma"
 msgstr "γ"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:21
+#: plugins/taglist/Latex.tags.xml.in:95
 msgid "Greek lambda"
 msgstr "λ"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:22
+#: plugins/taglist/Latex.tags.xml.in:99
 msgid "Greek rho"
 msgstr "ρ"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:23
+#: plugins/taglist/Latex.tags.xml.in:103
 msgid "Greek tau"
 msgstr "τ"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:24
+#: plugins/taglist/Latex.tags.xml.in:107
 msgid "Header 0 (chapter)"
 msgstr "零级标题(chapter)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:25
+#: plugins/taglist/Latex.tags.xml.in:112
 msgid "Header 0 (chapter*)"
 msgstr "零级标题(chapter*)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:26
+#: plugins/taglist/Latex.tags.xml.in:117
 msgid "Header 1 (section)"
 msgstr "一级标题(section)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:27
+#: plugins/taglist/Latex.tags.xml.in:122
 msgid "Header 1 (section*)"
 msgstr "一级标题(section*)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:28
+#: plugins/taglist/Latex.tags.xml.in:127
 msgid "Header 2 (subsection)"
 msgstr "二级标题(subsection)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:29
+#: plugins/taglist/Latex.tags.xml.in:132
 msgid "Header 2 (subsection*)"
 msgstr "二级标题(subsection*)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:30
+#: plugins/taglist/Latex.tags.xml.in:137
 msgid "Header 3 (subsubsection)"
 msgstr "三级标题(subsubsection)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:31
+#: plugins/taglist/Latex.tags.xml.in:142
 msgid "Header 3 (subsubsection*)"
 msgstr "三级标题(subsubsection*)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:32
+#: plugins/taglist/Latex.tags.xml.in:147
 msgid "Header 4 (paragraph)"
 msgstr "四级标题(paragraph)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:33
+#: plugins/taglist/Latex.tags.xml.in:152
 msgid "Header appendix"
 msgstr "标题附录"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:34
+#: plugins/taglist/Latex.tags.xml.in:156
 msgid "List description"
 msgstr "列表描述"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:35
+#: plugins/taglist/Latex.tags.xml.in:161
 msgid "List enumerate"
 msgstr "枚举列表"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:36
+#: plugins/taglist/Latex.tags.xml.in:166
 msgid "List itemize"
 msgstr "项目列表"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:37
+#: plugins/taglist/Latex.tags.xml.in:171
 msgid "Item with label"
 msgstr "带标签的项目"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:38
+#: plugins/taglist/Latex.tags.xml.in:176
 msgid "Item"
 msgstr "项目"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:39
+#: plugins/taglist/Latex.tags.xml.in:180
 msgid "Maths (display)"
 msgstr "数学(显示)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:40
+#: plugins/taglist/Latex.tags.xml.in:185
 msgid "Maths (inline)"
 msgstr "数学(嵌入)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:41
+#: plugins/taglist/Latex.tags.xml.in:190
 msgid "Operator fraction"
 msgstr "积分因子"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:42
+#: plugins/taglist/Latex.tags.xml.in:195
 msgid "Operator integral (display)"
 msgstr "∫(显示)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:43
+#: plugins/taglist/Latex.tags.xml.in:200
 msgid "Operator integral (inline)"
 msgstr "∫(嵌入)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:44
+#: plugins/taglist/Latex.tags.xml.in:205
 msgid "Operator sum (display)"
 msgstr "∑(显示)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:45
+#: plugins/taglist/Latex.tags.xml.in:210
 msgid "Operator sum (inline)"
 msgstr "∑(嵌入)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:46
+#: plugins/taglist/Latex.tags.xml.in:215
 msgid "Reference label"
 msgstr "引用标签"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:47
+#: plugins/taglist/Latex.tags.xml.in:220
 msgid "Reference ref"
 msgstr "引用 ref"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:48
-msgid "Symbol <<"
-msgstr "≪ 符号"
+#: plugins/taglist/Latex.tags.xml.in:225
+msgid "Symbol &lt;&lt;"
+msgstr ""
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:49
-msgid "Symbol <="
-msgstr "≤符号"
+#: plugins/taglist/Latex.tags.xml.in:229
+msgid "Symbol &lt;="
+msgstr ""
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:50
-msgid "Symbol >="
-msgstr "≥符号"
+#: plugins/taglist/Latex.tags.xml.in:233
+msgid "Symbol &gt;="
+msgstr ""
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:51
-msgid "Symbol >>"
-msgstr "≫符号"
+#: plugins/taglist/Latex.tags.xml.in:237
+msgid "Symbol &gt;&gt;"
+msgstr ""
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:52
+#: plugins/taglist/Latex.tags.xml.in:241
 msgid "Symbol and"
 msgstr "∧符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:53
+#: plugins/taglist/Latex.tags.xml.in:245
 msgid "Symbol const"
 msgstr "const 符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:54
+#: plugins/taglist/Latex.tags.xml.in:249
 msgid "Symbol d2-by-dt2-partial"
 msgstr "d2/dt2 二阶导符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:55
+#: plugins/taglist/Latex.tags.xml.in:254
 msgid "Symbol dagger"
 msgstr "†符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:56
+#: plugins/taglist/Latex.tags.xml.in:258
 msgid "Symbol d-by-dt"
 msgstr "d/dt 符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:57
+#: plugins/taglist/Latex.tags.xml.in:263
 msgid "Symbol d-by-dt-partial"
 msgstr "d/dt 部分符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:58
+#: plugins/taglist/Latex.tags.xml.in:268
 msgid "Symbol equiv"
 msgstr "≡符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:59
+#: plugins/taglist/Latex.tags.xml.in:272
 msgid "Symbol en-dash --"
 msgstr "--符号(短破折号)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:60
+#: plugins/taglist/Latex.tags.xml.in:276
 msgid "Symbol em-dash ---"
 msgstr "---符号(长破折号)"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:61
+#: plugins/taglist/Latex.tags.xml.in:280
 msgid "Symbol infinity"
 msgstr "∞符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:62
+#: plugins/taglist/Latex.tags.xml.in:284
 msgid "Symbol mathspace ,"
 msgstr ",符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:63
+#: plugins/taglist/Latex.tags.xml.in:288
 msgid "Symbol mathspace ."
 msgstr ".符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:64
+#: plugins/taglist/Latex.tags.xml.in:292
 msgid "Symbol mathspace _"
 msgstr "_符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:65
+#: plugins/taglist/Latex.tags.xml.in:296
 msgid "Symbol mathspace __"
 msgstr "__符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:66
+#: plugins/taglist/Latex.tags.xml.in:300
 msgid "Symbol simeq"
 msgstr "≃符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:67
+#: plugins/taglist/Latex.tags.xml.in:304
 msgid "Symbol star"
 msgstr "⋆符号"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:68
+#: plugins/taglist/Latex.tags.xml.in:308
 msgid "Typeface bold"
 msgstr "粗体"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:69
+#: plugins/taglist/Latex.tags.xml.in:313
 msgid "Typeface type"
 msgstr "打字机字体"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:70
+#: plugins/taglist/Latex.tags.xml.in:318
 msgid "Typeface italic"
 msgstr "意大利斜体"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:71
+#: plugins/taglist/Latex.tags.xml.in:323
 msgid "Typeface slanted"
 msgstr "斜体"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:73
+#: plugins/taglist/Latex.tags.xml.in:333
 msgid "Unbreakable text"
 msgstr "不可断文字"
 
-#: ../plugins/taglist/Latex.tags.xml.in.h:74
+#: plugins/taglist/Latex.tags.xml.in:338
 msgid "Footnote"
 msgstr "脚注"
 
-#: ../plugins/taglist/taglist.plugin.desktop.in.h:1
+#: plugins/taglist/taglist.plugin.desktop.in:5
 msgid "Tag list"
 msgstr "标记列表"
 
-#: ../plugins/taglist/taglist.plugin.desktop.in.h:2
+#: plugins/taglist/taglist.plugin.desktop.in:6
 msgid ""
 "Provides a method to easily insert commonly used tags/strings into a "
 "document without having to type them."
 msgstr "提供一种无需键入即可将常用标记/字符串轻易插入文档的方法。"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:1
+#: plugins/taglist/XSLT.tags.xml.in:7
 msgid "XSLT - Elements"
 msgstr "XSLT - 元素"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:2
-msgid "XSLT - Functions"
-msgstr "XSLT - 函数"
+#: plugins/taglist/XSLT.tags.xml.in:8
+msgid "apply-imports"
+msgstr ""
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:3
-msgid "XSLT - Axes"
-msgstr "XSLT - 轴"
+#: plugins/taglist/XSLT.tags.xml.in:12
+msgid "apply-templates"
+msgstr ""
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:4
-msgid "ancestor"
-msgstr "ancestor"
-
-#: ../plugins/taglist/XSLT.tags.xml.in.h:5
-msgid "ancestor-or-self"
-msgstr "ancestor-or-self"
-
-#: ../plugins/taglist/XSLT.tags.xml.in.h:6
+#: plugins/taglist/XSLT.tags.xml.in:16 plugins/taglist/XSLT.tags.xml.in:303
 msgid "attribute"
 msgstr "attribute"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:7
+#: plugins/taglist/XSLT.tags.xml.in:20
+msgid "attribute-set"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:24
+msgid "call-template"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:28
+msgid "choose"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:32 plugins/taglist/XSLT.tags.xml.in:150
+msgid "comment"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:36
+msgid "copy"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:39
+msgid "copy-of"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:43
+msgid "decimal-format"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:46
+msgid "element"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:50
+msgid "fallback"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:54
+msgid "for-each"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:58
+msgid "if"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:62
+msgid "import"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:66
+msgid "include"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:70 plugins/taglist/XSLT.tags.xml.in:199
+#: plugins/taglist/XUL.tags.xml.in:147
+msgid "key"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:74
+msgid "message"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:78
+msgid "namespace-alias"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:82 plugins/taglist/XSLT.tags.xml.in:233
+msgid "number"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:85
+msgid "otherwise"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:89
+msgid "output"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:93
+msgid "param"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:97
+msgid "preserve-space"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:101 plugins/taglist/XSLT.tags.xml.in:240
+msgid "processing-instruction"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:105
+msgid "sort"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:108
+msgid "strip-space"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:112
+msgid "stylesheet"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:116 plugins/taglist/XUL.tags.xml.in:398
+msgid "template"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:120 plugins/taglist/XSLT.tags.xml.in:280
+msgid "text"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:123
+msgid "value-of"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:127
+msgid "variable"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:131
+msgid "when"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:135
+msgid "with-param"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:141
+msgid "XSLT - Functions"
+msgstr "XSLT - 函数"
+
+#: plugins/taglist/XSLT.tags.xml.in:142
+msgid "boolean"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:146
+msgid "ceiling"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:153
+msgid "concat"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:157
+msgid "contains"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:161
+msgid "count"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:165
+msgid "current"
+msgstr "当前"
+
+#: plugins/taglist/XSLT.tags.xml.in:168
+msgid "document"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:172
+msgid "element-available"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:176
+msgid "false"
+msgstr "假"
+
+#: plugins/taglist/XSLT.tags.xml.in:179
+msgid "floor"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:183
+msgid "format-number"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:187
+msgid "function-available"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:191
+msgid "generate-id"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:195
+msgid "id"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:203
+msgid "lang"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:207
+msgid "last"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:210
+msgid "local-name"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:214
+msgid "name"
+msgstr "名称"
+
+#: plugins/taglist/XSLT.tags.xml.in:218
+msgid "namespace-uri"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:222
+msgid "node"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:225
+msgid "normalize-space"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:229
+msgid "not"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:237
+msgid "position"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:244
+msgid "round"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:248
+msgid "starts-with"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:252
+msgid "string"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:256
+msgid "string-length"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:260
+msgid "substring"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:264
+msgid "substring-after"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:268
+msgid "substring-before"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:272
+msgid "sum"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:276
+msgid "system-property"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:283
+msgid "translate"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:287
+msgid "true"
+msgstr "真"
+
+#: plugins/taglist/XSLT.tags.xml.in:290
+msgid "unparsed-entity-uri"
+msgstr ""
+
+#: plugins/taglist/XSLT.tags.xml.in:296
+msgid "XSLT - Axes"
+msgstr "XSLT - 轴"
+
+#: plugins/taglist/XSLT.tags.xml.in:297
+msgid "ancestor"
+msgstr "ancestor"
+
+#: plugins/taglist/XSLT.tags.xml.in:300
+msgid "ancestor-or-self"
+msgstr "ancestor-or-self"
+
+#: plugins/taglist/XSLT.tags.xml.in:306
 msgid "child"
 msgstr "child"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:8
+#: plugins/taglist/XSLT.tags.xml.in:309
 msgid "descendant"
 msgstr "descendant"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:9
+#: plugins/taglist/XSLT.tags.xml.in:312
 msgid "descendant-or-self"
 msgstr "descendant-or-self"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:10
+#: plugins/taglist/XSLT.tags.xml.in:315
 msgid "following"
 msgstr "following"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:11
+#: plugins/taglist/XSLT.tags.xml.in:318
 msgid "following-sibling"
 msgstr "following-sibling"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:12
+#: plugins/taglist/XSLT.tags.xml.in:321
 msgid "namespace"
 msgstr "namespace"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:13
+#: plugins/taglist/XSLT.tags.xml.in:324
 msgid "parent"
 msgstr "parent"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:14
+#: plugins/taglist/XSLT.tags.xml.in:327
 msgid "preceding"
 msgstr "preceding"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:15
+#: plugins/taglist/XSLT.tags.xml.in:330
 msgid "preceding-sibling"
 msgstr "preceding-sibling"
 
-#: ../plugins/taglist/XSLT.tags.xml.in.h:16
+#: plugins/taglist/XSLT.tags.xml.in:333
 msgid "self"
 msgstr "self"
 
-#: ../plugins/taglist/XUL.tags.xml.in.h:1
+#: plugins/taglist/XUL.tags.xml.in:3
 msgid "XUL - Tags"
 msgstr "XUL - 标记"
 
-#: ../plugins/time/org.mate.pluma.plugins.time.gschema.xml.in.h:1
+#: plugins/taglist/XUL.tags.xml.in:5
+msgid "action"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:10
+msgid "arrowscrollbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:15
+msgid "bbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:20
+msgid "binding"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:25
+msgid "bindings"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:30
+msgid "box"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:35
+msgid "broadcaster"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:39
+msgid "broadcasterset"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:44
+msgid "button"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:48
+msgid "browser"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:52
+msgid "checkbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:56
+msgid "caption"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:60
+msgid "colorpicker"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:65
+msgid "column"
+msgstr "列"
+
+#: plugins/taglist/XUL.tags.xml.in:69
+msgid "columns"
+msgstr "列"
+
+#: plugins/taglist/XUL.tags.xml.in:74
+msgid "commandset"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:79
+msgid "command"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:83
+msgid "conditions"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:88
+msgid "content"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:92
+msgid "deck"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:97
+msgid "description"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:102
+msgid "dialog"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:111
+msgid "dialogheader"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:115
+msgid "editor"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:119
+msgid "grid"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:124
+msgid "grippy"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:129
+msgid "groupbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:134
+msgid "hbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:139
+msgid "iframe"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:143
+msgid "image"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:151
+msgid "keyset"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:156
+msgid "label"
+msgstr "标签"
+
+#: plugins/taglist/XUL.tags.xml.in:160
+msgid "listbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:165
+msgid "listcell"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:169
+msgid "listcol"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:174
+msgid "listcols"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:179
+msgid "listhead"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:184
+msgid "listheader"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:188
+msgid "listitem"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:192
+msgid "member"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:196
+msgid "menu"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:201
+msgid "menubar"
+msgstr "菜单栏"
+
+#: plugins/taglist/XUL.tags.xml.in:206
+msgid "menuitem"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:210
+msgid "menulist"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:215
+msgid "menupopup"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:220
+msgid "menuseparator"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:224
+msgid "observes"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:228
+msgid "overlay"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:234
+msgid "page"
+msgstr "page"
+
+#: plugins/taglist/XUL.tags.xml.in:239
+msgid "popup"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:244
+msgid "popupset"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:249
+msgid "preference"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:254
+msgid "preferences"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:259
+msgid "prefpane"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:264
+msgid "prefwindow"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:269
+msgid "progressmeter"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:273
+msgid "radio"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:277
+msgid "radiogroup"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:282
+msgid "resizer"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:287
+msgid "richlistbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:292
+msgid "richlistitem"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:297
+msgid "row"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:302
+msgid "rows"
+msgstr "行"
+
+#: plugins/taglist/XUL.tags.xml.in:307
+msgid "rule"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:312
+msgid "script"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:317
+msgid "scrollbar"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:321
+msgid "scrollbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:326
+msgid "scrollcorner"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:331
+msgid "separator"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:336
+msgid "spacer"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:340
+msgid "splitter"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:345
+msgid "stack"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:350
+msgid "statusbar"
+msgstr "状态栏"
+
+#: plugins/taglist/XUL.tags.xml.in:355
+msgid "statusbarpanel"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:360
+msgid "stringbundle"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:364
+msgid "stringbundleset"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:369
+msgid "tab"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:373
+msgid "tabbrowser"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:378
+msgid "tabbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:383
+msgid "tabpanel"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:388
+msgid "tabpanels"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:393
+msgid "tabs"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:403
+msgid "textnode"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:408
+msgid "textbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:412
+msgid "titlebar"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:417
+msgid "toolbar"
+msgstr "工具栏"
+
+#: plugins/taglist/XUL.tags.xml.in:422
+msgid "toolbarbutton"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:426
+msgid "toolbargrippy"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:431
+msgid "toolbaritem"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:436
+msgid "toolbarpalette"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:441
+msgid "toolbarseparator"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:446
+msgid "toolbarset"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:451
+msgid "toolbarspacer"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:456
+msgid "toolbarspring"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:461
+msgid "toolbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:466
+msgid "tooltip"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:471
+msgid "tree"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:476
+msgid "treecell"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:480
+msgid "treechildren"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:485
+msgid "treecol"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:489
+msgid "treecols"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:494
+msgid "treeitem"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:499
+msgid "treerow"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:504
+msgid "treeseparator"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:509
+msgid "triple"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:514
+msgid "vbox"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:519
+msgid "window"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:525
+msgid "wizard"
+msgstr ""
+
+#: plugins/taglist/XUL.tags.xml.in:530
+msgid "wizardpage"
+msgstr ""
+
+#: plugins/time/org.mate.pluma.plugins.time.gschema.xml.in:12
 msgid "Prompt type"
 msgstr "提示类型"
 
-#: ../plugins/time/org.mate.pluma.plugins.time.gschema.xml.in.h:2
+#: plugins/time/org.mate.pluma.plugins.time.gschema.xml.in:16
 msgid "Selected format"
 msgstr "已选格式"
 
-#: ../plugins/time/org.mate.pluma.plugins.time.gschema.xml.in.h:3
+#: plugins/time/org.mate.pluma.plugins.time.gschema.xml.in:20
 msgid "Custom format"
 msgstr "自定义格式"
 
-#: ../plugins/time/pluma-time-plugin.c:186
+#: plugins/time/pluma-time-plugin.c:186
 msgid "In_sert Date and Time..."
 msgstr "插入日期和时间(_S)..."
 
-#: ../plugins/time/pluma-time-plugin.c:188
+#: plugins/time/pluma-time-plugin.c:188
 msgid "Insert current date and time at the cursor position"
 msgstr "在光标处插入当前的日期和时间"
 
-#: ../plugins/time/pluma-time-plugin.c:578
+#: plugins/time/pluma-time-plugin.c:578
 msgid "Available formats"
 msgstr "可用格式"
 
-#: ../plugins/time/time.plugin.desktop.in.h:1
+#: plugins/time/time.plugin.desktop.in:5
 msgid "Insert Date/Time"
 msgstr "插入日期/时间"
 
-#: ../plugins/time/time.plugin.desktop.in.h:2
+#: plugins/time/time.plugin.desktop.in:6
 msgid "Inserts current date and time at the cursor position."
 msgstr "在光标处插入当前的日期和时间。"
 
-#: ../plugins/trailsave/trailsave.plugin.desktop.in.h:1
+#: plugins/trailsave/trailsave.plugin.desktop.in:5
 msgid "Save Without Trailing Spaces"
 msgstr "保存时不附带尾随空白"
 
-#: ../plugins/trailsave/trailsave.plugin.desktop.in.h:2
+#: plugins/trailsave/trailsave.plugin.desktop.in:6
 msgid "Removes trailing spaces from lines before saving."
 msgstr "保存前删除文件中的尾随空格。"
 
-#: ../plugins/time/pluma-time-dialog.ui.h:1
+#. Translators: Do NOT translate or transliterate this text (this is an icon
+#. file name)!
+#: plugins/trailsave/trailsave.plugin.desktop.in:8
+msgid "edit-cut"
+msgstr ""
+
+#: plugins/time/pluma-time-dialog.ui:19
 msgid "Insert Date and Time"
 msgstr "插入日期和时间"
 
-#: ../plugins/time/pluma-time-dialog.ui.h:4
+#: plugins/time/pluma-time-dialog.ui:99
 msgid "_Insert"
 msgstr "插入(_I)"
 
-#: ../plugins/time/pluma-time-dialog.ui.h:5
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:8
+#: plugins/time/pluma-time-dialog.ui:144
+#: plugins/time/pluma-time-setup-dialog.ui:165
 msgid "Use the _selected format"
 msgstr "使用选中的格式(_S)"
 
-#: ../plugins/time/pluma-time-dialog.ui.h:7
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:9
+#: plugins/time/pluma-time-dialog.ui:226
+#: plugins/time/pluma-time-setup-dialog.ui:247
 msgid "_Use custom format"
 msgstr "使用自定义格式(_U)"
 
 #. Translators: Use the more common date format in your locale
-#: ../plugins/time/pluma-time-dialog.ui.h:9
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:12
-#, no-c-format
+#: plugins/time/pluma-time-dialog.ui:244
+#: plugins/time/pluma-time-setup-dialog.ui:265
 msgid "%d/%m/%Y %H:%M:%S"
 msgstr "%Y/%m/%d %H:%M:%S"
 
 #. Translators: This example should follow the date format defined in the
 #. entry above
-#: ../plugins/time/pluma-time-dialog.ui.h:10
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:14
+#: plugins/time/pluma-time-dialog.ui:264
+#: plugins/time/pluma-time-setup-dialog.ui:285
 msgid "01/11/2009 17:52:00"
 msgstr "2009/01/11 17:52:00"
 
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:1
+#: plugins/time/pluma-time-setup-dialog.ui:23
 msgid "Configure date/time plugin"
 msgstr "配置日期/时间插件"
 
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:5
+#: plugins/time/pluma-time-setup-dialog.ui:104
 msgid "When inserting date/time..."
 msgstr "在插入日期/时间时..."
 
-#: ../plugins/time/pluma-time-setup-dialog.ui.h:7
+#: plugins/time/pluma-time-setup-dialog.ui:143
 msgid "_Prompt for a format"
 msgstr "提示可使用的格式(_P)"


### PR DESCRIPTION
There were some misuse of full-width symbols in the translation of Chinese (China). I fixed it and simultaneously add some new translation in Transifex.