### PR TITLE
pluma-plugins-engine: fix memory leak

### DIFF
--- a/pluma/pluma-plugins-engine.c
+++ b/pluma/pluma-plugins-engine.c
@@ -57,6 +57,7 @@ static void
 pluma_plugins_engine_init (PlumaPluginsEngine *engine)
 {
 	GError *error = NULL;
+	char *user_plugins_dir;
 
 	pluma_debug (DEBUG_PLUGINS);
 
@@ -89,9 +90,11 @@ pluma_plugins_engine_init (PlumaPluginsEngine *engine)
 		g_clear_error (&error);
 	}
 
+	user_plugins_dir = pluma_dirs_get_user_plugins_dir ();
 	peas_engine_add_search_path (PEAS_ENGINE (engine),
-	                             pluma_dirs_get_user_plugins_dir (),
-	                             pluma_dirs_get_user_plugins_dir ());
+	                             user_plugins_dir,
+	                             user_plugins_dir);
+	g_free (user_plugins_dir);
 
 	peas_engine_add_search_path (PEAS_ENGINE (engine),
 	                             PLUMA_LIBDIR "/plugins",


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks
Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7f93b66cfcb8 in __interceptor_realloc (/lib64/libasan.so.6+0xaecb8)
    #1 0x7f93b52a4c97 in g_realloc ../glib/gmem.c:171
    #2 0x7f93b52cbe42 in g_string_maybe_expand ../glib/gstring.c:102
    #3 0x7f93b52cc6b7 in g_string_insert_len ../glib/gstring.c:486
    #4 0x7f93b52cc386 in g_string_append ../glib/gstring.c:549
    #5 0x7f93b527e63f in g_build_path_va ../glib/gfileutils.c:1969
    #6 0x7f93b527e92b in g_build_filename_va ../glib/gfileutils.c:2192
    #7 0x7f93b527eac8 in g_build_filename ../glib/gfileutils.c:2274
    #8 0x4317c3 in pluma_dirs_get_user_plugins_dir /home/robert/builddir.gcc/pluma/pluma/pluma-dirs.c:53
    #9 0x44fc39 in pluma_plugins_engine_init /home/robert/builddir.gcc/pluma/pluma/pluma-plugins-engine.c:93
    #10 0x7f93b53d4463 in g_type_create_instance ../gobject/gtype.c:1921
    #11 0x7f93b53b9ae4 in g_object_new_internal ../gobject/gobject.c:1939
    #12 0x7f93b53b9080 in g_object_new_with_properties ../gobject/gobject.c:2108
    #13 0x7f93b53b8e03 in g_object_new ../gobject/gobject.c:1779
    #14 0x44ff31 in pluma_plugins_engine_get_default /home/robert/builddir.gcc/pluma/pluma/pluma-plugins-engine.c:135
    #15 0x427a92 in main /home/robert/builddir.gcc/pluma/pluma/pluma.c:592
    #16 0x7f93b4f20b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7f93b66cfcb8 in __interceptor_realloc (/lib64/libasan.so.6+0xaecb8)
    #1 0x7f93b52a4c97 in g_realloc ../glib/gmem.c:171
    #2 0x7f93b52cbe42 in g_string_maybe_expand ../glib/gstring.c:102
    #3 0x7f93b52cc6b7 in g_string_insert_len ../glib/gstring.c:486
    #4 0x7f93b52cc386 in g_string_append ../glib/gstring.c:549
    #5 0x7f93b527e63f in g_build_path_va ../glib/gfileutils.c:1969
    #6 0x7f93b527e92b in g_build_filename_va ../glib/gfileutils.c:2192
    #7 0x7f93b527eac8 in g_build_filename ../glib/gfileutils.c:2274
    #8 0x4317c3 in pluma_dirs_get_user_plugins_dir /home/robert/builddir.gcc/pluma/pluma/pluma-dirs.c:53
    #9 0x44fc31 in pluma_plugins_engine_init /home/robert/builddir.gcc/pluma/pluma/pluma-plugins-engine.c:94
    #10 0x7f93b53d4463 in g_type_create_instance ../gobject/gtype.c:1921
    #11 0x7f93b53b9ae4 in g_object_new_internal ../gobject/gobject.c:1939
    #12 0x7f93b53b9080 in g_object_new_with_properties ../gobject/gobject.c:2108
    #13 0x7f93b53b8e03 in g_object_new ../gobject/gobject.c:1779
    #14 0x44ff31 in pluma_plugins_engine_get_default /home/robert/builddir.gcc/pluma/pluma/pluma-plugins-engine.c:135
    #15 0x427a92 in main /home/robert/builddir.gcc/pluma/pluma/pluma.c:592
    #16 0x7f93b4f20b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```