### PR TITLE
Avoid tracking .po files by Git yet managed by Transifex

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -298,6 +298,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk $(top_srcdir)/configure.a
 				po/stamp-po \
 				po/.intltool-merge-cache \
 				"po/*.gmo" \
+				"po/*.po" \
 				"po/*.header" \
 				"po/*.mo" \
 				"po/*.sed" \


### PR DESCRIPTION
"git commit -a" can upload .po files with no reason with "git push".
.po files are provides by Transifex synchronization.
I think it's better to avoid this.