### PR TITLE
build: display package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,8 +273,10 @@ tests/Makefile
 AC_OUTPUT
 
 echo "
+Configure summary:
 
-Configuration:
+	${PACKAGE_STRING}
+	`echo $PACKAGE_STRING | sed "s/./=/g"`
 
 	Source code location:	${srcdir}
 	Compiler:		${CC}


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>

Configure summary:

	pluma 1.25.0
	============

	Source code location:	.
	Compiler:		gcc
	Compiler flags:		-g -O2
	Warning flags:		-Wall -Wmissing-prototypes
	Spell Plugin enabled:	yes
	Gvfs metadata enabled:	yes
	GObject Introspection:	yes
	Tests enabled:		yes

 *** IMPORTANT ***

This is an unstable version of pluma.
It is for test purposes only.

Please, DO NOT use it in a production environment.
It will probably crash and you will lose your data.

If you are looking for a stable release of pluma, either download
it from:

  http://pub.mate-desktop.org/release/1.24/

Or checkout the 1.24 branch of the pluma module from:

  git://github.com/mate-desktop/pluma.git

Thanks,
The pluma team

 *** END OF WARNING ***
Now type `make' to compile pluma
```