### PR TITLE
bring back open file from location dialog

### DIFF
--- a/data/org.mate.pluma.gschema.xml.in
+++ b/data/org.mate.pluma.gschema.xml.in
@@ -216,6 +216,11 @@
       <summary>History for "replace with" entries</summary>
       <description>List of entries in "replace with" textbox.</description>
     </key>
+    <key name="uri-list" type="as">
+      <default>[]</default>
+      <summary>"Open Location..." entries</summary>
+      <description>List of entries in "uri_entry" widget.</description>
+    </key>
     <key name="active-plugins" type="as">
       <default>[ 'docinfo', 'modelines', 'filebrowser', 'spell', 'time' ]</default>
       <summary>Active plugins</summary>

--- a/pluma/dialogs/Makefile.am
+++ b/pluma/dialogs/Makefile.am
@@ -17,12 +17,15 @@ libdialogs_la_SOURCES = 			\
 	pluma-close-confirmation-dialog.h 	\
 	pluma-encodings-dialog.c		\
 	pluma-encodings-dialog.h		\
+	pluma-open-location-dialog.c		\
+	pluma-open-location-dialog.h		\
 	pluma-search-dialog.h			\
 	pluma-search-dialog.c
 
 ui_files =					\
 	pluma-encodings-dialog.ui		\
 	pluma-preferences-dialog.ui		\
+	pluma-open-location-dialog.ui		\
 	pluma-search-dialog.ui
 
 include $(top_srcdir)/gla11y.mk

