### PR TITLE
revert /usr/bin/sh shebangs + make search-recursive POSIX compliant

### DIFF
--- a/plugins/externaltools/data/build.tool.in
+++ b/plugins/externaltools/data/build.tool.in
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 EHOME=`echo $HOME | sed "s/#/\#/"`
 DIR=$PLUMA_CURRENT_DOCUMENT_DIR

--- a/plugins/externaltools/data/open-terminal-here.tool.in
+++ b/plugins/externaltools/data/open-terminal-here.tool.in
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 #TODO: use "mateconftool-2 -g /desktop/mate/applications/terminal/exec"
 mate-terminal --working-directory=$PLUMA_CURRENT_DOCUMENT_DIR &

--- a/plugins/externaltools/data/remove-trailing-spaces.tool.in
+++ b/plugins/externaltools/data/remove-trailing-spaces.tool.in
@@ -1,3 +1,3 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 sed 's/[[:blank:]]*$//'

--- a/plugins/externaltools/data/run-command.tool.in
+++ b/plugins/externaltools/data/run-command.tool.in
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 #TODO: use "gsettings get org.mate.applications-terminal exec"
 exec `zenity --entry --title="Run command - Pluma" --text="Command to run"`

--- a/plugins/externaltools/data/search-recursive.tool.in
+++ b/plugins/externaltools/data/search-recursive.tool.in
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # Copyright © 2011 Perberos
 # Copyright (C) 2012-2021 MATE Developers
 #

--- a/plugins/externaltools/data/search-recursive.tool.in
+++ b/plugins/externaltools/data/search-recursive.tool.in
@@ -17,24 +17,4 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 SEARCHTEXT=`zenity --entry --title="Search text on files" --text="Text to search"`
-
-if [ ! "${#SEARCHTEXT}" = 0 ]; then
-
-    OIFS=$IFS; IFS=$'\n'  # Backup and set new IFS
-
-    for LINE in `grep -nHIirF -- "$SEARCHTEXT" ./`; do
-        primer_indice=`expr index "$LINE" :`
-        tmp=${LINE:$primer_indice}
-        segundo_indice=`expr index "$tmp" :`
-        linea_codigo=${tmp:$segundo_indice}
-        
-        # lugar donde está la palabra
-        posicion=`expr index "$tmp" "$SEARCHTEXT"`
-
-        linea_archivo=${LINE:0:$primer_indice + $segundo_indice - 1}
-
-        echo "${linea_archivo}:  ${linea_codigo}"
-    done
-    
-    IFS=$OIFS  # Restore IFS
-fi
+grep -nHIirF -- "$SEARCHTEXT" ./ | sed 's|\([^:]*:[^:]*:\)|\1  |'


### PR DESCRIPTION
See [issue 640](https://github.com/mate-desktop/pluma/issues/640) for discussion on reverting /usr/bin/sh shebangs.

Also fix search-recursive to be more POSIX compliant.  Remove bashishms and non-POSIX expr(1) usage.  And make the script simpler and more efficient at the same time.