### PR TITLE
cppcheck warning: Local variable 'icon' shadows outer argument

### DIFF
--- a/plugins/filebrowser/pluma-file-browser-widget.c
+++ b/plugins/filebrowser/pluma-file-browser-widget.c
@@ -1516,7 +1516,7 @@ get_topmost_file (GFile * file)
 static GtkWidget *
 create_goto_menu_item (PlumaFileBrowserWidget *obj,
                        GList                  *item,
-                       GdkPixbuf              *icon)
+                       GdkPixbuf              *icon_pixbuf)
 {
 	GtkWidget *menu_item;
 	gchar     *label_text;
@@ -1528,8 +1528,8 @@ create_goto_menu_item (PlumaFileBrowserWidget *obj,
 	if (!get_from_bookmark_file (obj, loc->virtual_root, &label_text, &pixbuf)) {
 		label_text = pluma_file_browser_utils_file_basename (loc->virtual_root);
 
-		if (icon)
-			pixbuf = g_object_ref (icon);
+		if (icon_pixbuf)
+			pixbuf = g_object_ref (icon_pixbuf);
 	}
 
 	if (pixbuf) {


### PR DESCRIPTION
Test
```
$ cppcheck --enable=all --quiet . &> cppcheck.log && grep shadowArgument cppcheck.log
plugins/filebrowser/pluma-file-browser-widget.c:1538:14: style: Local variable 'icon' shadows outer argument [shadowArgument]
```