### PR TITLE
Remove warnings: cast between incompatible function types

### DIFF
--- a/plugins/filebrowser/pluma-file-bookmarks-store.c
+++ b/plugins/filebrowser/pluma-file-bookmarks-store.c
@@ -370,8 +370,7 @@ init_drives (PlumaFileBookmarksStore *model)
 	drives = g_volume_monitor_get_connected_drives (model->priv->volume_monitor);
 
 	g_list_foreach (drives, (GFunc)process_drive_cb, model);
-	g_list_foreach (drives, (GFunc)g_object_unref, NULL);
-	g_list_free (drives);
+	g_list_free_full (drives, g_object_unref);
 }
 
 static void
@@ -399,8 +398,7 @@ init_volumes (PlumaFileBookmarksStore *model)
 	volumes = g_volume_monitor_get_volumes (model->priv->volume_monitor);
 
 	g_list_foreach (volumes, (GFunc)process_volume_nodrive_cb, model);
-	g_list_foreach (volumes, (GFunc)g_object_unref, NULL);
-	g_list_free (volumes);
+	g_list_free_full (volumes, g_object_unref);
 }
 
 static void
@@ -430,8 +428,7 @@ init_mounts (PlumaFileBookmarksStore *model)
 	mounts = g_volume_monitor_get_mounts (model->priv->volume_monitor);
 
 	g_list_foreach (mounts, (GFunc)process_mount_novolume_cb, model);
-	g_list_foreach (mounts, (GFunc)g_object_unref, NULL);
-	g_list_free (mounts);
+	g_list_free_full (mounts, g_object_unref);
 }
 
 static void

--- a/plugins/filebrowser/pluma-file-browser-messages.c
+++ b/plugins/filebrowser/pluma-file-browser-messages.c
@@ -154,7 +154,8 @@ track_row_lookup (WindowData  *data,
 }
 
 static void
-message_cache_data_free (MessageCacheData *data)
+message_cache_data_free (MessageCacheData *data,
+                         GClosure         *closure)
 {
 	g_object_unref (data->message);
 	g_slice_free (MessageCacheData, data);

--- a/plugins/filebrowser/pluma-file-browser-store.c
+++ b/plugins/filebrowser/pluma-file-browser-store.c
@@ -3253,8 +3253,7 @@ async_data_free (AsyncData * data)
 {
 	g_object_unref (data->cancellable);
 
-	g_list_foreach (data->files, (GFunc)g_object_unref, NULL);
-	g_list_free (data->files);
+	g_list_free_full (data->files, g_object_unref);
 
 	if (!data->removed)
 		data->model->priv->async_handles = g_slist_remove (data->model->priv->async_handles, data);
@@ -3444,8 +3443,7 @@ pluma_file_browser_store_delete (PlumaFileBrowserStore * model,
 	rows = g_list_append(NULL, pluma_file_browser_store_get_path_real (model, node));
 	result = pluma_file_browser_store_delete_all (model, rows, trash);
 
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full (rows, (GDestroyNotify) gtk_tree_path_free);
 
 	return result;
 }

--- a/plugins/filebrowser/pluma-file-browser-view.c
+++ b/plugins/filebrowser/pluma-file-browser-view.c
@@ -379,8 +379,7 @@ activate_selected_files (PlumaFileBrowserView *view) {
 			g_signal_emit (view, signals[DIRECTORY_ACTIVATED], 0, &iter);
 	}
 
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full (rows, (GDestroyNotify) gtk_tree_path_free);
 }
 
 static void

--- a/plugins/filebrowser/pluma-file-browser-widget.c
+++ b/plugins/filebrowser/pluma-file-browser-widget.c
@@ -343,8 +343,7 @@ pluma_file_browser_widget_finalize (GObject * object)
 	g_object_unref (obj->priv->bookmarks_store);
 	g_object_unref (obj->priv->combo_model);
 
-	g_slist_foreach (obj->priv->filter_funcs, (GFunc) g_free, NULL);
-	g_slist_free (obj->priv->filter_funcs);
+	g_slist_free_full (obj->priv->filter_funcs, g_free);
 
 	for (loc = obj->priv->locations; loc; loc = loc->next)
 		location_free ((Location *) (loc->data));
@@ -1334,8 +1333,7 @@ pluma_file_browser_widget_get_first_selected (PlumaFileBrowserWidget *obj,
 
 	result = gtk_tree_model_get_iter(model, iter, (GtkTreePath *)(rows->data));
 
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full (rows, (GDestroyNotify) gtk_tree_path_free);
 
 	return result;
 }
@@ -1457,8 +1455,7 @@ get_deletable_files (PlumaFileBrowserWidget *obj) {
 		paths = g_list_append (paths, gtk_tree_path_copy (path));
 	}
 
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full (rows, (GDestroyNotify) gtk_tree_path_free);
 
 	return paths;
 }