--- a/pluma/dialogs/pluma-open-location-dialog.c
+++ b/pluma/dialogs/pluma-open-location-dialog.c
@@ -1,0 +1,230 @@
+/*
+ * pluma-open-location-dialog.c
+ * This file is part of pluma
+ *
+ * Copyright (C) 2001-2005 Paolo Maggi
+ * Copyright (C) 2020 MATE Developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+
+#include "pluma-open-location-dialog.h"
+#include "pluma-history-entry.h"
+#include "pluma-encodings-combo-box.h"
+#include "pluma-utils.h"
+#include "pluma-help.h"
+#include "pluma-dirs.h"
+
+struct _PlumaOpenLocationDialogPrivate
+{
+	GtkWidget *uri_entry;
+	GtkWidget *uri_text_entry;
+	GtkWidget *encoding_menu;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(PlumaOpenLocationDialog, pluma_open_location_dialog, GTK_TYPE_DIALOG)
+
+GtkWidget *
+pluma_open_location_dialog_new (GtkWindow *parent)
+{
+	GtkWidget *dlg;
+
+	dlg = g_object_new (pluma_open_location_dialog_get_type(), NULL);
+
+	if (parent != NULL)
+		gtk_window_set_transient_for (GTK_WINDOW (dlg), parent);
+
+	return dlg;
+}
+
+static void
+entry_changed (GtkComboBox *combo, PlumaOpenLocationDialog *dlg)
+{
+	const gchar *str;
+
+	str = gtk_entry_get_text (GTK_ENTRY (dlg->priv->uri_text_entry));
+	g_return_if_fail (str != NULL);
+
+	gtk_dialog_set_response_sensitive (GTK_DIALOG (dlg),
+					   GTK_RESPONSE_OK,
+					   (str[0] != '\0'));
+}
+
+static void
+response_handler (PlumaOpenLocationDialog *dlg,
+                  gint                     response_id,
+                  gpointer                 data)
+{
+	const gchar *text;
+
+	switch (response_id)
+	{
+		case GTK_RESPONSE_HELP:
+			pluma_help_display (GTK_WINDOW (dlg),
+					    NULL,
+					    NULL);
+
+			g_signal_stop_emission_by_name (dlg, "response");
+			break;
+
+		case GTK_RESPONSE_OK:
+			text = gtk_entry_get_text
+					(GTK_ENTRY (dlg->priv->uri_text_entry));
+			if (*text != '\0')
+			{
+				pluma_history_entry_prepend_text
+						 (PLUMA_HISTORY_ENTRY (dlg->priv->uri_entry),
+						  text);
+			}
+			break;
+	}
+}
+
+GFile *
+pluma_open_location_dialog_get_location (PlumaOpenLocationDialog *dlg)
+{
+	const gchar *str;
+	GFile *location;
+
+	g_return_val_if_fail (PLUMA_IS_OPEN_LOCATION_DIALOG (dlg), NULL);
+
+	str = gtk_entry_get_text (GTK_ENTRY (dlg->priv->uri_text_entry));
+	g_return_val_if_fail (str != NULL, NULL);
+
+	if (str[0] == '\0')
+		return NULL;
+
+	location = g_file_new_for_commandline_arg (str);
+
+	return location;
+}
+
+const PlumaEncoding *
+pluma_open_location_dialog_get_encoding	(PlumaOpenLocationDialog *dlg)
+{
+	g_return_val_if_fail (PLUMA_IS_OPEN_LOCATION_DIALOG (dlg), NULL);
+
+	return pluma_encodings_combo_box_get_selected_encoding (
+				PLUMA_ENCODINGS_COMBO_BOX (dlg->priv->encoding_menu));
+}
+
+static void
+pluma_open_location_dialog_class_init (PlumaOpenLocationDialogClass *klass)
+{
+}
+
+static void
+pluma_open_location_dialog_init (PlumaOpenLocationDialog *dlg)
+{
+	GtkWidget *content;
+	GtkWidget *vbox;
+	GtkWidget *location_label;
+	GtkWidget *encoding_label;
+	GtkWidget *encoding_hbox;
+	GtkWidget *error_widget;
+	gboolean   ret;
+	gchar *file;
+	gchar     *root_objects[] = {
+		"open_uri_dialog_content",
+		NULL
+	};
+
+	dlg->priv = pluma_open_location_dialog_get_instance_private (dlg);
+
+	pluma_dialog_add_button (GTK_DIALOG (dlg), _("_Cancel"), "process-stop", GTK_RESPONSE_CANCEL);
+	pluma_dialog_add_button (GTK_DIALOG (dlg), _("_OK"), "gtk-ok", GTK_RESPONSE_OK);
+	pluma_dialog_add_button (GTK_DIALOG (dlg), _("_Help"), "help-browser", GTK_RESPONSE_HELP);
+
+	gtk_window_set_title (GTK_WINDOW (dlg), _("Open Location"));
+	gtk_window_set_resizable (GTK_WINDOW (dlg), FALSE);
+	gtk_window_set_destroy_with_parent (GTK_WINDOW (dlg), TRUE);
+
+	gtk_dialog_set_default_response (GTK_DIALOG (dlg),
+					 GTK_RESPONSE_OK);
+
+	g_signal_connect (dlg,
+			  "response",
+			  G_CALLBACK (response_handler),
+			  dlg);
+
+	file = pluma_dirs_get_ui_file ("pluma-open-location-dialog.ui");
+	ret = pluma_utils_get_ui_objects (file,
+					  root_objects,
+					  &error_widget,
+					  "open_uri_dialog_content", &content,
+					  "main_vbox", &vbox,
+					  "location_label", &location_label,
+					  "encoding_label", &encoding_label,
+					  "encoding_hbox", &encoding_hbox,
+					   NULL);
+	g_free (file);
+
+	if (!ret)
+	{
+		gtk_widget_show (error_widget);
+
+		gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dlg))),
+		                    error_widget,
+		                    TRUE, TRUE, 0);
+		gtk_container_set_border_width (GTK_CONTAINER (error_widget), 5);
+
+		return;
+	}
+
+	dlg->priv->uri_entry = pluma_history_entry_new ("uri-list", FALSE);
+	dlg->priv->uri_text_entry = pluma_history_entry_get_entry (PLUMA_HISTORY_ENTRY (dlg->priv->uri_entry));
+	gtk_entry_set_activates_default (GTK_ENTRY (dlg->priv->uri_text_entry), TRUE);
+	gtk_widget_show (dlg->priv->uri_entry);
+	gtk_box_pack_start (GTK_BOX (vbox),
+			    dlg->priv->uri_entry,
+			    FALSE,
+			    FALSE,
+			    0);
+
+	gtk_label_set_mnemonic_widget (GTK_LABEL (location_label),
+				       dlg->priv->uri_entry);
+
+	dlg->priv->encoding_menu = pluma_encodings_combo_box_new (FALSE);
+
+	gtk_label_set_mnemonic_widget (GTK_LABEL (encoding_label),
+				       dlg->priv->encoding_menu);
+
+	gtk_box_pack_end (GTK_BOX (encoding_hbox),
+			  dlg->priv->encoding_menu,
+			  TRUE,
+			  TRUE,
+			  0);
+
+	gtk_widget_show (dlg->priv->encoding_menu);
+
+	g_signal_connect (dlg->priv->uri_entry,
+			  "changed",
+			  G_CALLBACK (entry_changed),
+			  dlg);
+
+	gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dlg))),
+			    content, TRUE, TRUE, 0);
+	g_object_unref (content);
+	gtk_container_set_border_width (GTK_CONTAINER (content), 5);
+}

--- a/pluma/dialogs/pluma-open-location-dialog.h
+++ b/pluma/dialogs/pluma-open-location-dialog.h
@@ -1,0 +1,91 @@
+/*
+ * pluma-open-location-dialog.h
+ * This file is part of pluma
+ *
+ * Copyright (C) 2001-2005 Paolo Maggi
+ * Copyright (C) 2020 MATE Developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+
+#ifndef __PLUMA_OPEN_LOCATION_DIALOG_H__
+#define __PLUMA_OPEN_LOCATION_DIALOG_H__
+
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+#include <pluma/pluma-encodings.h>
+
+G_BEGIN_DECLS
+
+/*
+ * Type checking and casting macros
+ */
+#define PLUMA_TYPE_OPEN_LOCATION_DIALOG              (pluma_open_location_dialog_get_type())
+#define PLUMA_OPEN_LOCATION_DIALOG(obj)              (G_TYPE_CHECK_INSTANCE_CAST((obj), PLUMA_TYPE_OPEN_LOCATION_DIALOG, PlumaOpenLocationDialog))
+#define PLUMA_OPEN_LOCATION_DIALOG_CONST(obj)        (G_TYPE_CHECK_INSTANCE_CAST((obj), PLUMA_TYPE_OPEN_LOCATION_DIALOG, PlumaOpenLocationDialog const))
+#define PLUMA_OPEN_LOCATION_DIALOG_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST((klass), PLUMA_TYPE_OPEN_LOCATION_DIALOG, PlumaOpenLocationDialogClass))
+#define PLUMA_IS_OPEN_LOCATION_DIALOG(obj)           (G_TYPE_CHECK_INSTANCE_TYPE((obj), PLUMA_TYPE_OPEN_LOCATION_DIALOG))
+#define PLUMA_IS_OPEN_LOCATION_DIALOG_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), PLUMA_TYPE_OPEN_LOCATION_DIALOG))
+#define PLUMA_OPEN_LOCATION_DIALOG_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS((obj), PLUMA_TYPE_OPEN_LOCATION_DIALOG, PlumaOpenLocationDialogClass))
+
+/* Private structure type */
+typedef struct _PlumaOpenLocationDialogPrivate PlumaOpenLocationDialogPrivate;
+
+/*
+ * Main object structure
+ */
+typedef struct _PlumaOpenLocationDialog PlumaOpenLocationDialog;
+
+struct _PlumaOpenLocationDialog
+{
+	GtkDialog dialog;
+
+	/*< private > */
+	PlumaOpenLocationDialogPrivate *priv;
+};
+
+/*
+ * Class definition
+ */
+typedef struct _PlumaOpenLocationDialogClass PlumaOpenLocationDialogClass;
+
+struct _PlumaOpenLocationDialogClass
+{
+	GtkDialogClass parent_class;
+};
+
+/*
+ * Public methods
+ */
+GType pluma_open_location_dialog_get_type(void);
+
+GtkWidget *pluma_open_location_dialog_new(GtkWindow *parent);
+
+GFile *pluma_open_location_dialog_get_location(PlumaOpenLocationDialog *dlg);
+
+const PlumaEncoding	*pluma_open_location_dialog_get_encoding(PlumaOpenLocationDialog *dlg);
+
+/*
+ * The widget automatically runs the help viewer when the Help button is pressed,
+ * so there is no need to catch the GTK_RESPONSE_HELP response.
+ *
+ * GTK_RESPONSE_OK response is emitted when the "Open" button is pressed.
+ */
+
+G_END_DECLS
+
+#endif  /* __PLUMA_OPEN_LOCATION_DIALOG_H__  */

