### PR TITLE
Allow close keyboard shortcut to close the window when empty

### DIFF
--- a/pluma/pluma-commands-file.c
+++ b/pluma/pluma-commands-file.c
@@ -1740,6 +1740,7 @@ _pluma_cmd_file_close (GtkAction   *action,
 
 	if (active_tab == NULL)
 	{
+		gtk_widget_destroy (GTK_WIDGET (window));
 		return;
 	}
 

--- a/pluma/pluma-window.c
+++ b/pluma/pluma-window.c
@@ -2530,6 +2530,10 @@ set_sensitivity_according_to_window_state (PlumaWindow *window)
                                     !(window->priv->state & PLUMA_WINDOW_STATE_SAVING) &&
                                     !(window->priv->state & PLUMA_WINDOW_STATE_PRINTING));
 
+    gtk_action_group_set_sensitive (window->priv->close_action_group,
+                                    !(window->priv->state & PLUMA_WINDOW_STATE_SAVING) &&
+                                    !(window->priv->state & PLUMA_WINDOW_STATE_PRINTING));
+
     action = gtk_action_group_get_action (window->priv->action_group,
                                           "FileCloseAll");
     gtk_action_set_sensitive (action,
@@ -3199,9 +3203,6 @@ update_sensitivity_according_to_open_tabs (PlumaWindow *window)
     action = gtk_action_group_get_action (window->priv->action_group,
                                           "DocumentsMoveToNewWindow");
     gtk_action_set_sensitive (action, window->priv->num_tabs > 1);
-
-    gtk_action_group_set_sensitive (window->priv->close_action_group,
-                                    window->priv->num_tabs != 0);
 }
 
 static void


### PR DESCRIPTION
When there are no open tabs, the close keyboard shortcut was being disabled. This change allows the shortcut to close the main window when no tabs are open, matching the behaviour in other applications that use tabs, such as Firefox.