### PR TITLE
remove note for disabled Python 2 plugins

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,3 +1,1 @@
 ## This is the plugins directory for pluma. If you want to write a plugin, you have to put the plugin folder here. Each plugin folder must contain a README file having a brief description of the plugin. See the other folders for better understanding.
-
-**NOTE:** As of now, all Python 2 plugins (external tools, indent lines, python console, quick open and snippets) are disabled until they are ported to Python 3 (see PR [#425](https://github.com/mate-desktop/pluma/pull/425)).


### PR DESCRIPTION
Removing the note regarding the disabled Python 2 plugins, since we now have compatibility with Python 3.