### PR TITLE
Retain whether a file ended with a trailing newline optionally displaying it

### DIFF
--- a/data/org.mate.pluma.gschema.xml.in
+++ b/data/org.mate.pluma.gschema.xml.in
@@ -50,6 +50,11 @@
       <summary>Autosave Interval</summary>
       <description>Number of minutes after which pluma will automatically save modified files.  This will only take effect if the "Autosave" option is turned on.</description>
     </key>
+    <key name="hide-trailing-newline" type="b">
+      <default>true</default>
+      <summary>Hide Tailing Newline</summary>
+      <description>Whether pluma should hide the final newline in opened files if one was present when loading the file.  Enabling this will also cause newly created files to be saved with a trailing newline by default.</description>
+    </key>
     <key name="show-save-confirmation" type="b">
       <default>true</default>
       <summary>Show save confirmation</summary>

--- a/pluma/dialogs/pluma-preferences-dialog.c
+++ b/pluma/dialogs/pluma-preferences-dialog.c
@@ -121,6 +121,9 @@ struct _PlumaPreferencesDialogPrivate
 	GtkWidget	*auto_save_checkbutton;
 	GtkWidget	*auto_save_spinbutton;
 
+	/* File Format */
+	GtkWidget	*hide_trailing_newline_checkbutton;
+
 	/* Line numbers */
 	GtkWidget	*display_line_numbers_checkbutton;
 
@@ -353,6 +356,11 @@ setup_editor_page (PlumaPreferencesDialog *dlg)
 			 dlg->priv->auto_save_spinbutton,
 			 "value",
 			 G_SETTINGS_BIND_GET | G_SETTINGS_BIND_SET | G_SETTINGS_BIND_NO_SENSITIVITY);