@@ -1491,8 +1488,7 @@ delete_selected_files (PlumaFileBrowserWidget * obj, gboolean trash)
 	result = pluma_file_browser_store_delete_all (PLUMA_FILE_BROWSER_STORE (model),
 						      rows, trash);
 
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full (rows, (GDestroyNotify) gtk_tree_path_free);
 
 	return result == PLUMA_FILE_BROWSER_STORE_RESULT_OK;
 }
@@ -2055,8 +2051,7 @@ pluma_file_browser_widget_get_num_selected_files_or_directories (PlumaFileBrowse
 		}
 	}
 
-	g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
-	g_list_free (rows);
+	g_list_free_full (rows, (GDestroyNotify) gtk_tree_path_free);
 
 	return result;
 }
@@ -2179,8 +2174,7 @@ try_activate_drive (PlumaFileBrowserWidget *widget,
 		try_mount_volume (widget, volume);
 	}
 
-	g_list_foreach (volumes, (GFunc)g_object_unref, NULL);
-	g_list_free (volumes);
+	g_list_free_full (volumes, g_object_unref);
 }
 
 static void

--- a/plugins/spell/pluma-spell-checker-dialog.c
+++ b/plugins/spell/pluma-spell-checker-dialog.c
@@ -426,8 +426,7 @@ pluma_spell_checker_dialog_set_misspelled_word (PlumaSpellCheckerDialog *dlg,
 	update_suggestions_list_model (dlg, sug);
 
 	/* free the suggestion list */
-	g_slist_foreach (sug, (GFunc)g_free, NULL);
-	g_slist_free (sug);
+	g_slist_free_full (sug, g_free);
 
 	gtk_widget_set_sensitive (dlg->ignore_button, TRUE);
 	gtk_widget_set_sensitive (dlg->ignore_all_button, TRUE);
@@ -578,8 +577,7 @@ check_word_button_clicked_handler (GtkButton *button, PlumaSpellCheckerDialog *d
 		update_suggestions_list_model (dlg, sug);
 
 		/* free the suggestion list */
-		g_slist_foreach (sug, (GFunc)g_free, NULL);
-		g_slist_free (sug);
+		g_slist_free_full (sug, g_free);
 	}
 }
 

--- a/pluma/pluma-commands-file.c
+++ b/pluma/pluma-commands-file.c
@@ -296,8 +296,7 @@ load_uri_list (PlumaWindow         *window,
 
 	ret = load_file_list (window, files, encoding, line_pos, create);
 
-	g_slist_foreach (files, (GFunc) g_object_unref, NULL);
-	g_slist_free (files);
+	g_slist_free_full (files, g_object_unref);
 
 	return ret;
 }
@@ -433,8 +432,7 @@ open_dialog_response_cb (PlumaFileChooserDialog *dialog,
 				   encoding,
 				   0);
 
-	g_slist_foreach (files, (GFunc) g_object_unref, NULL);
-	g_slist_free (files);
+	g_slist_free_full (files, g_object_unref);
 }
 
 void

--- a/pluma/pluma-history-entry.c
+++ b/pluma/pluma-history-entry.c
@@ -226,8 +226,7 @@ pluma_history_entry_save_history (PlumaHistoryEntry *entry)
 			      entry->priv->history_id,
 			      settings_items);
 
-	g_slist_foreach (settings_items, (GFunc) g_free, NULL);
-	g_slist_free (settings_items);
+	g_slist_free_full (settings_items, g_free);
 }
 
 static gboolean
@@ -373,8 +372,7 @@ pluma_history_entry_load_history (PlumaHistoryEntry *entry)
 				    -1);
 	}
 
-	g_slist_foreach (settings_items, (GFunc) g_free, NULL);
-	g_slist_free (settings_items);
+	g_slist_free_full (settings_items, g_free);
 }
 
 void

--- a/pluma/pluma-message-bus.c
+++ b/pluma/pluma-message-bus.c
@@ -158,17 +158,9 @@ message_free (Message *message)
 	g_free (message->method);
 	g_free (message->object_path);
 
