### PR TITLE
help: Add tip about how to show location entry on Open File dialog

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -382,6 +382,9 @@
             <note>
                 <para>You can open multiple files in <application>pluma</application>. The application adds a tab for each open file to the window. For more on this see <xref linkend="pluma-tabs"/>.</para>
             </note>
+            <tip>
+                <para>You can type the file location on <guilabel>Open File</guilabel> dialog. To switch between location entry and breadcrumbs, press <keycombo><keycap>Ctrl</keycap><keycap>l</keycap></keycombo>, <keycap>.</keycap>, <keycap>~</keycap> or <keycap>/</keycap>.</para>
+            </tip>
         </section>
 
         <!-- ============= To Save a File ==================================== -->


### PR DESCRIPTION
Test
```shell
$ yelp help:pluma/pluma-open-file
```
Screenshot

![Screenshot at 2020-04-16 17-29-33](https://user-images.githubusercontent.com/10171411/79475788-7046c000-8008-11ea-9b4c-a626310f6ee9.png)
