### PR TITLE
pluma-encodings-combo-box: implicit conversion changes signedness

### DIFF
--- a/pluma/pluma-encodings-combo-box.c
+++ b/pluma/pluma-encodings-combo-box.c
@@ -87,7 +87,7 @@ pluma_encodings_combo_box_set_property (GObject    *object,
 	switch (prop_id)
 	{
 		case PROP_SAVE_MODE:
-			combo->priv->save_mode = g_value_get_boolean (value);
+			combo->priv->save_mode = (g_value_get_boolean (value) != FALSE);
 			break;
 		default:
 			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);


### PR DESCRIPTION
```
git submodule init
git submodule update --recursive --remote
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-compile-warnings=maximum && make &> make.log
```
```
pluma-encodings-combo-box.c:90:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                        combo->priv->save_mode = g_value_get_boolean (value);
                                               ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```