### PR TITLE
help: add a link to syntax and semantics of regex

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -505,6 +505,7 @@
                     <guimenu>Search</guimenu> 
                     <guimenuitem>Clear Highlight</guimenuitem> 
                 </menuchoice>.</para>
+             <para>Refer to the <link xlink:href="man:pcrepattern"> <citerefentry> <refentrytitle>pcrepattern</refentrytitle> <manvolnum>3</manvolnum> </citerefentry> </link> for more information about the syntax and the semantics of the regular expressions supported on <guilabel>Find</guilabel>  dialog.</para>
         </section>
 
         <section xml:id="pluma-find-incremental">


### PR DESCRIPTION
Test:
```
$ yelp help:pluma/pluma-find-text
```

![Screenshot at 2020-04-16 22-51-55](https://user-images.githubusercontent.com/10171411/79505729-18727e00-8035-11ea-9a4a-384a3b4ea413.png)

![Screenshot at 2020-04-16 22-52-14](https://user-images.githubusercontent.com/10171411/79505757-232d1300-8035-11ea-91a8-feb3c169401e.png)


Closes #538