### PR TITLE
snippets: fix python 3.12+ invalid escape sequence warnings

### DIFF
--- a/plugins/snippets/snippets/Document.py
+++ b/plugins/snippets/snippets/Document.py
@@ -827,8 +827,8 @@ class Document:
             return components
 
     def relative_path(self, first, second, mime):
-        prot1 = re.match('(^[a-z]+:\/\/|\/)(.*)', first)
-        prot2 = re.match('(^[a-z]+:\/\/|\/)(.*)', second)
+        prot1 = re.match(r'(^[a-z]+:\/\/|\/)(.*)', first)
+        prot2 = re.match(r'(^[a-z]+:\/\/|\/)(.*)', second)
 
         if not prot1 or not prot2:
             return second

--- a/plugins/snippets/snippets/SubstitutionParser.py
+++ b/plugins/snippets/snippets/SubstitutionParser.py
@@ -159,7 +159,7 @@ class SubstitutionParser:
         return match.group(1), tokens[match.end():]
 
     def _condition_value(self, tokens):
-        match = re.match('\\\\?%s\s*' % self.REG_GROUP, tokens)
+        match = re.match('\\\\?%s\\s*' % self.REG_GROUP, tokens)
 
         if not match:
             return None, tokens


### PR DESCRIPTION
In Python 3.12+, invalid escape sequences changed from a DeprecationWarning to SyntaxWarning.

/usr/lib/x86_64-linux-gnu/pluma/plugins/snippets/Document.py:830: SyntaxWarning: invalid escape sequence '\/'
  prot1 = re.match('(^[a-z]+:\/\/|\/)(.*)', first)
/usr/lib/x86_64-linux-gnu/pluma/plugins/snippets/Document.py:831: SyntaxWarning: invalid escape sequence '\/'
  prot2 = re.match('(^[a-z]+:\/\/|\/)(.*)', second)
/usr/lib/x86_64-linux-gnu/pluma/plugins/snippets/SubstitutionParser.py:162: SyntaxWarning: invalid escape sequence '\s'
  match = re.match('\\\\?%s\s*' % self.REG_GROUP, tokens)