+	g_settings_bind (dlg->priv->editor_settings,
+			 PLUMA_SETTINGS_HIDE_TRAILING_NEWLINE,
+			 dlg->priv->hide_trailing_newline_checkbutton,
+			 "active",
+			 G_SETTINGS_BIND_GET | G_SETTINGS_BIND_SET);
 	g_settings_bind (dlg->priv->editor_settings,
 			 PLUMA_SETTINGS_DRAWER_NEWLINE,
 			 dlg->priv->draw_newlines_checkbutton,
@@ -1275,6 +1283,8 @@ pluma_preferences_dialog_init (PlumaPreferencesDialog *dlg)
 		"backup_copy_checkbutton", &dlg->priv->backup_copy_checkbutton,
 		"auto_save_checkbutton", &dlg->priv->auto_save_checkbutton,
 		"auto_save_spinbutton", &dlg->priv->auto_save_spinbutton,
+
+		"hide_trailing_newline_checkbutton", &dlg->priv->hide_trailing_newline_checkbutton,
 
 		"default_font_checkbutton", &dlg->priv->default_font_checkbutton,
 		"font_button", &dlg->priv->font_button,

--- a/pluma/dialogs/pluma-preferences-dialog.ui
+++ b/pluma/dialogs/pluma-preferences-dialog.ui
@@ -668,9 +668,6 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
-                        <child>
-                          <placeholder/>
-                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -683,6 +680,63 @@
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="file_format_main_vbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel" id="file_format_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">File Format</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="file_format_vbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkCheckButton" id="hide_trailing_newline_checkbutton">
+                            <property name="label" translatable="yes">Hide trailing _newline</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="tooltip-text" translatable="yes">Hide the final newline in opened files if one was present when loading the file. Enabling this will also cause newly created files to be saved with a trailing newline by default.</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
@@ -803,7 +857,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>

--- a/pluma/dialogs/pluma-preferences-dialog.ui
+++ b/pluma/dialogs/pluma-preferences-dialog.ui
@@ -422,6 +422,10 @@
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
+                        <accessibility>
+                          <relation type="label-for" target="tabs_width_hbox"/>
+                          <relation type="label-for" target="insert_spaces_checkbutton"/>
+                        </accessibility>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -472,6 +476,9 @@
                                 <property name="position">1</property>
                               </packing>
                             </child>
+                            <accessibility>
+                              <relation type="labelled-by" target="tab_stops_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -487,6 +494,9 @@
                             <property name="receives-default">False</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="tab_stops_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -523,6 +533,9 @@
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
+                        <accessibility>
+                          <relation type="label-for" target="auto_indent_checkbutton"/>
+                        </accessibility>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -545,6 +558,9 @@
                             <property name="receives-default">False</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="automatic_indentation_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -581,6 +597,10 @@
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
+                        <accessibility>
+                          <relation type="label-for" target="backup_copy_checkbutton"/>
+                          <relation type="label-for" target="autosave_hbox"/>
+                        </accessibility>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -603,6 +623,9 @@
                             <property name="receives-default">False</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="file_saving_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -661,6 +684,9 @@
                                 <property name="position">2</property>
                               </packing>
                             </child>
+                            <accessibility>
+                              <relation type="labelled-by" target="file_saving_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -696,6 +722,9 @@
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
+                        <accessibility>
+                          <relation type="label-for" target="hide_trailing_newline_checkbutton"/>
+                        </accessibility>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -718,6 +747,9 @@
                             <property name="tooltip-text" translatable="yes">Hide the final newline in opened files if one was present when loading the file. Enabling this will also cause newly created files to be saved with a trailing newline by default.</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="file_format_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -754,6 +786,13 @@
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
+                        <accessibility>
+                          <relation type="label-for" target="draw_spaces_checkbutton"/>
+                          <relation type="label-for" target="draw_trailing_spaces_checkbutton"/>
+                          <relation type="label-for" target="draw_tabs_checkbutton"/>
+                          <relation type="label-for" target="draw_trailing_tabs_checkbutton"/>
+                          <relation type="label-for" target="draw_newlines_checkbutton"/>
+                        </accessibility>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -777,6 +816,9 @@
                             <property name="receives-default">False</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="show_spaces_tabs_newlines_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -793,6 +835,9 @@
                             <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="show_spaces_tabs_newlines_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -808,6 +853,9 @@
                             <property name="receives-default">False</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="show_spaces_tabs_newlines_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -824,6 +872,9 @@
                             <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="show_spaces_tabs_newlines_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -839,6 +890,9 @@
                             <property name="receives-default">False</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
+                            <accessibility>
+                              <relation type="labelled-by" target="show_spaces_tabs_newlines_label"/>
+                            </accessibility>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/pluma/dialogs/pluma-preferences-dialog.ui
+++ b/pluma/dialogs/pluma-preferences-dialog.ui
@@ -1,67 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">1</property>
     <property name="upper">160</property>
     <property name="value">80</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="lower">1</property>
     <property name="upper">24</property>
     <property name="value">8</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">4</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">4</property>
   </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">8</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">help-browser</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">help-browser</property>
   </object>
   <object class="GtkImage" id="image2">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">window-close</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">window-close</property>
   </object>
   <object class="GtkImage" id="install_scheme_image">
-    <property name="can_focus">False</property>
-    <property name="icon_name">list-add</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">list-add</property>
   </object>
   <object class="GtkDialog" id="preferences_dialog">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="resizable">False</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">dialog</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
                 <property name="label" translatable="yes">_Help</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
                 <property name="image">image1</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -73,11 +73,11 @@
               <object class="GtkButton" id="closebutton1">
                 <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
                 <property name="image">image2</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -89,32 +89,32 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkNotebook" id="notebook">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="border_width">6</property>
+            <property name="can-focus">True</property>
+            <property name="border-width">6</property>
             <child>
               <object class="GtkBox" id="view_main_vbox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">12</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>
                   <object class="GtkBox" id="text_wrapping_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="text_wrapping_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Text Wrapping</property>
                         <attributes>
@@ -130,18 +130,18 @@
                     <child>
                       <object class="GtkBox" id="text_wrapping_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="wrap_text_checkbutton">
                             <property name="label" translatable="yes">Enable text _wrapping</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -153,11 +153,11 @@
                           <object class="GtkCheckButton" id="split_checkbutton">
                             <property name="label" translatable="yes">Do not _split words over two lines</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="margin_start">12</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="margin-start">12</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -182,13 +182,13 @@
                 <child>
                   <object class="GtkBox" id="highlighting_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="highlighting_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Highlighting</property>
                         <attributes>
@@ -204,18 +204,18 @@
                     <child>
                       <object class="GtkBox" id="highlighting_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="highlight_current_line_checkbutton">
                             <property name="label" translatable="yes">Highlight current _line</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -227,10 +227,10 @@
                           <object class="GtkCheckButton" id="bracket_matching_checkbutton">
                             <property name="label" translatable="yes">Highlight matching _bracket</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -255,13 +255,13 @@
                 <child>
                   <object class="GtkBox" id="display_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="display_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Display</property>
                         <attributes>
@@ -277,18 +277,18 @@
                     <child>
                       <object class="GtkBox" id="display_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="display_line_numbers_checkbutton">
                             <property name="label" translatable="yes">_Display line numbers</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -299,16 +299,16 @@
                         <child>
                           <object class="GtkBox" id="display_right_margin_hbox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkCheckButton" id="right_margin_checkbutton">
                                 <property name="label" translatable="yes">Display right _margin at column</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                                 <accessibility>
                                   <relation type="label-for" target="right_margin_position_spinbutton"/>
                                 </accessibility>
@@ -322,10 +322,10 @@
                             <child>
                               <object class="GtkSpinButton" id="right_margin_position_spinbutton">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="adjustment">adjustment1</property>
-                                <property name="climb_rate">1</property>
-                                <property name="snap_to_ticks">True</property>
+                                <property name="climb-rate">1</property>
+                                <property name="snap-to-ticks">True</property>
                                 <property name="numeric">True</property>
                                 <accessibility>
                                   <relation type="labelled-by" target="right_margin_checkbutton"/>
@@ -348,10 +348,10 @@
                           <object class="GtkCheckButton" id="display_grid_checkbutton">
                             <property name="label" translatable="yes">Display _grid pattern</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -363,10 +363,10 @@
                           <object class="GtkCheckButton" id="display_overview_map_checkbutton">
                             <property name="label" translatable="yes">Display _overview map</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -393,30 +393,30 @@
             <child type="tab">
               <object class="GtkLabel" id="view_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">View</property>
               </object>
               <packing>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="editor_main_vbox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">12</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>
                   <object class="GtkBox" id="tab_stops_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="tab_stops_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Tab Stops</property>
                         <attributes>
@@ -432,23 +432,23 @@
                     <child>
                       <object class="GtkBox" id="tabs_width_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkBox" id="tabs_width_hbox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="tab_width_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">_Tab width:</property>
-                                <property name="use_underline">True</property>
+                                <property name="use-underline">True</property>
                                 <property name="justify">center</property>
-                                <property name="mnemonic_widget">tabs_width_spinbutton</property>
+                                <property name="mnemonic-widget">tabs_width_spinbutton</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -459,10 +459,10 @@
                             <child>
                               <object class="GtkSpinButton" id="tabs_width_spinbutton">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="text" translatable="yes">8</property>
                                 <property name="adjustment">adjustment2</property>
-                                <property name="climb_rate">1</property>
+                                <property name="climb-rate">1</property>
                                 <property name="numeric">True</property>
                                 <property name="value">8</property>
                               </object>
@@ -483,10 +483,10 @@
                           <object class="GtkCheckButton" id="insert_spaces_checkbutton">
                             <property name="label" translatable="yes">Insert _spaces instead of tabs</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -511,13 +511,13 @@
                 <child>
                   <object class="GtkBox" id="indentation_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="automatic_indentation_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Automatic Indentation</property>
                         <attributes>
@@ -533,18 +533,18 @@
                     <child>
                       <object class="GtkBox" id="indentation_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="auto_indent_checkbutton">
                             <property name="label" translatable="yes">_Enable automatic indentation</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -569,13 +569,13 @@
                 <child>
                   <object class="GtkBox" id="file_saving_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="file_saving_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">File Saving</property>
                         <attributes>
@@ -591,18 +591,18 @@
                     <child>
                       <object class="GtkBox" id="file_saving_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="backup_copy_checkbutton">
                             <property name="label" translatable="yes">Create a _backup copy of files before saving</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -613,16 +613,16 @@
                         <child>
                           <object class="GtkBox" id="autosave_hbox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkCheckButton" id="auto_save_checkbutton">
                                 <property name="label" translatable="yes">_Autosave files every</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -633,10 +633,10 @@
                             <child>
                               <object class="GtkSpinButton" id="auto_save_spinbutton">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="text" translatable="yes">8</property>
                                 <property name="adjustment">adjustment3</property>
-                                <property name="climb_rate">1</property>
+                                <property name="climb-rate">1</property>
                                 <property name="numeric">True</property>
                                 <property name="value">8</property>
                               </object>
@@ -649,11 +649,11 @@
                             <child>
                               <object class="GtkLabel" id="minutes_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">_minutes</property>
-                                <property name="use_underline">True</property>
+                                <property name="use-underline">True</property>
                                 <property name="justify">center</property>
-                                <property name="mnemonic_widget">auto_save_spinbutton</property>
+                                <property name="mnemonic-widget">auto_save_spinbutton</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -667,6 +667,9 @@
                             <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -685,13 +688,13 @@
                 <child>
                   <object class="GtkBox" id="show_spaces_tabs_newlines_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="show_spaces_tabs_newlines_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Show Spaces, Tabs, Newlines</property>
                         <attributes>
@@ -708,18 +711,18 @@
                       <object class="GtkBox" id="show_spaces_tabs_newlines_vbox">
                         <property name="name">vbox</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="draw_spaces_checkbutton">
                             <property name="label" translatable="yes">Show _spaces</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -731,11 +734,11 @@
                           <object class="GtkCheckButton" id="draw_trailing_spaces_checkbutton">
                             <property name="label" translatable="yes">Show _trailing spaces only</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="margin_start">12</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="margin-start">12</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -747,10 +750,10 @@
                           <object class="GtkCheckButton" id="draw_tabs_checkbutton">
                             <property name="label" translatable="yes">Show _tabs</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -762,11 +765,11 @@
                           <object class="GtkCheckButton" id="draw_trailing_tabs_checkbutton">
                             <property name="label" translatable="yes">Show _trailing tabs only</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="margin_start">12</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="margin-start">12</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -778,10 +781,10 @@
                           <object class="GtkCheckButton" id="draw_newlines_checkbutton">
                             <property name="label" translatable="yes">Show _newlines</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -811,31 +814,31 @@
             <child type="tab">
               <object class="GtkLabel" id="editor_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Editor</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="font_and_colors_main_vbox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">12</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>
                   <object class="GtkBox" id="font_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="font_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Font</property>
                         <attributes>
@@ -851,18 +854,18 @@
                     <child>
                       <object class="GtkBox" id="font_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_start">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkCheckButton" id="default_font_checkbutton">
                             <property name="label">_Use the system fixed width font (%s)</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -873,17 +876,17 @@
                         <child>
                           <object class="GtkBox" id="font_hbox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="editor_font_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Editor _font: </property>
-                                <property name="use_underline">True</property>
+                                <property name="use-underline">True</property>
                                 <property name="justify">center</property>
-                                <property name="mnemonic_widget">font_button</property>
+                                <property name="mnemonic-widget">font_button</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -894,11 +897,11 @@
                             <child>
                               <object class="GtkFontButton" id="font_button">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="font">Sans 12</property>
                                 <property name="title" translatable="yes">Pick the editor font</property>
-                                <property name="use_font">True</property>
+                                <property name="use-font">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -930,13 +933,13 @@
                 <child>
                   <object class="GtkBox" id="color_scheme_main_vbox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="color_scheme_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Color Scheme</property>
                         <attributes>
@@ -952,23 +955,23 @@
                     <child>
                       <object class="GtkBox" id="color_scheme_vbox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkScrolledWindow" id="scrolledwindow">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
                             <property name="hexpand">True</property>
                             <property name="vexpand">True</property>
-                            <property name="shadow_type">etched-in</property>
+                            <property name="shadow-type">etched-in</property>
                             <child>
                               <object class="GtkTreeView" id="schemes_treeview">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="headers_visible">False</property>
-                                <property name="rules_hint">True</property>
+                                <property name="headers-visible">False</property>
+                                <property name="rules-hint">True</property>
                                 <child internal-child="selection">
                                   <object class="GtkTreeSelection"/>
                                 </child>
@@ -984,17 +987,17 @@
                         <child>
                           <object class="GtkButtonBox" id="hbuttonbox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">6</property>
-                            <property name="layout_style">end</property>
+                            <property name="layout-style">end</property>
                             <child>
                               <object class="GtkButton" id="install_scheme_button">
                                 <property name="label" translatable="yes">_Add...</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="image">install_scheme_image</property>
-                                <property name="use_underline">True</property>
+                                <property name="use-underline">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1006,9 +1009,9 @@
                               <object class="GtkButton" id="uninstall_scheme_button">
                                 <property name="label" translatable="yes">_Remove</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1045,19 +1048,19 @@
             <child type="tab">
               <object class="GtkLabel" id="font_colours_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Font &amp; Colors</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="plugin_manager_place_holder">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">12</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -1070,12 +1073,12 @@
             <child type="tab">
               <object class="GtkLabel" id="plugins_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Plugins</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>
@@ -1091,8 +1094,5 @@
       <action-widget response="-11">helpbutton1</action-widget>
       <action-widget response="-7">closebutton1</action-widget>
     </action-widgets>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/pluma/pluma-document-loader.c
+++ b/pluma/pluma-document-loader.c
@@ -76,7 +76,8 @@ enum
     PROP_DOCUMENT,
     PROP_URI,
     PROP_ENCODING,
-    PROP_NEWLINE_TYPE
+    PROP_NEWLINE_TYPE,
+    PROP_TRIM_TRAILING_NEWLINE,
 };
 
 #define READ_CHUNK_SIZE 8192
