### PR TITLE
cppcheck warning: Checking if unsigned expression is less than zero

### DIFF
--- a/plugins/taglist/pluma-taglist-plugin-panel.c
+++ b/plugins/taglist/pluma-taglist-plugin-panel.c
@@ -416,7 +416,7 @@ selected_group_changed (GtkComboBox             *combo,
 
 	group_name = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (combo));
 
-	if ((group_name == NULL) || (strlen (group_name) <= 0))
+	if ((group_name == NULL) || (*group_name == '\0'))
 	{
 		g_free (group_name);
 		return;


### PR DESCRIPTION
Test:
```
$ cppcheck --enable=all --quiet . &> cppcheck.log && grep unsignedLessThanZero cppcheck.log 
plugins/taglist/pluma-taglist-plugin-panel.c:419:51: style: Checking if unsigned expression 'strlen(group_name)' is less than zero. [unsignedLessThanZero]
```