-	g_list_foreach (message->listeners, (GFunc)listener_free, NULL);
-	g_list_free (message->listeners);
+	g_list_free_full (message->listeners, (GDestroyNotify) listener_free);
 
 	g_free (message);
-}
-
-static void
-message_queue_free (GList *queue)
-{
-	g_list_foreach (queue, (GFunc)g_object_unref, NULL);
-	g_list_free (queue);
 }
 
 static void
@@ -179,7 +171,7 @@ pluma_message_bus_finalize (GObject *object)
 	if (bus->priv->idle_id != 0)
 		g_source_remove (bus->priv->idle_id);
 
-	message_queue_free (bus->priv->message_queue);
+	g_list_free_full (bus->priv->message_queue, g_object_unref);
 
 	g_hash_table_destroy (bus->priv->messages);
 	g_hash_table_destroy (bus->priv->idmap);
@@ -432,7 +424,7 @@ idle_dispatch (PlumaMessageBus *bus)
 		dispatch_message (bus, msg);
 	}
 
-	message_queue_free (list);
+	g_list_free_full (list, g_object_unref);
 	return FALSE;
 }
 

--- a/pluma/pluma-prefs-manager.c
+++ b/pluma/pluma-prefs-manager.c
@@ -703,8 +703,7 @@ pluma_prefs_manager_get_auto_detected_encodings (void)
 		      tmp = g_slist_next (tmp);
 		}
 
-		g_slist_foreach (strings, (GFunc) g_free, NULL);
-		g_slist_free (strings);
+		g_slist_free_full (strings, g_free);
 
 	 	res = g_slist_reverse (res);
 	}
@@ -753,8 +752,7 @@ pluma_prefs_manager_get_shown_in_menu_encodings (void)
 		      tmp = g_slist_next (tmp);
 		}
 
-		g_slist_foreach (strings, (GFunc) g_free, NULL);
-		g_slist_free (strings);
+		g_slist_free_full (strings, g_free);
 
 	 	res = g_slist_reverse (res);
 	}

--- a/pluma/pluma-utils.c
+++ b/pluma/pluma-utils.c
@@ -102,8 +102,7 @@ pluma_utils_uri_has_writable_scheme (const gchar *uri)
 				    scheme,
 				    (GCompareFunc)strcmp) != NULL);
 
-	g_slist_foreach (writable_schemes, (GFunc)g_free, NULL);
-	g_slist_free (writable_schemes);
+	g_slist_free_full (writable_schemes, g_free);
 
 	g_free (scheme);
 

--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -1386,8 +1386,7 @@ update_recent_files_menu (PlumaWindow *window)
 
 	g_list_free (filtered_items);
 
-	g_list_foreach (items, (GFunc) gtk_recent_info_unref, NULL);
-	g_list_free (items);
+	g_list_free_full (items, (GDestroyNotify) gtk_recent_info_unref);
 }
 
 static void

