### PR TITLE
pluma-window: unused variable ‘ui_file’ [-Wunused-variable]

### DIFF
--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -1496,7 +1496,6 @@ create_menu_bar_and_toolbar (PlumaWindow *window,
     GtkUIManager *manager;
     GtkRecentManager *recent_manager;
     GError *error = NULL;
-    gchar *ui_file;
 
     pluma_debug (DEBUG_WINDOW);
 


### PR DESCRIPTION
culprit c7101aa