### PR TITLE
pluma-commands-search: fix warning -Wenum-conversion

### DIFF
--- a/pluma/pluma-commands-search.c
+++ b/pluma/pluma-commands-search.c
@@ -398,7 +398,7 @@ do_replace (PlumaSearchDialog *dialog,
 		{
 		need_refind = !g_regex_match_simple(unescaped_search_text,
 						    selected_text,
-						    match_case ? 0 : GTK_TEXT_SEARCH_CASE_INSENSITIVE ,
+						    match_case ? 0 : G_REGEX_CASELESS,
 						    0);
 		}
 	}


### PR DESCRIPTION
```
CC=clang CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" ./autogen.sh --prefix=/usr --enable-debug  --enable-compile-warnings=maximum && make &> make.log && sudo make install
```
Fix build warning:
```
pluma-commands-search.c:401:28: warning: implicit conversion from enumeration type 'GtkTextSearchFlags' to different enumeration type 'GRegexCompileFlags' [-Wenum-conversion]
                                                    match_case ? 0 : GTK_TEXT_SEARCH_CASE_INSENSITIVE ,
                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Test: find and replace a regex with or without match case.

<img width="521" alt="Captura de Pantalla 2021-10-20 a les 21 19 02" src="https://user-images.githubusercontent.com/10171411/138158289-d44a06e1-f1d9-4e41-afd9-2c72e298a838.png">
