### PR TITLE
pluma.c: set PlumaWindow size-request (min-size) to 250x250

### DIFF
--- a/pluma/pluma.c
+++ b/pluma/pluma.c
@@ -619,6 +619,7 @@ main (int argc, char *argv[])
 
 		pluma_debug_message (DEBUG_APP, "Create main window");
 		window = pluma_app_create_window (app, NULL);
+		gtk_widget_set_size_request (GTK_WIDGET (window), 250, 250);
 
 		if (file_list != NULL)
 		{


### PR DESCRIPTION
Fixes #194 and according warnings `(pluma:32085): Gtk-CRITICAL **: 22:14:17.094: gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkScrollbar`