@@ -105,6 +106,7 @@ struct _PlumaDocumentLoaderPrivate
     PlumaDocumentNewlineType     auto_detected_newline_type;
     GFile                       *gfile;
     goffset                      bytes_read;
+    gboolean                     trim_trailing_newline;
 
     /* Handle for remote files */
     GCancellable                *cancellable;
@@ -144,6 +146,9 @@ pluma_document_loader_set_property (GObject      *object,
         case PROP_NEWLINE_TYPE:
             loader->priv->auto_detected_newline_type = g_value_get_enum (value);
             break;
+        case PROP_TRIM_TRAILING_NEWLINE:
+            loader->priv->trim_trailing_newline = g_value_get_boolean (value);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
             break;
@@ -171,6 +176,9 @@ pluma_document_loader_get_property (GObject    *object,
             break;
         case PROP_NEWLINE_TYPE:
             g_value_set_enum (value, loader->priv->auto_detected_newline_type);
+            break;
+        case PROP_TRIM_TRAILING_NEWLINE:
+            g_value_set_boolean (value, loader->priv->trim_trailing_newline);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -277,15 +285,14 @@ pluma_document_loader_class_init (PlumaDocumentLoaderClass *klass)
                                                          G_PARAM_STATIC_STRINGS));
 
     g_object_class_install_property (object_class,
-                                     PROP_NEWLINE_TYPE,
-                                     g_param_spec_enum ("newline-type",
-                                                        "Newline type",
-                                                        "The accepted types of line ending",
-                                                        PLUMA_TYPE_DOCUMENT_NEWLINE_TYPE,
-                                                        PLUMA_DOCUMENT_NEWLINE_TYPE_LF,
-                                                        G_PARAM_READWRITE |
-                                                        G_PARAM_STATIC_NAME |
-                                                        G_PARAM_STATIC_BLURB));
+                                     PROP_TRIM_TRAILING_NEWLINE,
+                                     g_param_spec_boolean ("trim-trailing-newline",
+                                                           "Trim Trailing Newline",
+                                                           "Remove the final received newline from the document buffer?",
+                                                           TRUE,
+                                                           G_PARAM_READWRITE |
+                                                           G_PARAM_STATIC_STRINGS |
+                                                           G_PARAM_CONSTRUCT));
 
     signals[LOADING] =
         g_signal_new ("loading",
@@ -650,6 +657,9 @@ finish_query_info (AsyncData *async)
 
     /* Output stream */
     loader->priv->output = pluma_document_output_stream_new (loader->priv->document);
+    g_object_set (G_OBJECT (loader->priv->output),
+                  "trim-trailing-newline", loader->priv->trim_trailing_newline,
+                  NULL);
 
     /* start reading */
     read_file_chunk (async);

--- a/pluma/pluma-document-loader.c
+++ b/pluma/pluma-document-loader.c
@@ -78,6 +78,7 @@ enum
     PROP_ENCODING,
     PROP_NEWLINE_TYPE,
     PROP_TRIM_TRAILING_NEWLINE,
+    PROP_TRIMMED_TRAILING_NEWLINE,
 };
 
 #define READ_CHUNK_SIZE 8192
