### PR TITLE
quickopen-plugin: Use Gio.Settings instead of Pluma.MessageBus.send_s…

### DIFF
--- a/plugins/quickopen/quickopen/windowhelper.py
+++ b/plugins/quickopen/quickopen/windowhelper.py
@@ -87,22 +87,13 @@ class WindowHelper:
             paths.append(gfile.get_parent())
 
         # File browser root directory
-        bus = self._window.get_message_bus()
+        settings = Gio.Settings.new('org.mate.pluma.plugins.filebrowser.on-load')
+        root = settings.get_string('virtual-root')
+        if root:
+            gfile = Gio.file_new_for_uri(root)
 
-        try:
-            msg = bus.send_sync('/plugins/filebrowser', 'get_root')
-
-            if msg:
-                uri = msg.get_value('uri')
-
-                if uri:
-                    gfile = Gio.file_new_for_uri(uri)
-
-                    if gfile and gfile.is_native():
-                        paths.append(gfile)
-
-        except Exception:
-            pass
+            if gfile and gfile.is_native():
+                paths.append(gfile)
 
         # Recent documents
         paths.append(RecentDocumentsDirectory())


### PR DESCRIPTION
…ync()

This completely avoids the use of the message bus to get the filebrowser
root directory.

Traceback (most recent call last):
  File "/usr/lib64/pluma/plugins/pythonconsole/console.py", line 357, in __run
    r = eval(command, self.namespace, self.namespace)
  File "<string>", line 1, in <module>
AttributeError: 'MessageBus' object has no attribute 'send_sync'