--- a/pluma/dialogs/pluma-open-location-dialog.ui
+++ b/pluma/dialogs/pluma-open-location-dialog.ui
@@ -20,6 +20,7 @@
             <property name="can_focus">False</property>
             <property name="label" translatable="yes">Enter the _location of the file (URI) you would like to open:</property>
             <property name="use_underline">True</property>
+            <property name="mnemonic_widget">main_vbox</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -46,8 +47,9 @@
           <object class="GtkLabel" id="encoding_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">_Character Encoding:</property>
+            <property name="label" translatable="yes">Ch_aracter Encoding:</property>
             <property name="use_underline">True</property>
+            <property name="mnemonic_widget">encoding_hbox</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/pluma/dialogs/pluma-open-location-dialog.ui
+++ b/pluma/dialogs/pluma-open-location-dialog.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkBox" id="open_uri_dialog_content">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">5</property>
+    <child>
+      <object class="GtkBox" id="main_vbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">5</property>
+        <property name="homogeneous">True</property>
+        <child>
+          <object class="GtkLabel" id="location_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Enter the _location of the file (URI) you would like to open:</property>
+            <property name="use_underline">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="encoding_hbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="spacing">5</property>
+        <child>
+          <object class="GtkLabel" id="encoding_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">_Character Encoding:</property>
+            <property name="use_underline">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/pluma/pluma-ui.h
+++ b/pluma/pluma-ui.h
@@ -57,6 +57,8 @@ static const GtkActionEntry pluma_always_sensitive_menu_entries[] =
 	  N_("Create a new document"), G_CALLBACK (_pluma_cmd_file_new) },
 	{ "FileOpen", "document-open", N_("_Open..."), "<control>O",
 	  N_("Open a file"), G_CALLBACK (_pluma_cmd_file_open) },