@@ -179,6 +180,20 @@ pluma_document_loader_get_property (GObject    *object,
             break;
         case PROP_TRIM_TRAILING_NEWLINE:
             g_value_set_boolean (value, loader->priv->trim_trailing_newline);
+            break;
+        case PROP_TRIMMED_TRAILING_NEWLINE:
+            if (loader->priv->output != NULL)
+            {
+                gboolean trimmed_trailing_newline;
+                g_object_get (loader->priv->output,
+                              "trimmed-trailing-newline", &trimmed_trailing_newline,
+                              NULL);
+                g_value_set_boolean (value, trimmed_trailing_newline);
+            }
+            else
+            {
+                g_value_set_boolean (value, FALSE);
+            }
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -293,6 +308,15 @@ pluma_document_loader_class_init (PlumaDocumentLoaderClass *klass)
                                                            G_PARAM_READWRITE |
                                                            G_PARAM_STATIC_STRINGS |
                                                            G_PARAM_CONSTRUCT));
+
+    g_object_class_install_property (object_class,
+                                     PROP_TRIMMED_TRAILING_NEWLINE,
+                                     g_param_spec_boolean ("trimmed-trailing-newline",
+                                                           "Trailing Newline Trimmed",
+                                                           "Was the final received newline removed from the document buffer?",
+                                                           FALSE,
+                                                           G_PARAM_READABLE |
+                                                           G_PARAM_STATIC_STRINGS));
 
     signals[LOADING] =
         g_signal_new ("loading",

--- a/pluma/pluma-document-output-stream.c
+++ b/pluma/pluma-document-output-stream.c
@@ -45,6 +45,8 @@ struct _PlumaDocumentOutputStreamPrivate
 	gchar *buffer;
 	gsize buflen;
 
+	gboolean trim_trailing_newline;
+
 	guint is_initialized : 1;
 	guint is_closed : 1;
 };
