### PR TITLE
Remove -Wmissing-field-initializers warnings

### DIFF
--- a/plugins/filebrowser/pluma-file-browser-widget.c
+++ b/plugins/filebrowser/pluma-file-browser-widget.c
@@ -789,7 +789,7 @@ create_combo (PlumaFileBrowserWidget * obj)
 
 static GtkActionEntry toplevel_actions[] =
 {
-	{"FilterMenuAction", NULL, N_("_Filter")}
+	{"FilterMenuAction", NULL, N_("_Filter"), NULL, NULL, NULL}
 };
 
 static const GtkActionEntry tree_actions_selection[] =

--- a/pluma/pluma-ui.h
+++ b/pluma/pluma-ui.h
@@ -44,13 +44,13 @@ G_BEGIN_DECLS
 static const GtkActionEntry pluma_always_sensitive_menu_entries[] =
 {
 	/* Toplevel */
-	{ "File", NULL, N_("_File") },
-	{ "Edit", NULL, N_("_Edit") },
-	{ "View", NULL, N_("_View") },
-	{ "Search", NULL, N_("_Search") },
-	{ "Tools", NULL, N_("_Tools") },
-	{ "Documents", NULL, N_("_Documents") },
-	{ "Help", NULL, N_("_Help") },
+	{ "File", NULL, N_("_File"), NULL, NULL, NULL },
+	{ "Edit", NULL, N_("_Edit"), NULL, NULL, NULL },
+	{ "View", NULL, N_("_View"), NULL, NULL, NULL },
+	{ "Search", NULL, N_("_Search"), NULL, NULL, NULL },
+	{ "Tools", NULL, N_("_Tools"), NULL, NULL, NULL },
+	{ "Documents", NULL, N_("_Documents"), NULL, NULL, NULL },
+	{ "Help", NULL, N_("_Help"), NULL, NULL, NULL },
 
 	/* File menu */
 	{ "FileNew", "document-new", N_("_New"), "<control>N",
@@ -105,7 +105,7 @@ static const GtkActionEntry pluma_menu_entries[] =
 	  N_("Select the entire document"), G_CALLBACK (_pluma_cmd_edit_select_all) },
 
 	/* View menu */
-	{ "ViewHighlightMode", NULL, N_("_Highlight Mode") },
+	{ "ViewHighlightMode", NULL, N_("_Highlight Mode"), NULL, NULL, NULL },
 
 	/* Search menu */
 	{ "SearchFind", "edit-find", N_("_Find..."), "<control>F",


### PR DESCRIPTION
```
--
pluma-ui.h:47:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
   47 |  { "File", NULL, N_("_File") },
      |  ^
--
pluma-ui.h:48:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
   48 |  { "Edit", NULL, N_("_Edit") },
      |  ^
--
pluma-ui.h:49:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
   49 |  { "View", NULL, N_("_View") },
      |  ^
--
pluma-ui.h:50:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
   50 |  { "Search", NULL, N_("_Search") },
      |  ^
--
pluma-ui.h:51:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
   51 |  { "Tools", NULL, N_("_Tools") },
      |  ^
--
pluma-ui.h:52:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
   52 |  { "Documents", NULL, N_("_Documents") },
      |  ^
--
pluma-ui.h:53:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
   53 |  { "Help", NULL, N_("_Help") },
      |  ^
--
pluma-ui.h:108:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'const struct _GtkActionEntry'} [-Wmissing-field-initializers]
  108 |  { "ViewHighlightMode", NULL, N_("_Highlight Mode") },
      |  ^
--
pluma-file-browser-widget.c:792:2: warning: missing initializer for field 'accelerator' of 'GtkActionEntry' {aka 'struct _GtkActionEntry'} [-Wmissing-field-initializers]
  792 |  {"FilterMenuAction", NULL, N_("_Filter")}
      |  ^
```