+	{ "FileOpenURI", NULL, N_("Open _Location..."), "<control>L",
+	  N_("Open a file from a specified location"), G_CALLBACK (_pluma_cmd_file_open_uri) },
 
 	/* Edit menu */
 	{ "EditPreferences", "preferences-desktop", N_("Pr_eferences"), NULL,

--- a/pluma/pluma-ui.xml
+++ b/pluma/pluma-ui.xml
@@ -2,7 +2,7 @@
  * pluma-ui.xml
  * This file is part of pluma
  *
- * Copyright (C) 2005 - Paolo Maggi 
+ * Copyright (C) 2005 - Paolo Maggi
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,9 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA 02110-1301 USA.
  *
- * Modified by the pluma Team, 2005. See the AUTHORS file for a 
- * list of people on the pluma Team.  
- * See the ChangeLog files for a list of changes. 
+ * Modified by the pluma Team, 2005. See the AUTHORS file for a
+ * list of people on the pluma Team.
+ * See the ChangeLog files for a list of changes.
  *
  * $Id$
 -->
@@ -33,6 +33,7 @@
       <menuitem name="FileNewMenu" action="FileNew"/>
       <placeholder name="FileOps_1"/>
       <menuitem name="FileOpenMenu" action="FileOpen"/>
+      <menuitem name="FileOpenURIMenu" action="FileOpenURI"/>
       <placeholder name="FileOps_2"/>
       <separator/>
       <menuitem name="FileSaveMenu" action="FileSave"/>
@@ -60,9 +61,9 @@
       <menuitem name="EditCopyMenu" action="EditCopy"/>
       <menuitem name="EditPasteMenu" action="EditPaste"/>
       <menuitem name="EditDeleteMenu" action="EditDelete"/>
-      <placeholder name="EditOps_1" /> 
+      <placeholder name="EditOps_1" />
       <separator/>
-      <placeholder name="EditOps_2" /> 
+      <placeholder name="EditOps_2" />
       <menuitem name="EditSelectAllMenu" action="EditSelectAll"/>
       <placeholder name="EditOps_3" />
       <separator/>
@@ -103,12 +104,12 @@
       <separator/>
       <placeholder name="SearchOps_4" />
       <separator/>
-      <menuitem name="SearchClearHighlight" action="SearchClearHighlight"/>      
+      <menuitem name="SearchClearHighlight" action="SearchClearHighlight"/>
       <placeholder name="SearchOps_5" />
       <separator/>
       <placeholder name="SearchOps_6" />
       <separator/>
-      <menuitem name="SearchGoToLineMenu" action="SearchGoToLine"/>      
+      <menuitem name="SearchGoToLineMenu" action="SearchGoToLine"/>
       <placeholder name="SearchOps_7" />
       <separator/>
       <placeholder name="SearchOps_8" />
@@ -136,7 +137,7 @@
       <placeholder name="DocumentsOps_2" />
       <separator/>
       <placeholder name="DocumentsOps_3" />
-      <menuitem action="DocumentsPreviousDocument" />      
+      <menuitem action="DocumentsPreviousDocument" />
       <menuitem action="DocumentsNextDocument" />
       <separator/>
       <menuitem action="DocumentsMoveToNewWindow"/>
@@ -195,7 +196,7 @@
     <separator/>
     <menuitem action="FilePrint"/>
     <separator/>
-    <placeholder name="NotebookPupupOps_1"/>   
+    <placeholder name="NotebookPupupOps_1"/>
     <separator/>
     <menuitem name="FileCloseMenu" action="FileClose"/>
   </popup>

--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -2552,6 +2552,11 @@ set_sensitivity_according_to_window_state (PlumaWindow *window)
 	gtk_action_set_sensitive (action,
 				  !(window->priv->state & PLUMA_WINDOW_STATE_SAVING_SESSION));
 
+	action = gtk_action_group_get_action (window->priv->always_sensitive_action_group,
+						      "FileOpenURI");
+	gtk_action_set_sensitive (action,
+				  !(window->priv->state & PLUMA_WINDOW_STATE_SAVING_SESSION));
+
 	gtk_action_group_set_sensitive (window->priv->recents_action_group,
 					!(window->priv->state & PLUMA_WINDOW_STATE_SAVING_SESSION));
 


### PR DESCRIPTION
That feature was removed from gedit [in 2009](https://gitlab.gnome.org/GNOME/gedit/commit/26c2dfbd90b2f973f8540b15be4da38216e3a70b). I know that there is an option in file-chooser-dialog to open a file from location (ctrl+l), but most people don't. And this dialog here is fast accessible and features history entries. It is mostly the same code as 2009, but with some deprecation fixes.

![Screenshot at 2020-04-05 10-39-27](https://user-images.githubusercontent.com/39454100/78470418-be66e400-7729-11ea-832f-5bc7fbc7300d.png)

 Fixes #210 