@@ -52,7 +54,8 @@ struct _PlumaDocumentOutputStreamPrivate
 enum
 {
 	PROP_0,
-	PROP_DOCUMENT
+	PROP_DOCUMENT,
+	PROP_TRIM_TRAILING_NEWLINE,
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (PlumaDocumentOutputStream, pluma_document_output_stream, G_TYPE_OUTPUT_STREAM)
@@ -85,6 +88,10 @@ pluma_document_output_stream_set_property (GObject      *object,
 			stream->priv->doc = PLUMA_DOCUMENT (g_value_get_object (value));
 			break;
 
+		case PROP_TRIM_TRAILING_NEWLINE:
+			stream->priv->trim_trailing_newline = g_value_get_boolean (value);
+			break;
+
 		default:
 			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 			break;
@@ -103,6 +110,10 @@ pluma_document_output_stream_get_property (GObject    *object,
 	{
 		case PROP_DOCUMENT:
 			g_value_set_object (value, stream->priv->doc);
+			break;
+
+		case PROP_TRIM_TRAILING_NEWLINE:
+			g_value_set_boolean (value, stream->priv->trim_trailing_newline);
 			break;
 
 		default:
@@ -166,6 +177,16 @@ pluma_document_output_stream_class_init (PlumaDocumentOutputStreamClass *klass)
 							      PLUMA_TYPE_DOCUMENT,
 							      G_PARAM_READWRITE |
 							      G_PARAM_CONSTRUCT_ONLY));
+
+	g_object_class_install_property (object_class,
+					 PROP_TRIM_TRAILING_NEWLINE,
+					 g_param_spec_boolean ("trim-trailing-newline",
+							       "Trim Trailing Newline",
+							       "Remove the final received newline from the document buffer?",
+							       TRUE,
+							       G_PARAM_READWRITE |
+							       G_PARAM_STATIC_STRINGS |
+							       G_PARAM_CONSTRUCT));
 }
 
 static void
@@ -270,7 +291,10 @@ remove_ending_newline (PlumaDocumentOutputStream *stream)
 static void
 end_append_text_to_document (PlumaDocumentOutputStream *stream)
 {
-	remove_ending_newline (stream);
+	if (stream->priv->trim_trailing_newline)
+	{
+		remove_ending_newline (stream);
+	}
 
 	gtk_text_buffer_set_modified (GTK_TEXT_BUFFER (stream->priv->doc),
 				      FALSE);

--- a/pluma/pluma-document-output-stream.c
+++ b/pluma/pluma-document-output-stream.c
@@ -46,6 +46,7 @@ struct _PlumaDocumentOutputStreamPrivate
 	gsize buflen;
 
 	gboolean trim_trailing_newline;
+	gboolean trimmed_trailing_newline;
 
 	guint is_initialized : 1;
 	guint is_closed : 1;
@@ -56,6 +57,7 @@ enum
 	PROP_0,
 	PROP_DOCUMENT,
 	PROP_TRIM_TRAILING_NEWLINE,
+	PROP_TRIMMED_TRAILING_NEWLINE,
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (PlumaDocumentOutputStream, pluma_document_output_stream, G_TYPE_OUTPUT_STREAM)
@@ -114,6 +116,10 @@ pluma_document_output_stream_get_property (GObject    *object,
 
 		case PROP_TRIM_TRAILING_NEWLINE:
 			g_value_set_boolean (value, stream->priv->trim_trailing_newline);
+			break;
+
+		case PROP_TRIMMED_TRAILING_NEWLINE:
+			g_value_set_boolean (value, stream->priv->trimmed_trailing_newline);
 			break;
 
 		default:
@@ -187,6 +193,15 @@ pluma_document_output_stream_class_init (PlumaDocumentOutputStreamClass *klass)
 							       G_PARAM_READWRITE |
 							       G_PARAM_STATIC_STRINGS |
 							       G_PARAM_CONSTRUCT));
+
+	g_object_class_install_property (object_class,
+					 PROP_TRIMMED_TRAILING_NEWLINE,
+					 g_param_spec_boolean ("trimmed-trailing-newline",
+							       "Trailing Newline Trimmed",
+							       "Was the final received newline removed from the document buffer?",
+							       FALSE,
+							       G_PARAM_READABLE |
+							       G_PARAM_STATIC_STRINGS));
 }
 
 static void
