### PR TITLE
Remove unused macros

### DIFF
--- a/pluma/pluma-encodings-combo-box.c
+++ b/pluma/pluma-encodings-combo-box.c
@@ -40,8 +40,6 @@
 #include <pluma/pluma-prefs-manager.h>
 #include <pluma/dialogs/pluma-encodings-dialog.h>
 
-#define ENCODING_KEY "Enconding"
-
 struct _PlumaEncodingsComboBoxPrivate
 {
 	GtkListStore *store;

--- a/pluma/pluma-utils.c
+++ b/pluma/pluma-utils.c
@@ -57,8 +57,6 @@
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 
-#define STDIN_DELAY_MICROSECONDS 100000
-
 /**
  * pluma_utils_uris_has_file_scheme
  *

--- a/tests/document-saver.c
+++ b/tests/document-saver.c
@@ -42,7 +42,6 @@
 #define UNOWNED_LOCAL_DIRECTORY "/tmp/pluma-document-saver-unowned"
 #define UNOWNED_LOCAL_URI "/tmp/pluma-document-saver-unowned/pluma-document-saver-test.txt"
 
-#define UNOWNED_REMOTE_DIRECTORY "sftp://localhost/tmp/pluma-document-saver-unowned"
 #define UNOWNED_REMOTE_URI "sftp://localhost/tmp/pluma-document-saver-unowned/pluma-document-saver-test.txt"
 
 #define UNOWNED_GROUP_LOCAL_URI "/tmp/pluma-document-saver-unowned-group.txt"


### PR DESCRIPTION
Test:
```
$ CFLAGS="-Wunused-macros" ./autogen.sh --prefix=/usr && LANG=en_US.UTF-8 make &> make.log
$ grep -v marshal make.log | grep -v EGG | grep -A 2 unused-macros
<cut>
--
pluma-encodings-combo-box.c:43: warning: macro "ENCODING_KEY" is not used [-Wunused-macros]
   43 | #define ENCODING_KEY "Enconding"
      | 
--
pluma-utils.c:60: warning: macro "STDIN_DELAY_MICROSECONDS" is not used [-Wunused-macros]
   60 | #define STDIN_DELAY_MICROSECONDS 100000
      | 
--
document-saver.c:45: warning: macro "UNOWNED_REMOTE_DIRECTORY" is not used [-Wunused-macros]
   45 | #define UNOWNED_REMOTE_DIRECTORY "sftp://localhost/tmp/pluma-document-saver-unowned"
      | 
```