--- a/pluma/pluma.c
+++ b/pluma/pluma.c
@@ -128,8 +128,7 @@ static const GOptionEntry options [] =
 static void
 free_command_line_data (void)
 {
-	g_slist_foreach (file_list, (GFunc) g_object_unref, NULL);
-	g_slist_free (file_list);
+	g_slist_free_full (file_list, g_object_unref);
 	file_list = NULL;
 
 	g_strfreev (remaining_args);


### PR DESCRIPTION
```
pluma.c:131:30: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  131 |  g_slist_foreach (file_list, (GFunc) g_object_unref, NULL);
      |                              ^
--
pluma-commands-file.c:299:26: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  299 |  g_slist_foreach (files, (GFunc) g_object_unref, NULL);
      |                          ^
--
pluma-commands-file.c:436:26: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  436 |  g_slist_foreach (files, (GFunc) g_object_unref, NULL);
      |                          ^
--
pluma-history-entry.c:229:35: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  229 |  g_slist_foreach (settings_items, (GFunc) g_free, NULL);
      |                                   ^
--
pluma-history-entry.c:376:35: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  376 |  g_slist_foreach (settings_items, (GFunc) g_free, NULL);
      |                                   ^
--
pluma-message-bus.c:161:38: warning: cast between incompatible function types from ‘void (*)(Listener *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  161 |  g_list_foreach (message->listeners, (GFunc)listener_free, NULL);
      |                                      ^
--
pluma-message-bus.c:170:25: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  170 |  g_list_foreach (queue, (GFunc)g_object_unref, NULL);
      |                         ^
--
pluma-prefs-manager.c:706:29: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  706 |   g_slist_foreach (strings, (GFunc) g_free, NULL);
      |                             ^
--
pluma-prefs-manager.c:756:29: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  756 |   g_slist_foreach (strings, (GFunc) g_free, NULL);
      |                             ^
--
pluma-utils.c:105:37: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  105 |  g_slist_foreach (writable_schemes, (GFunc)g_free, NULL);
      |                                     ^
--
pluma-window.c:1389:25: warning: cast between incompatible function types from ‘void (*)(GtkRecentInfo *)’ {aka ‘void (*)(struct _GtkRecentInfo *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1389 |  g_list_foreach (items, (GFunc) gtk_recent_info_unref, NULL);
      |                         ^
--
pluma-file-bookmarks-store.c:373:26: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  373 |  g_list_foreach (drives, (GFunc)g_object_unref, NULL);
      |                          ^
--
pluma-file-bookmarks-store.c:402:27: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  402 |  g_list_foreach (volumes, (GFunc)g_object_unref, NULL);
      |                           ^
--
pluma-file-bookmarks-store.c:433:26: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  433 |  g_list_foreach (mounts, (GFunc)g_object_unref, NULL);
      |                          ^
--
pluma-file-browser-store.c:3256:31: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 3256 |  g_list_foreach (data->files, (GFunc)g_object_unref, NULL);
      |                               ^
--
pluma-file-browser-store.c:3447:24: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 3447 |  g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
      |                        ^
--
pluma-file-browser-view.c:382:24: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  382 |  g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
      |                        ^
--
pluma-file-browser-widget.c:346:44: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  346 |  g_slist_foreach (obj->priv->filter_funcs, (GFunc) g_free, NULL);
      |                                            ^
--
pluma-file-browser-widget.c:1337:24: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1337 |  g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
      |                        ^
--
pluma-file-browser-widget.c:1460:24: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1460 |  g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
      |                        ^
--
pluma-file-browser-widget.c:1494:24: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 1494 |  g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
      |                        ^
--
pluma-file-browser-widget.c:2058:24: warning: cast between incompatible function types from ‘void (*)(GtkTreePath *)’ {aka ‘void (*)(struct _GtkTreePath *)’} to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 2058 |  g_list_foreach (rows, (GFunc)gtk_tree_path_free, NULL);
      |                        ^
--
pluma-file-browser-widget.c:2182:27: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
 2182 |  g_list_foreach (volumes, (GFunc)g_object_unref, NULL);
      |                           ^
--
pluma-file-browser-messages.c:921:12: warning: cast between incompatible function types from ‘void (*)(MessageCacheData *)’ to ‘void (*)(void *, GClosure *)’ {aka ‘void (*)(void *, struct _GClosure *)’} [-Wcast-function-type]
  921 |            (GClosureNotify)message_cache_data_free,
      |            ^
pluma-file-browser-messages.c:934:12: warning: cast between incompatible function types from ‘void (*)(MessageCacheData *)’ to ‘void (*)(void *, GClosure *)’ {aka ‘void (*)(void *, struct _GClosure *)’} [-Wcast-function-type]
  934 |            (GClosureNotify)message_cache_data_free,
      |            ^
pluma-file-browser-messages.c:946:12: warning: cast between incompatible function types from ‘void (*)(MessageCacheData *)’ to ‘void (*)(void *, GClosure *)’ {aka ‘void (*)(void *, struct _GClosure *)’} [-Wcast-function-type]
  946 |            (GClosureNotify)message_cache_data_free,
      |            ^
pluma-file-browser-messages.c:958:12: warning: cast between incompatible function types from ‘void (*)(MessageCacheData *)’ to ‘void (*)(void *, GClosure *)’ {aka ‘void (*)(void *, struct _GClosure *)’} [-Wcast-function-type]
  958 |            (GClosureNotify)message_cache_data_free,
      |            ^
pluma-file-browser-messages.c:970:12: warning: cast between incompatible function types from ‘void (*)(MessageCacheData *)’ to ‘void (*)(void *, GClosure *)’ {aka ‘void (*)(void *, struct _GClosure *)’} [-Wcast-function-type]
  970 |            (GClosureNotify)message_cache_data_free,
      |            ^
--
pluma-spell-checker-dialog.c:429:24: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  429 |  g_slist_foreach (sug, (GFunc)g_free, NULL);
      |                        ^
--
pluma-spell-checker-dialog.c:581:25: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  581 |   g_slist_foreach (sug, (GFunc)g_free, NULL);
      |                         ^
```