@@ -196,6 +211,8 @@ pluma_document_output_stream_init (PlumaDocumentOutputStream *stream)
 
 	stream->priv->buffer = NULL;
 	stream->priv->buflen = 0;
+
+	stream->priv->trimmed_trailing_newline = FALSE;
 
 	stream->priv->is_initialized = FALSE;
 	stream->priv->is_closed = FALSE;
@@ -285,6 +302,8 @@ remove_ending_newline (PlumaDocumentOutputStream *stream)
 		gtk_text_buffer_delete (GTK_TEXT_BUFFER (stream->priv->doc),
 		                        &start,
 		                        &end);
+
+		stream->priv->trimmed_trailing_newline = TRUE;
 	}
 }
 

--- a/pluma/pluma-document-saver.c
+++ b/pluma/pluma-document-saver.c
@@ -63,7 +63,8 @@ enum {
     PROP_URI,
     PROP_ENCODING,
     PROP_NEWLINE_TYPE,
-    PROP_FLAGS
+    PROP_ADD_TRAILING_NEWLINE,
+    PROP_FLAGS,
 };
 
 typedef struct
@@ -94,6 +95,7 @@ struct _PlumaDocumentSaverPrivate
     gchar                    *uri;
     const PlumaEncoding      *encoding;
     PlumaDocumentNewlineType  newline_type;
