### PR TITLE
pluma: fix build warning about missing field initializer

### DIFF
--- a/pluma/pluma.c
+++ b/pluma/pluma.c
@@ -123,7 +123,7 @@ static const GOptionEntry options [] =
 	{ G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &remaining_args,
 	  NULL, N_("[FILE...]") }, /* collects file arguments */
 
-	{NULL}
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static void


### PR DESCRIPTION
```
pluma.c:126:7: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        {NULL}
             ^
```