### PR TITLE
release 1.26.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+### pluma 1.26.0
+
+  * Translations update
+  * filebrowser-plugin: fix segfault on open-terminal action
+  * update copyright to 2021
+  * build: fix shebangs
+  * warning: declaration of ‘taglist’ shadows a global declaration
+  * pluma: Use EXIT_SUCCESS macro instead of int value (portability)
+  * help: update help for sort plugin
+  * sort plugin: Port sort plugin to the new GtkSourceView api.
+
 ### pluma 1.25.3
 
   * port plugins to use the window-construct property.

--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,8 @@ dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.63.2)
 
 m4_define(pluma_major_version, 1)
-m4_define(pluma_minor_version, 25)
-m4_define(pluma_micro_version, 3)
+m4_define(pluma_minor_version, 26)
+m4_define(pluma_micro_version, 0)
 m4_define(pluma_version, pluma_major_version.pluma_minor_version.pluma_micro_version)
 
 AC_INIT([pluma], [pluma_version],

--- a/plugins/filebrowser/pluma-file-bookmarks-store.c
+++ b/plugins/filebrowser/pluma-file-bookmarks-store.c
@@ -824,10 +824,8 @@ pluma_file_bookmarks_store_get_uri (PlumaFileBookmarksStore * model,
 				    GtkTreeIter * iter)
 {
 	GObject * obj;
-	GFile * file = NULL;
 	guint flags;
 	gchar * ret = NULL;
-	gboolean isfs;
 
 	g_return_val_if_fail (PLUMA_IS_FILE_BOOKMARKS_STORE (model), NULL);
 	g_return_val_if_fail (iter != NULL, NULL);
@@ -839,26 +837,25 @@ pluma_file_bookmarks_store_get_uri (PlumaFileBookmarksStore * model,
 			    &obj,
 			    -1);
 
-	if (obj == NULL)
-		return NULL;
-
-	isfs = (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_FS);
-
-	if (isfs && (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_MOUNT))
+	if (obj != NULL)
 	{
-		file = g_mount_get_root (G_MOUNT (obj));
-	}
-	else if (!isfs)
-	{
-		file = g_object_ref (obj);
-	}
+		if (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_FS)
+		{
+			if (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_MOUNT)
+			{
+				GFile * file;
 
-	g_object_unref (obj);
+				file = g_mount_get_root (G_MOUNT (obj));
+				ret = g_file_get_uri (file);
+				g_object_unref (file);
+			}
+		}
+		else
+		{
+			ret = g_file_get_uri (G_FILE (obj));
+		}
 
-	if (file)
-	{
-		ret = g_file_get_uri (file);
-		g_object_unref (file);
+		g_object_unref (obj);
 	}
 
 	return ret;


### PR DESCRIPTION
```
CC=clang CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" ./autogen.sh --prefix=/usr --enable-debug  --enable-compile-warnings=maximum && make &> make.log && sudo make install
```
warning
```
pluma-file-bookmarks-store.c:853:8: warning: incompatible pointer types assigning to 'GFile *' (aka 'struct _GFile *') from 'typeof (obj)' (aka 'struct _GObject *') [-Wincompatible-pointer-types]
                file = g_object_ref (obj);
                     ^ ~~~~~~~~~~~~~~~~~~
```