### PR TITLE
help: Remove Open Location from shortcut keys table

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1140,14 +1140,6 @@
                     </row>
                     <row valign="top">
                         <entry>
-                            <para>Ctrl + L</para>
-                        </entry>
-                        <entry>
-                            <para>Open a location.</para>
-                        </entry>
-                    </row>
-                    <row valign="top">
-                        <entry>
                             <para>Ctrl + S</para>
                         </entry>
                         <entry>


### PR DESCRIPTION
Test
```
$ yelp help:pluma/pluma-shortcutkeys
```
### Before

![Screenshot at 2020-04-16 16-27-13](https://user-images.githubusercontent.com/10171411/79468451-37eeb400-7fff-11ea-8446-6b82ad5e9851.png)

### After

![Screenshot at 2020-04-16 16-24-55](https://user-images.githubusercontent.com/10171411/79468404-2d341f00-7fff-11ea-8417-68b6b3735744.png)