+    gboolean                  add_trailing_newline;
 
     PlumaDocumentSaveFlags    flags;
 
@@ -139,6 +141,9 @@ pluma_document_saver_set_property (GObject      *object,
         case PROP_NEWLINE_TYPE:
             saver->priv->newline_type = g_value_get_enum (value);
             break;
+        case PROP_ADD_TRAILING_NEWLINE:
+            saver->priv->add_trailing_newline = g_value_get_boolean (value);
+            break;
         case PROP_FLAGS:
             saver->priv->flags = g_value_get_flags (value);
             break;
@@ -169,6 +174,9 @@ pluma_document_saver_get_property (GObject    *object,
             break;
         case PROP_NEWLINE_TYPE:
             g_value_set_enum (value, saver->priv->newline_type);
+            break;
+        case PROP_ADD_TRAILING_NEWLINE:
+            g_value_set_boolean (value, saver->priv->add_trailing_newline);
             break;
         case PROP_FLAGS:
             g_value_set_flags (value, saver->priv->flags);
@@ -308,6 +316,16 @@ pluma_document_saver_class_init (PlumaDocumentSaverClass *klass)
                                                          G_PARAM_STATIC_NAME |
                                                          G_PARAM_STATIC_BLURB |
                                                          G_PARAM_CONSTRUCT_ONLY));
