### PR TITLE
pluma-document: Fix warning assertion 'G_IS_FILE (file)' failed

### DIFF
--- a/pluma/pluma-document.c
+++ b/pluma/pluma-document.c
@@ -699,7 +699,12 @@ set_language (PlumaDocument     *doc,
               gboolean           set_by_user)
 {
 	GtkSourceLanguage *old_lang;
-	const gchar       *bom_langs;
+	const gchar       *new_lang_id;
+	const gchar       *bom_langs[] = {
+		"asp", "dtl", "docbook", "html", "mxml", "mallard", "markdown",
+		"mediawiki", "php", "tera", "xml", "xslt", NULL
+	};
+	gboolean is_bom_lang = FALSE;
 
 	pluma_debug (DEBUG_DOCUMENT);
 
@@ -708,9 +713,11 @@ set_language (PlumaDocument     *doc,
 	if (old_lang == lang)
 		return;
 
-	bom_langs = "asp,dtl,docbook,html,mxml,mallard,markdown,mediawiki,php,tera,xml,xslt";
+	new_lang_id = gtk_source_language_get_id (lang);
+	if (new_lang_id)
+		is_bom_lang = g_strv_contains (bom_langs, new_lang_id);
 
-	if (g_strrstr (bom_langs, gtk_source_language_get_id (lang)))
+	if (is_bom_lang)
 	{
 		GFile *file;
 

--- a/pluma/pluma-document.c
+++ b/pluma/pluma-document.c
@@ -713,12 +713,17 @@ set_language (PlumaDocument     *doc,
 	if (g_strrstr (bom_langs, gtk_source_language_get_id (lang)))
 	{
 		GFile *file;
+
 		file = pluma_document_get_location (doc);
+		if (file)
+		{
+			if (!file_with_bom (file))
+				gtk_source_buffer_set_language (GTK_SOURCE_BUFFER (doc), lang);
 
-		if (!file_with_bom (file))
+			g_object_unref (file);
+		}
+		else
 			gtk_source_buffer_set_language (GTK_SOURCE_BUFFER (doc), lang);
-
-		g_object_unref (file);
 	}
 	else
 		gtk_source_buffer_set_language (GTK_SOURCE_BUFFER (doc), lang);


### PR DESCRIPTION
Test: Create a new document, without saving the new document, select a highlight mode
```
(pluma:84684): GLib-GIO-CRITICAL **: 22:56:46.725: g_file_get_path: assertion 'G_IS_FILE (file)' failed
fopen: Bad address
```