### PR TITLE
externaltools: fix python invalid escape sequence warning

### DIFF
--- a/plugins/externaltools/tools/library.py
+++ b/plugins/externaltools/tools/library.py
@@ -197,7 +197,7 @@ class ToolDirectory(object):
 
 
 class Tool(object):
-    RE_KEY = re.compile('^([a-zA-Z_][a-zA-Z0-9_.\-]*)(\[([a-zA-Z_@]+)\])?$')
+    RE_KEY = re.compile(r'^([a-zA-Z_][a-zA-Z0-9_.\-]*)(\[([a-zA-Z_@]+)\])?$')
 
     def __init__(self, parent, filename=None):
         super(Tool, self).__init__()


### PR DESCRIPTION
In later versions of Python, invalid escape sequences changed from a DeprecationWarning to SyntaxWarning. This change uses a raw string for the RE_KEY regex pattern to fix the invalid escape sequence warning.

Fixes #737