+
+    g_object_class_install_property (object_class,
+                                     PROP_ADD_TRAILING_NEWLINE,
+                                     g_param_spec_boolean ("add-trailing-newline",
+                                                           "Add Trailing Newline",
+                                                            "Automatically add a trailing newline to the file contents?",
+                                                           TRUE,
+                                                           G_PARAM_READWRITE |
+                                                           G_PARAM_STATIC_STRINGS |
+                                                           G_PARAM_CONSTRUCT));
 
     g_object_class_install_property (object_class,
                                      PROP_FLAGS,
@@ -723,6 +741,10 @@ async_replace_ready_callback (GFile        *source,
 
     saver->priv->input = pluma_document_input_stream_new (GTK_TEXT_BUFFER (saver->priv->document),
                                                           saver->priv->newline_type);
+
+    g_object_set (G_OBJECT (saver->priv->input),
+                  "add-trailing-newline", saver->priv->add_trailing_newline,
+                  NULL);
 
     saver->priv->size = pluma_document_input_stream_get_total_size (PLUMA_DOCUMENT_INPUT_STREAM (saver->priv->input));
 

--- a/pluma/pluma-document.c
+++ b/pluma/pluma-document.c
@@ -1724,6 +1724,10 @@ pluma_document_save_real (PlumaDocument          *doc,
 			  G_CALLBACK (document_saver_saving),
 			  doc);
 
+	g_object_set (G_OBJECT (doc->priv->saver),
+	              "add-trailing-newline", doc->priv->hide_trailing_newline,
+	              NULL);
+
 	doc->priv->requested_encoding = encoding;
 
 	pluma_document_saver_save (doc->priv->saver,

--- a/pluma/pluma-document.c
+++ b/pluma/pluma-document.c
@@ -128,6 +128,7 @@ struct _PlumaDocumentPrivate
 	gint	     num_of_lines_search_text;
 
 	PlumaDocumentNewlineType newline_type;
+	gboolean hide_trailing_newline;
 
 	/* Temp data while loading */
 	PlumaDocumentLoader *loader;
@@ -165,7 +166,8 @@ enum {
 	PROP_ENCODING,
 	PROP_CAN_SEARCH_AGAIN,
 	PROP_ENABLE_SEARCH_HIGHLIGHTING,
-	PROP_NEWLINE_TYPE
+	PROP_NEWLINE_TYPE,
+	PROP_HIDE_TRAILING_NEWLINE,
 };
 
 enum {
@@ -360,6 +362,9 @@ pluma_document_get_property (GObject    *object,
 		case PROP_NEWLINE_TYPE:
 			g_value_set_enum (value, doc->priv->newline_type);
 			break;
+		case PROP_HIDE_TRAILING_NEWLINE:
+			g_value_set_boolean (value, doc->priv->hide_trailing_newline);
+			break;
 		default:
 			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 			break;
@@ -391,6 +396,9 @@ pluma_document_set_property (GObject      *object,
 		case PROP_CONTENT_TYPE:
 			pluma_document_set_content_type (doc,
 			                                 g_value_get_string (value));
+			break;
+		case PROP_HIDE_TRAILING_NEWLINE:
+			doc->priv->hide_trailing_newline = g_value_get_boolean (value);
 			break;
 		default:
 			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -531,6 +539,21 @@ pluma_document_class_init (PlumaDocumentClass *klass)
 	                                                    G_PARAM_READWRITE |
 	                                                    G_PARAM_STATIC_NAME |
 	                                                    G_PARAM_STATIC_BLURB));
+
+	/**
+	 * PlumaDocument:hide-trailing-newline:
+	 *
+	 * The :hide-trailing-newline property determines whether the final newline
+	 * in the document (if any) is stripped on loading and automatically readded
+	 * on saving the document
+	 */
+	g_object_class_install_property (object_class, PROP_HIDE_TRAILING_NEWLINE,
+	                                 g_param_spec_boolean ("hide-trailing-newline",
+	                                                       "Hide Trailing Newline",
+	                                                       "Drop trailing newline from input and add it on output",
+	                                                       TRUE,
+	                                                       G_PARAM_READWRITE |
+	                                                       G_PARAM_STATIC_STRINGS));
 
 	/* This signal is used to update the cursor position is the statusbar,
 	 * it's emitted either when the insert mark is moved explicitely or
@@ -981,6 +1004,8 @@ pluma_document_init (PlumaDocument *doc)
 	doc->priv->encoding = pluma_encoding_get_utf8 ();
 
 	doc->priv->newline_type = PLUMA_DOCUMENT_NEWLINE_TYPE_DEFAULT;
+	doc->priv->hide_trailing_newline = g_settings_get_boolean (doc->priv->editor_settings,
+	                                                           PLUMA_SETTINGS_HIDE_TRAILING_NEWLINE);
 
 	undo_actions = g_settings_get_uint (doc->priv->editor_settings, PLUMA_SETTINGS_MAX_UNDO_ACTIONS);
 
@@ -1540,6 +1565,10 @@ pluma_document_load_real (PlumaDocument       *doc,
 			  "loading",
 			  G_CALLBACK (document_loader_loading),
 			  doc);
+
+	g_object_set (G_OBJECT (doc->priv->loader),
+	              "trim-trailing-newline", doc->priv->hide_trailing_newline,
+	              NULL);
 
 	doc->priv->create = create;
 	doc->priv->requested_encoding = encoding;

--- a/pluma/pluma-settings.h
+++ b/pluma/pluma-settings.h
@@ -103,6 +103,7 @@ GSList *                pluma_settings_get_writable_vfs_schemes (GSettings *sett
 #define PLUMA_SETTINGS_CREATE_BACKUP_COPY           "create-backup-copy"
 #define PLUMA_SETTINGS_AUTO_SAVE                    "auto-save"
 #define PLUMA_SETTINGS_AUTO_SAVE_INTERVAL           "auto-save-interval"
+#define PLUMA_SETTINGS_HIDE_TRAILING_NEWLINE        "hide-trailing-newline"
 #define PLUMA_SETTINGS_MAX_UNDO_ACTIONS             "max-undo-actions"
 #define PLUMA_SETTINGS_WRAP_MODE                    "wrap-mode"
 #define PLUMA_SETTINGS_TABS_SIZE                    "tabs-size"


### PR DESCRIPTION
For some reason I felt the need to rewrite #388 after all these years and the result is this.

A lot of the discussion of the old PR still applies, but instead of always having the trailing newline visible (like in that PR), having the trailing newline is now optional.

Details:

 1. The trailing newline is not displayed by default but there is a setting – with UI – that can be used to always have it displayed (addresses feedback from other PR)
 2. Files that do not end in a trailing newline when opened are saved without a trailing newline instead of forcefully adding one as is currently done
 3. Newly created (or edited previously completely empty) files are saved with an automatically added trailing newline if the setting is enabled, without one otherwise (matches current behaviour by default)
 4. Each PlumaDocument instance remembers whether a hidden trailing newline is present/expected similarly to how remembering the expected/used line ending (LF/CRLF/CR) is implemented
 5. The PR is made up of several separate smaller commits that can be reviewed independently if that is preferred

