### PR TITLE
wayland: add  guard backend-specific calls by an ifdef

### DIFF
--- a/pluma/pluma-app.c
+++ b/pluma/pluma-app.c
@@ -36,8 +36,8 @@
 #include <unistd.h>
 
 #include <glib/gi18n.h>
+#include <gdk/gdk.h>
 #include <gdk/gdkx.h>
-
 #include "pluma-app.h"
 #include "pluma-prefs-manager-app.h"
 #include "pluma-commands.h"
@@ -653,8 +653,15 @@ is_in_viewport (PlumaWindow  *window,
 	x += vp_x;
 	y += vp_y;
 
-	sc_width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
-	sc_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
+	if (GDK_IS_X11_DISPLAY (gdk_display_get_default ()))
+	{
+		sc_width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+		sc_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
+	}
+	else
+	{
+		return TRUE;
+	}
 
 	return x + width * .25 >= viewport_x &&
 	       x + width * .75 <= viewport_x + sc_width &&


### PR DESCRIPTION
See https://developer.gnome.org/gdk3/stable/gdk3-Wayland-Interaction.html for details.

I have been playing with pluma (master) and weston (8.0.0-1) in a vm with Ubuntu MATE 20.04 lately. Although I don't know neither pluma nor weston a lot, it seems to work for me.

Test: install weston, launch weston in terminal or logout and go into a proper weston session (for me on debian stable and weston 5.0.0-3 I got a black screen) and compile and launch pluma.

![Screenshot at 2020-04-02 16-47-55](https://user-images.githubusercontent.com/39454100/78263049-bf1d3180-7501-11ea-9b83-00ccd2af678c.png)

