### PR TITLE
travis: fix build error on archlinux

### DIFF
--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -100,6 +100,8 @@ include $(top_srcdir)/gtk-doc.make
 # Other files to distribute
 # e.g. EXTRA_DIST += version.xml.in
 
+DISTCLEANFILES = $(DOC_MODULE).actions
+
 regenerate-types:
 	grep _get_type $(DOC_SOURCE_DIR)/pluma-*.h | grep -oR '^.*\.h' | sort | uniq - | sed -r 's/^.*\.h$/#include "\0"/' > pluma.types
 	grep _get_type $(DOC_SOURCE_DIR)/pluma-*.h | grep -oR '^.*\.h' | sort | uniq - | sed -re 'y/-/_/' -e 's/^(.*)\.h$/\1_get_type/' >> pluma.types.new


### PR DESCRIPTION
Fix make distcheck failed on archlinux:
```
make[2]: Leaving directory '/rootdir/pluma-1.25.0/_build/sub'
rm -f config.status config.cache config.log configure.lineno config.status.lineno
rm -f Makefile
ERROR: files left in build directory after distclean:
./docs/reference/pluma.actions
make[1]: *** [Makefile:812: distcleancheck] Error 1
make[1]: Leaving directory '/rootdir/pluma-1.25.0/_build/sub'
make: *** [Makefile:741: distcheck] Error 1
!!! ERROR: run command [docker exec -t pluma-archlinux-build /rootdir/after_scripts].
```