### PR TITLE
preferences: enable the plugin 'sort' by default

### DIFF
--- a/data/org.mate.pluma.gschema.xml.in
+++ b/data/org.mate.pluma.gschema.xml.in
@@ -217,7 +217,7 @@
       <description>List of entries in "replace with" textbox.</description>
     </key>
     <key name="active-plugins" type="as">
-      <default>[ 'docinfo', 'modelines', 'filebrowser', 'spell', 'time' ]</default>
+      <default>[ 'docinfo', 'modelines', 'filebrowser', 'spell', 'time', 'sort' ]</default>
       <summary>Active plugins</summary>
       <description>List of active plugins. It contains the "Location" of the active plugins. See the .pluma-plugin file for obtaining the "Location" of a given plugin.</description>
     </key>


### PR DESCRIPTION
Hi,

The "sort" plugin is widely used by users, let's enable it by default.

Thank you.

Best regards.