### PR TITLE
Fix double activation of extensions

### DIFF
--- a/pluma/pluma-view.c
+++ b/pluma/pluma-view.c
@@ -413,11 +413,6 @@ on_notify_buffer_cb (PlumaView  *view,
                       "search_highlight_updated",
                       G_CALLBACK (search_highlight_updated_cb),
                       view);
-
-    /* We only activate the extensions when the right buffer is set,
-     * because most plugins will expect this behaviour, and we won't
-     * change the buffer later anyway. */
-    peas_extension_set_call (view->priv->extensions, "activate", view);
 }
 
 #ifdef GTK_SOURCE_VERSION_3_24
@@ -2320,9 +2315,9 @@ extension_removed (PeasExtensionSet *extensions,
 static void
 pluma_view_realize (GtkWidget *widget)
 {
-     PlumaView *view = PLUMA_VIEW (widget);
+    PlumaView *view = PLUMA_VIEW (widget);
 
-     GTK_WIDGET_CLASS (pluma_view_parent_class)->realize (widget);
+    GTK_WIDGET_CLASS (pluma_view_parent_class)->realize (widget);
 
     g_signal_connect (view->priv->extensions, "extension-added",
                       G_CALLBACK (extension_added),


### PR DESCRIPTION
see https://gitlab.gnome.org/GNOME/gedit/-/commit/aed206a36a561a60fd06db66182f91ad8d666992. In this commit it was deleted as well. The activation of the extensions takes place in `pluma_view_realize` (l. 2316) by calling 
```
		peas_extension_set_foreach (view->priv->extensions,
				            (PeasExtensionSetForeachFunc) extension_added,
				            view);
```
This should fix the problem exposed by https://github.com/mate-desktop/pluma-plugins/pull/31.