### PR TITLE
filebrowser: fix warning -Wincompatible-pointer-types

### DIFF
--- a/plugins/filebrowser/pluma-file-bookmarks-store.c
+++ b/plugins/filebrowser/pluma-file-bookmarks-store.c
@@ -824,10 +824,8 @@ pluma_file_bookmarks_store_get_uri (PlumaFileBookmarksStore * model,
 				    GtkTreeIter * iter)
 {
 	GObject * obj;
-	GFile * file = NULL;
 	guint flags;
 	gchar * ret = NULL;
-	gboolean isfs;
 
 	g_return_val_if_fail (PLUMA_IS_FILE_BOOKMARKS_STORE (model), NULL);
 	g_return_val_if_fail (iter != NULL, NULL);
@@ -839,26 +837,25 @@ pluma_file_bookmarks_store_get_uri (PlumaFileBookmarksStore * model,
 			    &obj,
 			    -1);
 
-	if (obj == NULL)
-		return NULL;
-
-	isfs = (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_FS);
-
-	if (isfs && (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_MOUNT))
+	if (obj != NULL)
 	{
-		file = g_mount_get_root (G_MOUNT (obj));
-	}
-	else if (!isfs)
-	{
-		file = g_object_ref (obj);
-	}
+		if (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_FS)
+		{
+			if (flags & PLUMA_FILE_BOOKMARKS_STORE_IS_MOUNT)
+			{
+				GFile * file;
 
-	g_object_unref (obj);
+				file = g_mount_get_root (G_MOUNT (obj));
+				ret = g_file_get_uri (file);
+				g_object_unref (file);
+			}
+		}
+		else
+		{
+			ret = g_file_get_uri (G_FILE (obj));
+		}
 
-	if (file)
-	{
-		ret = g_file_get_uri (file);
-		g_object_unref (file);
+		g_object_unref (obj);
 	}
 
 	return ret;


### PR DESCRIPTION
```
CC=clang CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" ./autogen.sh --prefix=/usr --enable-debug  --enable-compile-warnings=maximum && make &> make.log && sudo make install
```
warning
```
pluma-file-bookmarks-store.c:853:8: warning: incompatible pointer types assigning to 'GFile *' (aka 'struct _GFile *') from 'typeof (obj)' (aka 'struct _GObject *') [-Wincompatible-pointer-types]
                file = g_object_ref (obj);
                     ^ ~~~~~~~~~~~~~~~~~~
```