### PR TITLE
Fix out-of-bounds write

### DIFF
--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -328,7 +328,7 @@ pluma_window_key_press_event (GtkWidget   *widget,
         g_strcanon (tempsize, "1234567890", '\0');
         g_strreverse (tempsize);
 
-        gchar tempfont [strlen (font)];
+        gchar tempfont [strlen (font) + 1];
         strcpy (tempfont, font);
         tempfont [strlen (font) - strlen (tempsize)] = 0;
 


### PR DESCRIPTION
Closes #664

The size of tempfont was one byte too short, so strcpy performed an out-of-bounds write when writing the terminating 0. This lead to segfault when D_FORTIFY_SOURCE=3 compiler flag was turned on.

Fix tested on openSUSE Tumbleweed.