### PR TITLE
build: show compiler flags on configuration summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,8 @@ Configuration:
 
 	Source code location:	${srcdir}
 	Compiler:		${CC}
+	Compiler flags:		${CFLAGS}
+	Warning flags:		${WARN_CFLAGS}
 	Spell Plugin enabled:	$enable_enchant
 	Gvfs metadata enabled:	$enable_gvfs_metadata
 	GObject Introspection:	${have_introspection}


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum
<cut>

Configuration:

	Source code location:	.
	Compiler:		gcc
	Compiler flags:		-g -O2
	Warning flags:		-Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-sign-compare
	Spell Plugin enabled:	yes
	Gvfs metadata enabled:	yes
	GObject Introspection:	yes
	Tests enabled:		yes

<cut>
```