### PR TITLE
build: fix shebangs

### DIFF
--- a/data/pluma-bugreport.sh.in
+++ b/data/pluma-bugreport.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 
 PKG_CONFIG_MODULES="glib-2.0 gtk+-3.0 gtksourceview-4 enchant iso-codes"
 

--- a/plugins/externaltools/data/build.tool.in
+++ b/plugins/externaltools/data/build.tool.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 
 EHOME=`echo $HOME | sed "s/#/\#/"`
 DIR=$PLUMA_CURRENT_DOCUMENT_DIR

--- a/plugins/externaltools/data/open-terminal-here.tool.in
+++ b/plugins/externaltools/data/open-terminal-here.tool.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 
 #TODO: use "mateconftool-2 -g /desktop/mate/applications/terminal/exec"
 mate-terminal --working-directory=$PLUMA_CURRENT_DOCUMENT_DIR &

--- a/plugins/externaltools/data/remove-trailing-spaces.tool.in
+++ b/plugins/externaltools/data/remove-trailing-spaces.tool.in
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/sh
 
 sed 's/[[:blank:]]*$//'

--- a/plugins/externaltools/data/run-command.tool.in
+++ b/plugins/externaltools/data/run-command.tool.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 
 #TODO: use "gsettings get org.mate.applications-terminal exec"
 exec `zenity --entry --title="Run command - Pluma" --text="Command to run"`

--- a/plugins/externaltools/data/search-recursive.tool.in
+++ b/plugins/externaltools/data/search-recursive.tool.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/sh
 # Copyright © 2011 Perberos
 #
 # This program is free software; you can redistribute it and/or modify it

--- a/plugins/externaltools/data/switch-c.tool.in
+++ b/plugins/externaltools/data/switch-c.tool.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 # Copyright © 2011 Perberos
 # Copyright © 2012-2017 MATE developers


### PR DESCRIPTION
- mangling shebang warnings
- ambiguous python shebang error

From fedora build server with pluma-1.24.2
https://koji.fedoraproject.org/koji/getfile?taskID=64704645&volume=DEFAULT&name=build.log&offset=-4000
```
+ /usr/lib/rpm/redhat/brp-mangle-shebangs
mangling shebang in /usr/share/pluma/plugins/externaltools/tools/build from /bin/sh to #!/usr/bin/sh
mangling shebang in /usr/share/pluma/plugins/externaltools/tools/open-terminal-here from /bin/sh to #!/usr/bin/sh
mangling shebang in /usr/share/pluma/plugins/externaltools/tools/remove-trailing-spaces from /bin/sh to #!/usr/bin/sh
mangling shebang in /usr/share/pluma/plugins/externaltools/tools/run-command from /bin/sh to #!/usr/bin/sh
mangling shebang in /usr/share/pluma/plugins/externaltools/tools/search-recursive from /bin/bash to #!/usr/bin/bash
*** ERROR: ambiguous python shebang in /usr/share/pluma/plugins/externaltools/tools/switch-c: #!/usr/bin/python. Change it to python3 (or python2) explicitly.
mangling shebang in /usr/libexec/pluma/pluma-bugreport.sh from /bin/sh to #!/usr/bin/sh
error: Bad exit status from /var/tmp/rpm-tmp.3qkkmn (%install)
RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.3qkkmn (%install)
Child return code was: 1
EXCEPTION: [Error()]
```