### PR TITLE
Add quotes before and after font-family's value

### DIFF
--- a/pluma/pluma-pango.c
+++ b/pluma/pluma-pango.c
@@ -103,11 +103,7 @@ pluma_pango_font_description_to_css (const PangoFontDescription *desc)
   set = pango_font_description_get_set_fields (desc);
   if (set & PANGO_FONT_MASK_FAMILY)
     {
-      g_string_append (s, "font-family: ");
-      g_string_append (s, "\"");
-      g_string_append (s, pango_font_description_get_family (desc));
-      g_string_append (s, "\"");
-      g_string_append (s, "; ");
+      g_string_append_printf (s, "font-family: \"%s\"; ", pango_font_description_get_family (desc));
     }
   if (set & PANGO_FONT_MASK_STYLE)
     {

--- a/pluma/pluma-pango.c
+++ b/pluma/pluma-pango.c
@@ -104,7 +104,9 @@ pluma_pango_font_description_to_css (const PangoFontDescription *desc)
   if (set & PANGO_FONT_MASK_FAMILY)
     {
       g_string_append (s, "font-family: ");
+      g_string_append (s, "\"");
       g_string_append (s, pango_font_description_get_family (desc));
+      g_string_append (s, "\"");
       g_string_append (s, "; ");
     }
   if (set & PANGO_FONT_MASK_STYLE)


### PR DESCRIPTION
1. If the font-family'value is Chinese or any non ASCII characters, the GTK CSS parser will produce a warning message: "Theme parsing error: <data>:1:24: Expected a string.". That is, the GTK CSS parser can not process Chinese or non ASCII characters correctly.
2. So, we should add quotes before and after font-family's value.
3. GTK4 has good support for non ASCII characters.