### PR TITLE
pluma-utils: Enable multiline mode on regex search

### DIFF
--- a/pluma/pluma-utils.c
+++ b/pluma/pluma-utils.c
@@ -1573,7 +1573,7 @@ pluma_gtk_text_iter_regex_search (const GtkTextIter *iter,
 	gboolean found;
 
 	match_string = "";
-	compile_flags = 0;
+	compile_flags = G_REGEX_OPTIMIZE | G_REGEX_MULTILINE;
 
 	if ((flags & GTK_TEXT_SEARCH_CASE_INSENSITIVE) != 0)
 		compile_flags |= G_REGEX_CASELESS;


### PR DESCRIPTION
Test: search `^\d{2}\.\w{3}+.*` in te text below:
```
11 aa 222
11.aaa 222
 11 aaa 222
11.aaa 222
11
11.aaa 222
```

Result: found the even lines

<img width="668" alt="Captura de Pantalla 2020-04-16 a les 22 00 47" src="https://user-images.githubusercontent.com/10171411/79501100-c9751a80-802d-11ea-8915-0dfbbe660d21.png">


Closes #541
