### PR TITLE
pluma-view: Fix incorrect interface font - 1.24 branch

### DIFF
--- a/pluma/Makefile.am
+++ b/pluma/Makefile.am
@@ -53,6 +53,7 @@ NOINST_H_FILES =			\
 	pluma-history-entry.h		\
 	pluma-io-error-message-area.h	\
 	pluma-language-manager.h	\
+	pluma-pango.h		\
 	pluma-plugins-engine.h		\
 	pluma-prefs-manager-private.h	\
 	pluma-print-job.h		\
@@ -129,6 +130,7 @@ libpluma_c_files = 			\
 	pluma-message.c			\
 	pluma-notebook.c		\
 	pluma-panel.c			\
+	pluma-pango.c			\
 	pluma-plugins-engine.c		\
 	pluma-prefs-manager-app.c	\
 	pluma-prefs-manager.c		\

--- a/pluma/pluma-pango.c
+++ b/pluma/pluma-pango.c
@@ -1,0 +1,230 @@
+/* pluma-pango.c
+ *
+ * This file is a copy of pango_font_description_to_css from gtk gtkfontbutton.c
+ *
+ * Copyright (C) 2016 Matthias Clasen <mclasen@redhat.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define G_LOG_DOMAIN "pluma-pango"
+
+#include "config.h"
+
+#include "pluma-pango.h"
+
+#if PANGO_VERSION_CHECK (1, 44, 0)
+static void
+add_css_variations (GString    *s,
+                    const char *variations)
+{
+  const char *p;
+  const char *sep = "";
+
+  if (variations == NULL || variations[0] == '\0')
+    {
+      g_string_append (s, "normal");
+      return;
+    }
+
+  p = variations;
+  while (p && *p)
+    {
+      const char *start;
+      const char *end, *end2;
+      double value;
+      char name[5];
+
+      while (g_ascii_isspace (*p)) p++;
+
+      start = p;
+      end = strchr (p, ',');
+      if (end && (end - p < 6))
+        goto skip;
+
+      name[0] = p[0];
+      name[1] = p[1];
+      name[2] = p[2];
+      name[3] = p[3];
+      name[4] = '\0';
+
+      p += 4;
+      while (g_ascii_isspace (*p)) p++;
+      if (*p == '=') p++;
+
+      if (p - start < 5)
+        goto skip;
+
+      value = g_ascii_strtod (p, (char **) &end2);
+
+      while (end2 && g_ascii_isspace (*end2)) end2++;
+
+      if (end2 && (*end2 != ',' && *end2 != '\0'))
+        goto skip;
+
+      g_string_append_printf (s, "%s\"%s\" %g", sep, name, value);
+      sep = ", ";
+
+skip:
+      p = end ? end + 1 : NULL;
+    }
+}
+#endif
+
+/**
+ * pluma_pango_font_description_to_css:
+ *
+ * This function will generate CSS suitable for Gtk's CSS engine
+ * based on the properties of the #PangoFontDescription.
+ *
+ * Returns: (transfer full): A newly allocated string containing the
+ *    CSS describing the font description.
+ */
+gchar *
+pluma_pango_font_description_to_css (const PangoFontDescription *desc)
+{
+  GString *s;
+  PangoFontMask set;
+
+  s = g_string_new ("");
+
+  set = pango_font_description_get_set_fields (desc);
+  if (set & PANGO_FONT_MASK_FAMILY)
+    {
+      g_string_append (s, "font-family: ");
+      g_string_append (s, pango_font_description_get_family (desc));
+      g_string_append (s, "; ");
+    }
+  if (set & PANGO_FONT_MASK_STYLE)
+    {
+      switch (pango_font_description_get_style (desc))
+        {
+        case PANGO_STYLE_NORMAL:
+          g_string_append (s, "font-style: normal; ");
+          break;
+        case PANGO_STYLE_OBLIQUE:
+          g_string_append (s, "font-style: oblique; ");
+          break;
+        case PANGO_STYLE_ITALIC:
+          g_string_append (s, "font-style: italic; ");
+          break;
+        default:
+          break;
+        }
+    }
+  if (set & PANGO_FONT_MASK_VARIANT)
+    {
+      switch (pango_font_description_get_variant (desc))
+        {
+        case PANGO_VARIANT_NORMAL:
+          g_string_append (s, "font-variant: normal; ");
+          break;
+        case PANGO_VARIANT_SMALL_CAPS:
+          g_string_append (s, "font-variant: small-caps; ");
+          break;
+        default:
+          break;
+        }
+    }
+  if (set & PANGO_FONT_MASK_WEIGHT)
+    {
+      switch (pango_font_description_get_weight (desc))
+        {
+        case PANGO_WEIGHT_THIN:
+          g_string_append (s, "font-weight: 100; ");
+          break;
+        case PANGO_WEIGHT_ULTRALIGHT:
+          g_string_append (s, "font-weight: 200; ");
+          break;
+        case PANGO_WEIGHT_LIGHT:
+        case PANGO_WEIGHT_SEMILIGHT:
+          g_string_append (s, "font-weight: 300; ");
+          break;
+        case PANGO_WEIGHT_BOOK:
+        case PANGO_WEIGHT_NORMAL:
+          g_string_append (s, "font-weight: 400; ");
+          break;
+        case PANGO_WEIGHT_MEDIUM:
+          g_string_append (s, "font-weight: 500; ");
+          break;
+        case PANGO_WEIGHT_SEMIBOLD:
+          g_string_append (s, "font-weight: 600; ");
+          break;
+        case PANGO_WEIGHT_BOLD:
+          g_string_append (s, "font-weight: 700; ");
+          break;
+        case PANGO_WEIGHT_ULTRABOLD:
+          g_string_append (s, "font-weight: 800; ");
+          break;
+        case PANGO_WEIGHT_HEAVY:
+        case PANGO_WEIGHT_ULTRAHEAVY:
+          g_string_append (s, "font-weight: 900; ");
+          break;
+        default:
+          break;
+        }
+    }
+  if (set & PANGO_FONT_MASK_STRETCH)
+    {
+      switch (pango_font_description_get_stretch (desc))
+        {
+        case PANGO_STRETCH_ULTRA_CONDENSED:
+          g_string_append (s, "font-stretch: ultra-condensed; ");
+          break;
+        case PANGO_STRETCH_EXTRA_CONDENSED:
+          g_string_append (s, "font-stretch: extra-condensed; ");
+          break;
+        case PANGO_STRETCH_CONDENSED:
+          g_string_append (s, "font-stretch: condensed; ");
+          break;
+        case PANGO_STRETCH_SEMI_CONDENSED:
+          g_string_append (s, "font-stretch: semi-condensed; ");
+          break;
+        case PANGO_STRETCH_NORMAL:
+          g_string_append (s, "font-stretch: normal; ");
+          break;
+        case PANGO_STRETCH_SEMI_EXPANDED:
+          g_string_append (s, "font-stretch: semi-expanded; ");
+          break;
+        case PANGO_STRETCH_EXPANDED:
+          g_string_append (s, "font-stretch: expanded; ");
+          break;
+        case PANGO_STRETCH_EXTRA_EXPANDED:
+          break;
+        case PANGO_STRETCH_ULTRA_EXPANDED:
+          g_string_append (s, "font-stretch: ultra-expanded; ");
+          break;
+        default:
+          break;
+        }
+    }
+  if (set & PANGO_FONT_MASK_SIZE)
+    {
+      g_string_append_printf (s, "font-size: %dpt; ", pango_font_description_get_size (desc) / PANGO_SCALE);
+    }
+
+#if PANGO_VERSION_CHECK (1, 44, 0)
+  if (set & PANGO_FONT_MASK_VARIATIONS)
+    {
+      const char *variations;
+
+      g_string_append (s, "font-variation-settings: ");
+      variations = pango_font_description_get_variations (desc);
+      add_css_variations (s, variations);
+      g_string_append (s, "; ");
+    }
+#endif
+
+  return g_string_free (s, FALSE);
+}

--- a/pluma/pluma-pango.h
+++ b/pluma/pluma-pango.h
@@ -1,0 +1,28 @@
+/* pluma-pango.h
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PLUMA_PANGO_H
+#define PLUMA_PANGO_H
+
+#include <pango/pango.h>
+
+G_BEGIN_DECLS
+
+gchar *pluma_pango_font_description_to_css (const PangoFontDescription *font_desc);
+
+G_END_DECLS
+
+#endif /* PLUMA_PANGO_H */


### PR DESCRIPTION
Fixes issue #525 by setting the textview font with css without also setting
the font for the labels. Changes based on gedit and gtk/gtkfontbutton.c.